### PR TITLE
tests: work on sorted dive lists

### DIFF
--- a/dives/TestDiveDM5.xml
+++ b/dives/TestDiveDM5.xml
@@ -4,387 +4,197 @@
 <divesites>
 </divesites>
 <dives>
-<dive number='1' sac='11.046 l/min' otu='46' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
-  <notes>Notes are here</notes>
-  <cylinder size='12.0 l' o2='33.0%' start='205.11 bar' />
+<dive number='4' sac='10.260 l/min' otu='49' cns='18%' date='2013-02-02' time='08:21:50' duration='60:40 min'>
+  <notes>Notes test</notes>
+  <cylinder size='12.0 l' o2='33.0%' start='194.74 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>
-  <depth max='22.44 m' mean='16.291 m' />
+  <depth max='28.84 m' mean='17.188 m' />
   <temperature air='28.0 C' water='26.0 C' />
   <event time='0:00 min' type='11' value='33' name='gaschange' cylinder='0' o2='33.0%' />
-  <event time='59:32 min' name='surface' />
-  <sample time='0:00 min' depth='1.39 m' temp='28.0 C' pressure='206.52 bar' />
-  <sample time='0:20 min' depth='4.63 m' pressure='205.11 bar' />
-  <sample time='0:40 min' depth='7.66 m' pressure='203.6 bar' />
-  <sample time='1:00 min' depth='11.76 m' pressure='201.95 bar' />
-  <sample time='1:20 min' depth='16.77 m' pressure='200.03 bar' />
-  <sample time='1:40 min' depth='20.82 m' temp='27.0 C' pressure='198.3 bar' />
-  <sample time='2:00 min' depth='21.21 m' pressure='195.75 bar' />
-  <sample time='2:20 min' depth='21.89 m' pressure='194.02 bar' />
-  <sample time='2:40 min' depth='21.67 m' pressure='192.43 bar' />
-  <sample time='3:00 min' depth='21.7 m' pressure='191.11 bar' />
-  <sample time='3:20 min' depth='22.05 m' temp='26.0 C' pressure='189.73 bar' />
-  <sample time='3:40 min' depth='21.94 m' pressure='188.5 bar' />
-  <sample time='4:00 min' depth='21.5 m' pressure='187.16 bar' />
-  <sample time='4:20 min' depth='21.22 m' pressure='186.05 bar' />
-  <sample time='4:40 min' depth='21.36 m' pressure='185.17 bar' />
-  <sample time='5:00 min' depth='21.4 m' pressure='184.02 bar' />
-  <sample time='5:20 min' depth='21.73 m' pressure='182.64 bar' />
-  <sample time='5:40 min' depth='21.44 m' pressure='181.76 bar' />
-  <sample time='6:00 min' depth='21.49 m' pressure='180.84 bar' />
-  <sample time='6:20 min' depth='21.13 m' pressure='179.67 bar' />
-  <sample time='6:40 min' depth='21.33 m' pressure='178.53 bar' />
-  <sample time='7:00 min' depth='22.04 m' pressure='178.31 bar' />
-  <sample time='7:20 min' depth='22.41 m' pressure='177.35 bar' />
-  <sample time='7:40 min' depth='22.02 m' pressure='175.77 bar' />
-  <sample time='8:00 min' depth='21.72 m' pressure='174.27 bar' />
-  <sample time='8:20 min' depth='21.26 m' pressure='173.85 bar' />
-  <sample time='8:40 min' depth='20.89 m' pressure='172.56 bar' />
-  <sample time='9:00 min' depth='21.1 m' pressure='171.35 bar' />
-  <sample time='9:20 min' depth='21.24 m' pressure='170.33 bar' />
-  <sample time='9:40 min' depth='20.36 m' pressure='169.29 bar' />
-  <sample time='10:00 min' depth='20.15 m' pressure='168.59 bar' />
-  <sample time='10:20 min' depth='20.04 m' pressure='167.8 bar' />
-  <sample time='10:40 min' depth='19.95 m' pressure='166.2 bar' />
-  <sample time='11:00 min' depth='19.55 m' pressure='165.48 bar' />
-  <sample time='11:20 min' depth='19.36 m' pressure='164.12 bar' />
-  <sample time='11:40 min' depth='18.59 m' pressure='163.4 bar' />
-  <sample time='12:00 min' depth='18.04 m' pressure='162.63 bar' />
-  <sample time='12:20 min' depth='17.57 m' pressure='161.95 bar' />
-  <sample time='12:40 min' depth='17.2 m' pressure='160.65 bar' />
-  <sample time='13:00 min' depth='16.63 m' pressure='159.58 bar' />
-  <sample time='13:20 min' depth='17.12 m' pressure='158.25 bar' />
-  <sample time='13:40 min' depth='17.04 m' pressure='157.56 bar' />
-  <sample time='14:00 min' depth='17.15 m' pressure='156.6 bar' />
-  <sample time='14:20 min' depth='17.07 m' pressure='156.06 bar' />
-  <sample time='14:40 min' depth='16.71 m' pressure='155.24 bar' />
-  <sample time='15:00 min' depth='17.02 m' pressure='154.44 bar' />
-  <sample time='15:20 min' depth='16.76 m' pressure='153.71 bar' />
-  <sample time='15:40 min' depth='16.43 m' pressure='152.75 bar' />
-  <sample time='16:00 min' depth='16.81 m' pressure='152.09 bar' />
-  <sample time='16:20 min' depth='16.95 m' pressure='151.12 bar' />
-  <sample time='16:40 min' depth='17.06 m' pressure='150.37 bar' />
-  <sample time='17:00 min' depth='16.81 m' pressure='149.38 bar' />
-  <sample time='17:20 min' depth='17.01 m' pressure='148.7 bar' />
-  <sample time='17:40 min' depth='17.22 m' pressure='147.72 bar' />
-  <sample time='18:00 min' depth='16.86 m' pressure='146.86 bar' />
-  <sample time='18:20 min' depth='17.12 m' pressure='146.25 bar' />
-  <sample time='18:40 min' depth='17.28 m' pressure='145.01 bar' />
-  <sample time='19:00 min' depth='17.02 m' pressure='144.55 bar' />
-  <sample time='19:20 min' depth='17.12 m' pressure='143.39 bar' />
-  <sample time='19:40 min' depth='16.87 m' pressure='142.35 bar' />
-  <sample time='20:00 min' depth='17.05 m' pressure='141.57 bar' />
-  <sample time='20:20 min' depth='17.37 m' pressure='140.85 bar' />
-  <sample time='20:40 min' depth='17.34 m' pressure='140.16 bar' />
-  <sample time='21:00 min' depth='17.47 m' pressure='139.23 bar' />
-  <sample time='21:20 min' depth='17.45 m' pressure='138.24 bar' />
-  <sample time='21:40 min' depth='17.37 m' pressure='137.58 bar' />
-  <sample time='22:00 min' depth='16.97 m' pressure='136.78 bar' />
-  <sample time='22:20 min' depth='16.88 m' pressure='135.6 bar' />
-  <sample time='22:40 min' depth='17.03 m' pressure='134.95 bar' />
-  <sample time='23:00 min' depth='17.17 m' pressure='133.88 bar' />
-  <sample time='23:20 min' depth='17.11 m' pressure='133.21 bar' />
-  <sample time='23:40 min' depth='17.13 m' pressure='132.32 bar' />
-  <sample time='24:00 min' depth='17.12 m' pressure='131.63 bar' />
-  <sample time='24:20 min' depth='17.04 m' pressure='130.81 bar' />
-  <sample time='24:40 min' depth='16.86 m' pressure='130.33 bar' />
-  <sample time='25:00 min' depth='16.98 m' pressure='129.12 bar' />
-  <sample time='25:20 min' depth='16.86 m' pressure='128.34 bar' />
-  <sample time='25:40 min' depth='16.86 m' pressure='127.56 bar' />
-  <sample time='26:00 min' depth='16.96 m' pressure='126.87 bar' />
-  <sample time='26:20 min' depth='17.17 m' pressure='126.32 bar' />
-  <sample time='26:40 min' depth='16.74 m' pressure='125.03 bar' />
-  <sample time='27:00 min' depth='17.2 m' pressure='124.31 bar' />
-  <sample time='27:20 min' depth='17.26 m' pressure='123.65 bar' />
-  <sample time='27:40 min' depth='17.24 m' pressure='123.35 bar' />
-  <sample time='28:00 min' depth='17.31 m' pressure='122.17 bar' />
-  <sample time='28:20 min' depth='17.4 m' pressure='121.34 bar' />
-  <sample time='28:40 min' depth='17.43 m' pressure='120.7 bar' />
-  <sample time='29:00 min' depth='17.43 m' pressure='120.28 bar' />
-  <sample time='29:20 min' depth='17.43 m' pressure='119.61 bar' />
-  <sample time='29:40 min' depth='17.45 m' pressure='119.26 bar' />
-  <sample time='30:00 min' depth='17.44 m' pressure='119.04 bar' />
-  <sample time='30:20 min' depth='17.06 m' pressure='117.96 bar' />
-  <sample time='30:40 min' depth='16.59 m' pressure='117.1 bar' />
-  <sample time='31:00 min' depth='16.98 m' pressure='115.9 bar' />
-  <sample time='31:20 min' depth='16.88 m' pressure='115.17 bar' />
-  <sample time='31:40 min' depth='16.66 m' pressure='114.41 bar' />
-  <sample time='32:00 min' depth='16.65 m' pressure='113.8 bar' />
-  <sample time='32:20 min' depth='16.76 m' pressure='112.87 bar' />
-  <sample time='32:40 min' depth='17.25 m' pressure='112.23 bar' />
-  <sample time='33:00 min' depth='17.0 m' pressure='111.6 bar' />
-  <sample time='33:20 min' depth='16.59 m' pressure='110.69 bar' />
-  <sample time='33:40 min' depth='16.47 m' pressure='109.65 bar' />
-  <sample time='34:00 min' depth='16.59 m' pressure='108.94 bar' />
-  <sample time='34:20 min' depth='16.62 m' pressure='108.25 bar' />
-  <sample time='34:40 min' depth='16.98 m' pressure='107.94 bar' />
-  <sample time='35:00 min' depth='17.34 m' pressure='106.89 bar' />
-  <sample time='35:20 min' depth='17.34 m' pressure='105.79 bar' />
-  <sample time='35:40 min' depth='17.29 m' pressure='105.52 bar' />
-  <sample time='36:00 min' depth='17.26 m' pressure='104.84 bar' />
-  <sample time='36:20 min' depth='17.25 m' pressure='104.07 bar' />
-  <sample time='36:40 min' depth='17.39 m' pressure='103.01 bar' />
-  <sample time='37:00 min' depth='17.02 m' pressure='102.24 bar' />
-  <sample time='37:20 min' depth='16.87 m' pressure='101.45 bar' />
-  <sample time='37:40 min' depth='16.75 m' pressure='100.98 bar' />
-  <sample time='38:00 min' depth='16.51 m' pressure='99.94 bar' />
-  <sample time='38:20 min' depth='16.78 m' pressure='99.38 bar' />
-  <sample time='38:40 min' depth='16.93 m' pressure='98.77 bar' />
-  <sample time='39:00 min' depth='16.64 m' pressure='98.13 bar' />
-  <sample time='39:20 min' depth='16.35 m' pressure='97.1 bar' />
-  <sample time='39:40 min' depth='16.84 m' pressure='96.32 bar' />
-  <sample time='40:00 min' depth='16.93 m' pressure='95.61 bar' />
-  <sample time='40:20 min' depth='16.92 m' pressure='94.89 bar' />
-  <sample time='40:40 min' depth='16.96 m' pressure='93.88 bar' />
-  <sample time='41:00 min' depth='16.99 m' pressure='93.26 bar' />
-  <sample time='41:20 min' depth='16.96 m' pressure='92.73 bar' />
-  <sample time='41:40 min' depth='16.57 m' pressure='91.96 bar' />
-  <sample time='42:00 min' depth='16.07 m' pressure='91.15 bar' />
-  <sample time='42:20 min' depth='15.95 m' pressure='90.42 bar' />
-  <sample time='42:40 min' depth='16.24 m' pressure='89.9 bar' />
-  <sample time='43:00 min' depth='16.38 m' pressure='88.92 bar' />
-  <sample time='43:20 min' depth='16.67 m' pressure='88.2 bar' />
-  <sample time='43:40 min' depth='16.61 m' pressure='87.41 bar' />
-  <sample time='44:00 min' depth='17.17 m' pressure='86.42 bar' />
-  <sample time='44:20 min' depth='17.24 m' pressure='85.9 bar' />
-  <sample time='44:40 min' depth='17.41 m' pressure='85.16 bar' />
-  <sample time='45:00 min' depth='17.45 m' pressure='84.36 bar' />
-  <sample time='45:20 min' depth='17.2 m' pressure='83.57 bar' />
-  <sample time='45:40 min' depth='16.97 m' pressure='82.76 bar' />
-  <sample time='46:00 min' depth='17.45 m' pressure='81.8 bar' />
-  <sample time='46:20 min' depth='17.26 m' pressure='81.25 bar' />
-  <sample time='46:40 min' depth='17.35 m' pressure='80.64 bar' />
-  <sample time='47:00 min' depth='17.7 m' pressure='79.66 bar' />
-  <sample time='47:20 min' depth='17.06 m' pressure='78.83 bar' />
-  <sample time='47:40 min' depth='17.1 m' pressure='78.14 bar' />
-  <sample time='48:00 min' depth='16.99 m' pressure='77.16 bar' />
-  <sample time='48:20 min' depth='17.22 m' pressure='76.68 bar' />
-  <sample time='48:40 min' depth='17.01 m' pressure='75.75 bar' />
-  <sample time='49:00 min' depth='17.31 m' pressure='74.8 bar' />
-  <sample time='49:20 min' depth='17.39 m' pressure='74.08 bar' />
-  <sample time='49:40 min' depth='17.43 m' pressure='73.52 bar' />
-  <sample time='50:00 min' depth='16.83 m' pressure='73.01 bar' />
-  <sample time='50:20 min' depth='16.52 m' pressure='72.01 bar' />
-  <sample time='50:40 min' depth='16.59 m' pressure='71.01 bar' />
-  <sample time='51:00 min' depth='16.49 m' pressure='69.98 bar' />
-  <sample time='51:20 min' depth='16.04 m' pressure='69.34 bar' />
-  <sample time='51:40 min' depth='15.55 m' pressure='68.15 bar' />
-  <sample time='52:00 min' depth='15.03 m' pressure='67.46 bar' />
-  <sample time='52:20 min' depth='14.18 m' pressure='66.65 bar' />
-  <sample time='52:40 min' depth='12.88 m' pressure='65.84 bar' />
-  <sample time='53:00 min' depth='12.03 m' pressure='65.1 bar' />
-  <sample time='53:20 min' depth='11.19 m' pressure='64.53 bar' />
-  <sample time='53:40 min' depth='10.47 m' pressure='63.65 bar' />
-  <sample time='54:00 min' depth='9.12 m' pressure='62.93 bar' />
-  <sample time='54:20 min' depth='7.64 m' pressure='62.24 bar' />
-  <sample time='54:40 min' depth='6.79 m' pressure='61.55 bar' />
-  <sample time='55:00 min' depth='6.02 m' pressure='61.15 bar' />
-  <sample time='55:20 min' depth='5.47 m' pressure='60.67 bar' />
-  <sample time='55:40 min' depth='5.36 m' pressure='60.21 bar' />
-  <sample time='56:00 min' depth='5.49 m' pressure='59.39 bar' />
-  <sample time='56:20 min' depth='5.31 m' pressure='59.21 bar' />
-  <sample time='56:40 min' depth='5.33 m' pressure='56.0 bar' />
-  <sample time='57:00 min' depth='5.31 m' pressure='56.45 bar' />
-  <sample time='57:20 min' depth='5.28 m' pressure='56.2 bar' />
-  <sample time='57:40 min' depth='4.93 m' pressure='55.6 bar' />
-  <sample time='58:00 min' depth='4.88 m' pressure='55.3 bar' />
-  <sample time='58:20 min' depth='4.63 m' pressure='54.78 bar' />
-  <sample time='58:40 min' depth='3.75 m' pressure='54.37 bar' />
-  <sample time='59:00 min' depth='2.69 m' pressure='54.08 bar' />
-  <sample time='59:20 min' depth='1.88 m' pressure='53.87 bar' />
-  </divecomputer>
-</dive>
-<dive number='2' sac='11.298 l/min' otu='33' cns='12%' tags='boat, photography, tag' date='2013-02-02' time='13:44:21' duration='61:00 min'>
-  <notes>Testing notes</notes>
-  <cylinder size='12.0 l' o2='33.0%' start='209.04 bar' />
-  <divecomputer model='Vyper Air' deviceid='013749e4'>
-  <depth max='21.88 m' mean='12.354 m' />
-  <temperature air='27.0 C' water='26.0 C' />
-  <event time='0:00 min' type='11' value='33' name='gaschange' cylinder='0' o2='33.0%' />
-  <event time='61:06 min' name='surface' />
-  <sample time='0:00 min' depth='1.21 m' temp='27.0 C' pressure='210.5 bar' />
-  <sample time='0:20 min' depth='3.91 m' pressure='209.04 bar' />
-  <sample time='0:40 min' depth='3.25 m' pressure='207.71 bar' />
-  <sample time='1:00 min' depth='4.4 m' pressure='206.45 bar' />
-  <sample time='1:20 min' depth='5.21 m' pressure='205.76 bar' />
-  <sample time='1:40 min' depth='5.58 m' pressure='204.9 bar' />
-  <sample time='2:00 min' depth='6.36 m' pressure='204.13 bar' />
-  <sample time='2:20 min' depth='6.85 m' pressure='202.86 bar' />
-  <sample time='2:40 min' depth='6.83 m' pressure='201.74 bar' />
-  <sample time='3:00 min' depth='7.81 m' pressure='200.94 bar' />
-  <sample time='3:20 min' depth='8.73 m' temp='26.0 C' pressure='200.13 bar' />
-  <sample time='3:40 min' depth='9.83 m' pressure='199.3 bar' />
-  <sample time='4:00 min' depth='10.91 m' pressure='198.07 bar' />
-  <sample time='4:20 min' depth='12.97 m' pressure='197.43 bar' />
-  <sample time='4:40 min' depth='14.5 m' />
-  <sample time='5:00 min' depth='15.9 m' pressure='196.2 bar' />
-  <sample time='5:20 min' depth='17.96 m' pressure='195.23 bar' />
-  <sample time='5:40 min' depth='19.49 m' pressure='193.24 bar' />
-  <sample time='6:00 min' depth='19.56 m' pressure='192.76 bar' />
-  <sample time='6:20 min' depth='20.4 m' />
-  <sample time='6:40 min' depth='21.11 m' pressure='191.84 bar' />
-  <sample time='7:00 min' depth='21.8 m' pressure='188.37 bar' />
-  <sample time='7:20 min' depth='21.32 m' pressure='187.13 bar' />
-  <sample time='7:40 min' depth='21.23 m' pressure='186.16 bar' />
-  <sample time='8:00 min' depth='20.93 m' pressure='184.62 bar' />
-  <sample time='8:20 min' depth='20.75 m' pressure='183.49 bar' />
-  <sample time='8:40 min' depth='21.13 m' pressure='182.62 bar' />
-  <sample time='9:00 min' depth='21.35 m' pressure='181.5 bar' />
-  <sample time='9:20 min' depth='21.36 m' pressure='180.55 bar' />
-  <sample time='9:40 min' depth='20.15 m' pressure='180.28 bar' />
-  <sample time='10:00 min' depth='18.68 m' pressure='178.76 bar' />
-  <sample time='10:20 min' depth='16.92 m' pressure='177.37 bar' />
-  <sample time='10:40 min' depth='15.56 m' pressure='176.5 bar' />
-  <sample time='11:00 min' depth='14.46 m' pressure='175.95 bar' />
-  <sample time='11:20 min' depth='13.38 m' pressure='175.11 bar' />
-  <sample time='11:40 min' depth='12.72 m' pressure='174.25 bar' />
-  <sample time='12:00 min' depth='11.51 m' pressure='173.46 bar' />
-  <sample time='12:20 min' depth='12.78 m' pressure='172.51 bar' />
-  <sample time='12:40 min' depth='13.27 m' pressure='172.02 bar' />
-  <sample time='13:00 min' depth='14.41 m' pressure='171.87 bar' />
-  <sample time='13:20 min' depth='15.02 m' pressure='170.88 bar' />
-  <sample time='13:40 min' depth='15.94 m' pressure='168.9 bar' />
-  <sample time='14:00 min' depth='16.58 m' pressure='168.24 bar' />
-  <sample time='14:20 min' depth='17.36 m' pressure='167.28 bar' />
-  <sample time='14:40 min' depth='17.92 m' pressure='166.21 bar' />
-  <sample time='15:00 min' depth='18.41 m' pressure='165.78 bar' />
-  <sample time='15:20 min' depth='18.39 m' pressure='165.1 bar' />
-  <sample time='15:40 min' depth='17.94 m' pressure='164.22 bar' />
-  <sample time='16:00 min' depth='18.15 m' pressure='163.55 bar' />
-  <sample time='16:20 min' depth='18.48 m' pressure='161.29 bar' />
-  <sample time='16:40 min' depth='18.22 m' pressure='160.28 bar' />
-  <sample time='17:00 min' depth='17.82 m' pressure='159.8 bar' />
-  <sample time='17:20 min' depth='18.41 m' pressure='159.08 bar' />
-  <sample time='17:40 min' depth='18.39 m' />
-  <sample time='18:00 min' depth='18.39 m' pressure='156.83 bar' />
-  <sample time='18:20 min' depth='17.77 m' pressure='155.84 bar' />
-  <sample time='18:40 min' depth='17.31 m' pressure='155.33 bar' />
-  <sample time='19:00 min' depth='16.98 m' pressure='154.15 bar' />
-  <sample time='19:20 min' depth='16.42 m' pressure='153.18 bar' />
-  <sample time='19:40 min' depth='16.44 m' pressure='152.52 bar' />
-  <sample time='20:00 min' depth='16.79 m' pressure='151.45 bar' />
-  <sample time='20:20 min' depth='17.16 m' pressure='150.91 bar' />
-  <sample time='20:40 min' depth='17.43 m' pressure='150.24 bar' />
-  <sample time='21:00 min' depth='17.63 m' pressure='149.18 bar' />
-  <sample time='21:20 min' depth='18.05 m' pressure='148.46 bar' />
-  <sample time='21:40 min' depth='17.66 m' pressure='147.64 bar' />
-  <sample time='22:00 min' depth='17.46 m' pressure='146.43 bar' />
-  <sample time='22:20 min' depth='16.96 m' pressure='145.46 bar' />
-  <sample time='22:40 min' depth='14.82 m' pressure='144.89 bar' />
-  <sample time='23:00 min' depth='13.36 m' pressure='144.34 bar' />
-  <sample time='23:20 min' depth='12.65 m' pressure='143.8 bar' />
-  <sample time='23:40 min' depth='12.32 m' pressure='142.86 bar' />
-  <sample time='24:00 min' depth='12.85 m' pressure='142.29 bar' />
-  <sample time='24:20 min' depth='13.36 m' pressure='141.24 bar' />
-  <sample time='24:40 min' depth='12.8 m' pressure='140.44 bar' />
-  <sample time='25:00 min' depth='12.04 m' pressure='139.95 bar' />
-  <sample time='25:20 min' depth='11.19 m' pressure='139.24 bar' />
-  <sample time='25:40 min' depth='11.15 m' pressure='138.37 bar' />
-  <sample time='26:00 min' depth='11.02 m' pressure='137.93 bar' />
-  <sample time='26:20 min' depth='10.99 m' pressure='136.86 bar' />
-  <sample time='26:40 min' depth='11.29 m' temp='25.0 C' pressure='136.49 bar' />
-  <sample time='27:00 min' depth='12.04 m' pressure='136.01 bar' />
-  <sample time='27:20 min' depth='12.19 m' pressure='134.44 bar' />
-  <sample time='27:40 min' depth='12.45 m' pressure='134.08 bar' />
-  <sample time='28:00 min' depth='12.39 m' pressure='133.21 bar' />
-  <sample time='28:20 min' depth='12.16 m' pressure='132.5 bar' />
-  <sample time='28:40 min' depth='11.3 m' pressure='131.68 bar' />
-  <sample time='29:00 min' depth='10.38 m' pressure='131.14 bar' />
-  <sample time='29:20 min' depth='10.42 m' pressure='130.41 bar' />
-  <sample time='29:40 min' depth='10.32 m' pressure='129.67 bar' />
-  <sample time='30:00 min' depth='10.48 m' pressure='128.9 bar' />
-  <sample time='30:20 min' depth='10.7 m' pressure='128.24 bar' />
-  <sample time='30:40 min' depth='10.28 m' pressure='127.56 bar' />
-  <sample time='31:00 min' depth='10.49 m' pressure='126.79 bar' />
-  <sample time='31:20 min' depth='10.35 m' pressure='126.12 bar' />
-  <sample time='31:40 min' depth='9.89 m' temp='26.0 C' pressure='125.32 bar' />
-  <sample time='32:00 min' depth='10.09 m' pressure='124.81 bar' />
-  <sample time='32:20 min' depth='10.23 m' pressure='124.11 bar' />
-  <sample time='32:40 min' depth='10.24 m' pressure='123.33 bar' />
-  <sample time='33:00 min' depth='11.38 m' pressure='122.7 bar' />
-  <sample time='33:20 min' depth='12.01 m' pressure='121.8 bar' />
-  <sample time='33:40 min' depth='11.72 m' pressure='121.22 bar' />
-  <sample time='34:00 min' depth='12.38 m' pressure='120.67 bar' />
-  <sample time='34:20 min' depth='11.88 m' pressure='119.84 bar' />
-  <sample time='34:40 min' depth='11.94 m' pressure='119.04 bar' />
-  <sample time='35:00 min' depth='11.63 m' pressure='118.59 bar' />
-  <sample time='35:20 min' depth='10.91 m' pressure='118.19 bar' />
-  <sample time='35:40 min' depth='10.83 m' pressure='117.64 bar' />
-  <sample time='36:00 min' depth='10.69 m' pressure='116.9 bar' />
-  <sample time='36:20 min' depth='10.69 m' pressure='116.25 bar' />
-  <sample time='36:40 min' depth='10.49 m' pressure='115.76 bar' />
-  <sample time='37:00 min' depth='10.42 m' pressure='115.2 bar' />
-  <sample time='37:20 min' depth='10.46 m' pressure='114.87 bar' />
-  <sample time='37:40 min' depth='10.49 m' pressure='113.99 bar' />
-  <sample time='38:00 min' depth='10.68 m' pressure='113.35 bar' />
-  <sample time='38:20 min' depth='11.1 m' pressure='112.7 bar' />
-  <sample time='38:40 min' depth='11.39 m' pressure='112.26 bar' />
-  <sample time='39:00 min' depth='11.08 m' pressure='111.67 bar' />
-  <sample time='39:20 min' depth='11.41 m' pressure='110.55 bar' />
-  <sample time='39:40 min' depth='12.23 m' pressure='109.94 bar' />
-  <sample time='40:00 min' depth='12.42 m' pressure='109.43 bar' />
-  <sample time='40:20 min' depth='12.57 m' pressure='108.7 bar' />
-  <sample time='40:40 min' depth='12.65 m' pressure='107.98 bar' />
-  <sample time='41:00 min' depth='12.75 m' pressure='107.39 bar' />
-  <sample time='41:20 min' depth='12.64 m' pressure='106.64 bar' />
-  <sample time='41:40 min' depth='12.76 m' pressure='106.19 bar' />
-  <sample time='42:00 min' depth='13.24 m' pressure='105.2 bar' />
-  <sample time='42:20 min' depth='13.15 m' pressure='104.51 bar' />
-  <sample time='42:40 min' depth='13.38 m' pressure='103.85 bar' />
-  <sample time='43:00 min' depth='13.89 m' pressure='103.0 bar' />
-  <sample time='43:20 min' depth='14.12 m' pressure='102.06 bar' />
-  <sample time='43:40 min' depth='13.98 m' pressure='101.96 bar' />
-  <sample time='44:00 min' depth='13.95 m' pressure='100.92 bar' />
-  <sample time='44:20 min' depth='14.02 m' pressure='100.6 bar' />
-  <sample time='44:40 min' depth='13.68 m' pressure='99.81 bar' />
-  <sample time='45:00 min' depth='13.21 m' pressure='99.08 bar' />
-  <sample time='45:20 min' depth='12.74 m' pressure='98.66 bar' />
-  <sample time='45:40 min' depth='12.71 m' pressure='97.63 bar' />
-  <sample time='46:00 min' depth='11.91 m' pressure='97.23 bar' />
-  <sample time='46:20 min' depth='11.57 m' pressure='96.49 bar' />
-  <sample time='46:40 min' depth='11.1 m' pressure='96.0 bar' />
-  <sample time='47:00 min' depth='10.48 m' pressure='95.28 bar' />
-  <sample time='47:20 min' depth='10.51 m' pressure='94.64 bar' />
-  <sample time='47:40 min' depth='10.9 m' pressure='94.15 bar' />
-  <sample time='48:00 min' depth='11.06 m' pressure='93.75 bar' />
-  <sample time='48:20 min' depth='11.02 m' pressure='92.91 bar' />
-  <sample time='48:40 min' depth='10.37 m' pressure='92.43 bar' />
-  <sample time='49:00 min' depth='10.63 m' pressure='92.02 bar' />
-  <sample time='49:20 min' depth='11.0 m' pressure='91.61 bar' />
-  <sample time='49:40 min' depth='10.58 m' pressure='90.94 bar' />
-  <sample time='50:00 min' depth='10.69 m' pressure='90.09 bar' />
-  <sample time='50:20 min' depth='10.48 m' pressure='89.8 bar' />
-  <sample time='50:40 min' depth='10.95 m' pressure='88.82 bar' />
-  <sample time='51:00 min' depth='10.54 m' pressure='88.39 bar' />
-  <sample time='51:20 min' depth='11.26 m' pressure='87.63 bar' />
-  <sample time='51:40 min' depth='11.89 m' pressure='86.98 bar' />
-  <sample time='52:00 min' depth='11.03 m' pressure='86.26 bar' />
-  <sample time='52:20 min' depth='11.12 m' pressure='85.65 bar' />
-  <sample time='52:40 min' depth='11.29 m' pressure='84.81 bar' />
-  <sample time='53:00 min' depth='11.35 m' pressure='84.08 bar' />
-  <sample time='53:20 min' depth='11.27 m' pressure='83.69 bar' />
-  <sample time='53:40 min' depth='10.96 m' pressure='83.0 bar' />
-  <sample time='54:00 min' depth='9.95 m' pressure='82.74 bar' />
-  <sample time='54:20 min' depth='8.83 m' pressure='81.86 bar' />
-  <sample time='54:40 min' depth='8.68 m' pressure='81.19 bar' />
-  <sample time='55:00 min' depth='8.13 m' pressure='80.89 bar' />
-  <sample time='55:20 min' depth='7.79 m' pressure='80.44 bar' />
-  <sample time='55:40 min' depth='6.37 m' pressure='79.99 bar' />
-  <sample time='56:00 min' depth='5.62 m' pressure='79.63 bar' />
-  <sample time='56:20 min' depth='5.61 m' pressure='79.18 bar' />
-  <sample time='56:40 min' depth='5.47 m' pressure='78.8 bar' />
-  <sample time='57:00 min' depth='5.02 m' pressure='78.27 bar' />
-  <sample time='57:20 min' depth='5.21 m' pressure='77.81 bar' />
-  <sample time='57:40 min' depth='5.17 m' pressure='77.38 bar' />
-  <sample time='58:00 min' depth='4.99 m' pressure='76.7 bar' />
-  <sample time='58:20 min' depth='5.0 m' pressure='76.51 bar' />
-  <sample time='58:40 min' depth='4.96 m' pressure='76.08 bar' />
-  <sample time='59:00 min' depth='4.91 m' pressure='75.57 bar' />
-  <sample time='59:20 min' depth='4.76 m' pressure='75.06 bar' />
-  <sample time='59:40 min' depth='4.67 m' pressure='73.21 bar' />
-  <sample time='60:00 min' depth='4.28 m' pressure='72.89 bar' />
-  <sample time='60:20 min' depth='3.1 m' pressure='72.81 bar' />
-  <sample time='60:40 min' depth='2.27 m' pressure='72.51 bar' />
-  <sample time='61:00 min' depth='1.67 m' pressure='72.34 bar' />
+  <event time='60:53 min' name='surface' />
+  <sample time='0:00 min' depth='1.4 m' temp='28.0 C' pressure='195.99 bar' />
+  <sample time='0:20 min' depth='4.98 m' pressure='194.74 bar' />
+  <sample time='0:40 min' depth='5.28 m' pressure='193.94 bar' />
+  <sample time='1:00 min' depth='5.43 m' pressure='192.84 bar' />
+  <sample time='1:20 min' depth='6.14 m' pressure='192.0 bar' />
+  <sample time='1:40 min' depth='6.16 m' temp='27.0 C' pressure='191.15 bar' />
+  <sample time='2:00 min' depth='6.06 m' pressure='190.2 bar' />
+  <sample time='2:20 min' depth='6.74 m' pressure='189.65 bar' />
+  <sample time='2:40 min' depth='7.17 m' pressure='189.2 bar' />
+  <sample time='3:00 min' depth='7.62 m' pressure='188.07 bar' />
+  <sample time='3:20 min' depth='7.83 m' temp='26.0 C' pressure='187.47 bar' />
+  <sample time='3:40 min' depth='8.44 m' pressure='186.79 bar' />
+  <sample time='4:00 min' depth='8.98 m' pressure='185.91 bar' />
+  <sample time='4:20 min' depth='9.23 m' pressure='184.96 bar' />
+  <sample time='4:40 min' depth='10.19 m' pressure='184.35 bar' />
+  <sample time='5:00 min' depth='11.77 m' pressure='183.37 bar' />
+  <sample time='5:20 min' depth='12.92 m' pressure='182.15 bar' />
+  <sample time='5:40 min' depth='14.22 m' pressure='181.19 bar' />
+  <sample time='6:00 min' depth='15.71 m' pressure='179.71 bar' />
+  <sample time='6:20 min' depth='17.62 m' pressure='179.08 bar' />
+  <sample time='6:40 min' depth='19.09 m' pressure='178.54 bar' />
+  <sample time='7:00 min' depth='20.55 m' pressure='177.23 bar' />
+  <sample time='7:20 min' depth='22.08 m' pressure='175.26 bar' />
+  <sample time='7:40 min' depth='23.01 m' pressure='174.06 bar' />
+  <sample time='8:00 min' depth='24.89 m' pressure='172.96 bar' />
+  <sample time='8:20 min' depth='25.36 m' pressure='171.69 bar' />
+  <sample time='8:40 min' depth='25.27 m' pressure='170.43 bar' />
+  <sample time='9:00 min' depth='26.06 m' pressure='169.37 bar' />
+  <sample time='9:20 min' depth='26.36 m' pressure='168.25 bar' />
+  <sample time='9:40 min' depth='27.56 m' pressure='166.71 bar' />
+  <sample time='10:00 min' depth='27.76 m' pressure='165.21 bar' />
+  <sample time='10:20 min' depth='27.7 m' pressure='163.7 bar' />
+  <sample time='10:40 min' depth='27.76 m' pressure='162.66 bar' />
+  <sample time='11:00 min' depth='27.63 m' pressure='161.57 bar' />
+  <sample time='11:20 min' depth='27.51 m' pressure='160.16 bar' />
+  <sample time='11:40 min' depth='28.4 m' pressure='158.82 bar' />
+  <sample time='12:00 min' depth='28.68 m' pressure='158.06 bar' />
+  <sample time='12:20 min' depth='28.74 m' pressure='156.65 bar' />
+  <sample time='12:40 min' depth='28.58 m' pressure='155.33 bar' />
+  <sample time='13:00 min' depth='28.33 m' pressure='154.13 bar' />
+  <sample time='13:20 min' depth='27.55 m' pressure='153.69 bar' />
+  <sample time='13:40 min' depth='27.02 m' pressure='152.5 bar' />
+  <sample time='14:00 min' depth='27.31 m' pressure='151.08 bar' />
+  <sample time='14:20 min' depth='27.38 m' pressure='149.77 bar' />
+  <sample time='14:40 min' depth='27.44 m' pressure='148.88 bar' />
+  <sample time='15:00 min' depth='27.44 m' pressure='148.02 bar' />
+  <sample time='15:20 min' depth='27.37 m' pressure='146.72 bar' />
+  <sample time='15:40 min' depth='27.09 m' pressure='145.8 bar' />
+  <sample time='16:00 min' depth='27.39 m' pressure='144.99 bar' />
+  <sample time='16:20 min' depth='27.43 m' pressure='144.29 bar' />
+  <sample time='16:40 min' depth='27.45 m' pressure='143.39 bar' />
+  <sample time='17:00 min' depth='27.43 m' pressure='142.57 bar' />
+  <sample time='17:20 min' depth='27.38 m' pressure='141.74 bar' />
+  <sample time='17:40 min' depth='27.52 m' pressure='140.48 bar' />
+  <sample time='18:00 min' depth='26.52 m' pressure='139.52 bar' />
+  <sample time='18:20 min' depth='26.36 m' pressure='138.33 bar' />
+  <sample time='18:40 min' depth='26.21 m' pressure='137.14 bar' />
+  <sample time='19:00 min' depth='26.27 m' pressure='136.11 bar' />
+  <sample time='19:20 min' depth='25.83 m' pressure='135.01 bar' />
+  <sample time='19:40 min' depth='25.68 m' pressure='134.06 bar' />
+  <sample time='20:00 min' depth='25.19 m' pressure='133.28 bar' />
+  <sample time='20:20 min' depth='25.77 m' pressure='132.47 bar' />
+  <sample time='20:40 min' depth='25.72 m' pressure='131.17 bar' />
+  <sample time='21:00 min' depth='25.69 m' pressure='130.39 bar' />
+  <sample time='21:20 min' depth='25.78 m' pressure='129.51 bar' />
+  <sample time='21:40 min' depth='25.71 m' pressure='128.73 bar' />
+  <sample time='22:00 min' depth='25.2 m' pressure='128.35 bar' />
+  <sample time='22:20 min' depth='24.63 m' pressure='126.95 bar' />
+  <sample time='22:40 min' depth='24.38 m' pressure='126.09 bar' />
+  <sample time='23:00 min' depth='24.34 m' pressure='125.38 bar' />
+  <sample time='23:20 min' depth='23.77 m' pressure='124.43 bar' />
+  <sample time='23:40 min' depth='23.29 m' pressure='122.67 bar' />
+  <sample time='24:00 min' depth='23.05 m' pressure='121.7 bar' />
+  <sample time='24:20 min' depth='22.26 m' pressure='120.93 bar' />
+  <sample time='24:40 min' depth='21.48 m' pressure='120.07 bar' />
+  <sample time='25:00 min' depth='21.41 m' pressure='119.12 bar' />
+  <sample time='25:20 min' depth='21.04 m' pressure='118.09 bar' />
+  <sample time='25:40 min' depth='21.48 m' pressure='117.24 bar' />
+  <sample time='26:00 min' depth='21.85 m' pressure='116.49 bar' />
+  <sample time='26:20 min' depth='22.0 m' pressure='115.51 bar' />
+  <sample time='26:40 min' depth='20.98 m' pressure='114.75 bar' />
+  <sample time='27:00 min' depth='21.06 m' pressure='113.91 bar' />
+  <sample time='27:20 min' depth='20.78 m' pressure='112.91 bar' />
+  <sample time='27:40 min' depth='20.58 m' pressure='112.3 bar' />
+  <sample time='28:00 min' depth='20.11 m' pressure='111.44 bar' />
+  <sample time='28:20 min' depth='20.36 m' pressure='110.57 bar' />
+  <sample time='28:40 min' depth='20.71 m' pressure='110.01 bar' />
+  <sample time='29:00 min' depth='21.26 m' pressure='109.05 bar' />
+  <sample time='29:20 min' depth='20.83 m' pressure='107.7 bar' />
+  <sample time='29:40 min' depth='21.07 m' pressure='107.09 bar' />
+  <sample time='30:00 min' depth='21.34 m' pressure='105.96 bar' />
+  <sample time='30:20 min' depth='20.72 m' pressure='104.95 bar' />
+  <sample time='30:40 min' depth='20.84 m' pressure='104.0 bar' />
+  <sample time='31:00 min' depth='20.69 m' pressure='103.3 bar' />
+  <sample time='31:20 min' depth='20.99 m' pressure='102.88 bar' />
+  <sample time='31:40 min' depth='21.52 m' temp='25.0 C' pressure='101.79 bar' />
+  <sample time='32:00 min' depth='21.84 m' pressure='100.94 bar' />
+  <sample time='32:20 min' depth='21.73 m' pressure='100.07 bar' />
+  <sample time='32:40 min' depth='21.37 m' pressure='99.12 bar' />
+  <sample time='33:00 min' depth='21.08 m' pressure='98.3 bar' />
+  <sample time='33:20 min' depth='21.08 m' temp='26.0 C' pressure='97.57 bar' />
+  <sample time='33:40 min' depth='21.12 m' pressure='96.84 bar' />
+  <sample time='34:00 min' depth='20.95 m' pressure='96.39 bar' />
+  <sample time='34:20 min' depth='21.33 m' pressure='96.1 bar' />
+  <sample time='34:40 min' depth='21.97 m' pressure='94.62 bar' />
+  <sample time='35:00 min' depth='22.07 m' temp='25.0 C' pressure='93.36 bar' />
+  <sample time='35:20 min' depth='21.9 m' pressure='92.32 bar' />
+  <sample time='35:40 min' depth='21.35 m' pressure='91.61 bar' />
+  <sample time='36:00 min' depth='20.09 m' pressure='90.78 bar' />
+  <sample time='36:20 min' depth='19.49 m' pressure='89.83 bar' />
+  <sample time='36:40 min' depth='17.62 m' pressure='89.36 bar' />
+  <sample time='37:00 min' depth='16.54 m' pressure='88.41 bar' />
+  <sample time='37:20 min' depth='15.22 m' pressure='87.92 bar' />
+  <sample time='37:40 min' depth='15.02 m' pressure='87.35 bar' />
+  <sample time='38:00 min' depth='14.49 m' pressure='86.63 bar' />
+  <sample time='38:20 min' depth='14.96 m' temp='26.0 C' pressure='85.7 bar' />
+  <sample time='38:40 min' depth='14.6 m' pressure='85.3 bar' />
+  <sample time='39:00 min' depth='14.93 m' pressure='84.56 bar' />
+  <sample time='39:20 min' depth='14.55 m' pressure='83.94 bar' />
+  <sample time='39:40 min' depth='14.83 m' pressure='83.28 bar' />
+  <sample time='40:00 min' depth='14.75 m' pressure='82.74 bar' />
+  <sample time='40:20 min' depth='15.04 m' pressure='82.07 bar' />
+  <sample time='40:40 min' depth='15.76 m' pressure='81.15 bar' />
+  <sample time='41:00 min' depth='16.58 m' pressure='80.53 bar' />
+  <sample time='41:20 min' depth='16.08 m' pressure='79.89 bar' />
+  <sample time='41:40 min' depth='16.32 m' pressure='79.0 bar' />
+  <sample time='42:00 min' depth='16.28 m' pressure='78.38 bar' />
+  <sample time='42:20 min' depth='15.97 m' pressure='77.79 bar' />
+  <sample time='42:40 min' depth='16.44 m' pressure='76.9 bar' />
+  <sample time='43:00 min' depth='16.26 m' pressure='76.32 bar' />
+  <sample time='43:20 min' depth='15.9 m' pressure='75.55 bar' />
+  <sample time='43:40 min' depth='16.03 m' pressure='74.86 bar' />
+  <sample time='44:00 min' depth='15.95 m' pressure='73.89 bar' />
+  <sample time='44:20 min' depth='15.82 m' pressure='73.37 bar' />
+  <sample time='44:40 min' depth='15.93 m' pressure='72.71 bar' />
+  <sample time='45:00 min' depth='15.85 m' pressure='71.91 bar' />
+  <sample time='45:20 min' depth='16.26 m' pressure='71.05 bar' />
+  <sample time='45:40 min' depth='15.54 m' pressure='70.49 bar' />
+  <sample time='46:00 min' depth='15.98 m' pressure='70.0 bar' />
+  <sample time='46:20 min' depth='16.02 m' pressure='69.29 bar' />
+  <sample time='46:40 min' depth='16.03 m' pressure='68.39 bar' />
+  <sample time='47:00 min' depth='16.1 m' pressure='67.68 bar' />
+  <sample time='47:20 min' depth='15.79 m' />
+  <sample time='47:40 min' depth='16.25 m' />
+  <sample time='48:00 min' depth='16.26 m' />
+  <sample time='48:20 min' depth='15.01 m' />
+  <sample time='48:40 min' depth='13.48 m' pressure='66.55 bar' />
+  <sample time='49:00 min' depth='11.94 m' />
+  <sample time='49:20 min' depth='10.95 m' />
+  <sample time='49:40 min' depth='9.16 m' />
+  <sample time='50:00 min' depth='8.17 m' />
+  <sample time='50:20 min' depth='7.06 m' />
+  <sample time='50:40 min' depth='5.3 m' pressure='62.07 bar' />
+  <sample time='51:00 min' depth='5.37 m' pressure='60.67 bar' />
+  <sample time='51:20 min' depth='5.79 m' pressure='60.31 bar' />
+  <sample time='51:40 min' depth='5.98 m' pressure='59.71 bar' />
+  <sample time='52:00 min' depth='5.8 m' pressure='59.39 bar' />
+  <sample time='52:20 min' depth='5.94 m' pressure='58.82 bar' />
+  <sample time='52:40 min' depth='5.68 m' pressure='58.73 bar' />
+  <sample time='53:00 min' depth='5.64 m' pressure='58.44 bar' />
+  <sample time='53:20 min' depth='5.82 m' pressure='57.57 bar' />
+  <sample time='53:40 min' depth='5.81 m' pressure='57.24 bar' />
+  <sample time='54:00 min' depth='5.72 m' pressure='56.84 bar' />
+  <sample time='54:20 min' depth='5.68 m' pressure='56.57 bar' />
+  <sample time='54:40 min' depth='5.26 m' pressure='56.42 bar' />
+  <sample time='55:00 min' depth='5.44 m' />
+  <sample time='55:20 min' depth='5.85 m' />
+  <sample time='55:40 min' depth='5.88 m' />
+  <sample time='56:00 min' depth='5.87 m' />
+  <sample time='56:20 min' depth='5.54 m' />
+  <sample time='56:40 min' depth='5.62 m' />
+  <sample time='57:00 min' depth='5.59 m' />
+  <sample time='57:20 min' depth='5.61 m' />
+  <sample time='57:40 min' depth='5.17 m' />
+  <sample time='58:00 min' depth='4.75 m' />
+  <sample time='58:20 min' depth='5.1 m' />
+  <sample time='58:40 min' depth='5.22 m' />
+  <sample time='59:00 min' depth='5.17 m' />
+  <sample time='59:20 min' depth='4.95 m' pressure='54.1 bar' />
+  <sample time='59:40 min' depth='4.41 m' />
+  <sample time='60:00 min' depth='3.48 m' />
+  <sample time='60:20 min' depth='2.28 m' pressure='48.23 bar' />
+  <sample time='60:40 min' depth='1.89 m' pressure='47.52 bar' />
   </divecomputer>
 </dive>
 <dive number='3' sac='10.109 l/min' otu='42' cns='15%' date='2013-02-02' time='10:53:54' duration='66:00 min'>
@@ -596,197 +406,387 @@
   <sample time='66:00 min' depth='2.43 m' />
   </divecomputer>
 </dive>
-<dive number='4' sac='10.260 l/min' otu='49' cns='18%' date='2013-02-02' time='08:21:50' duration='60:40 min'>
-  <notes>Notes test</notes>
-  <cylinder size='12.0 l' o2='33.0%' start='194.74 bar' />
+<dive number='2' sac='11.298 l/min' otu='33' cns='12%' tags='boat, photography, tag' date='2013-02-02' time='13:44:21' duration='61:00 min'>
+  <notes>Testing notes</notes>
+  <cylinder size='12.0 l' o2='33.0%' start='209.04 bar' />
   <divecomputer model='Vyper Air' deviceid='013749e4'>
-  <depth max='28.84 m' mean='17.188 m' />
+  <depth max='21.88 m' mean='12.354 m' />
+  <temperature air='27.0 C' water='26.0 C' />
+  <event time='0:00 min' type='11' value='33' name='gaschange' cylinder='0' o2='33.0%' />
+  <event time='61:06 min' name='surface' />
+  <sample time='0:00 min' depth='1.21 m' temp='27.0 C' pressure='210.5 bar' />
+  <sample time='0:20 min' depth='3.91 m' pressure='209.04 bar' />
+  <sample time='0:40 min' depth='3.25 m' pressure='207.71 bar' />
+  <sample time='1:00 min' depth='4.4 m' pressure='206.45 bar' />
+  <sample time='1:20 min' depth='5.21 m' pressure='205.76 bar' />
+  <sample time='1:40 min' depth='5.58 m' pressure='204.9 bar' />
+  <sample time='2:00 min' depth='6.36 m' pressure='204.13 bar' />
+  <sample time='2:20 min' depth='6.85 m' pressure='202.86 bar' />
+  <sample time='2:40 min' depth='6.83 m' pressure='201.74 bar' />
+  <sample time='3:00 min' depth='7.81 m' pressure='200.94 bar' />
+  <sample time='3:20 min' depth='8.73 m' temp='26.0 C' pressure='200.13 bar' />
+  <sample time='3:40 min' depth='9.83 m' pressure='199.3 bar' />
+  <sample time='4:00 min' depth='10.91 m' pressure='198.07 bar' />
+  <sample time='4:20 min' depth='12.97 m' pressure='197.43 bar' />
+  <sample time='4:40 min' depth='14.5 m' />
+  <sample time='5:00 min' depth='15.9 m' pressure='196.2 bar' />
+  <sample time='5:20 min' depth='17.96 m' pressure='195.23 bar' />
+  <sample time='5:40 min' depth='19.49 m' pressure='193.24 bar' />
+  <sample time='6:00 min' depth='19.56 m' pressure='192.76 bar' />
+  <sample time='6:20 min' depth='20.4 m' />
+  <sample time='6:40 min' depth='21.11 m' pressure='191.84 bar' />
+  <sample time='7:00 min' depth='21.8 m' pressure='188.37 bar' />
+  <sample time='7:20 min' depth='21.32 m' pressure='187.13 bar' />
+  <sample time='7:40 min' depth='21.23 m' pressure='186.16 bar' />
+  <sample time='8:00 min' depth='20.93 m' pressure='184.62 bar' />
+  <sample time='8:20 min' depth='20.75 m' pressure='183.49 bar' />
+  <sample time='8:40 min' depth='21.13 m' pressure='182.62 bar' />
+  <sample time='9:00 min' depth='21.35 m' pressure='181.5 bar' />
+  <sample time='9:20 min' depth='21.36 m' pressure='180.55 bar' />
+  <sample time='9:40 min' depth='20.15 m' pressure='180.28 bar' />
+  <sample time='10:00 min' depth='18.68 m' pressure='178.76 bar' />
+  <sample time='10:20 min' depth='16.92 m' pressure='177.37 bar' />
+  <sample time='10:40 min' depth='15.56 m' pressure='176.5 bar' />
+  <sample time='11:00 min' depth='14.46 m' pressure='175.95 bar' />
+  <sample time='11:20 min' depth='13.38 m' pressure='175.11 bar' />
+  <sample time='11:40 min' depth='12.72 m' pressure='174.25 bar' />
+  <sample time='12:00 min' depth='11.51 m' pressure='173.46 bar' />
+  <sample time='12:20 min' depth='12.78 m' pressure='172.51 bar' />
+  <sample time='12:40 min' depth='13.27 m' pressure='172.02 bar' />
+  <sample time='13:00 min' depth='14.41 m' pressure='171.87 bar' />
+  <sample time='13:20 min' depth='15.02 m' pressure='170.88 bar' />
+  <sample time='13:40 min' depth='15.94 m' pressure='168.9 bar' />
+  <sample time='14:00 min' depth='16.58 m' pressure='168.24 bar' />
+  <sample time='14:20 min' depth='17.36 m' pressure='167.28 bar' />
+  <sample time='14:40 min' depth='17.92 m' pressure='166.21 bar' />
+  <sample time='15:00 min' depth='18.41 m' pressure='165.78 bar' />
+  <sample time='15:20 min' depth='18.39 m' pressure='165.1 bar' />
+  <sample time='15:40 min' depth='17.94 m' pressure='164.22 bar' />
+  <sample time='16:00 min' depth='18.15 m' pressure='163.55 bar' />
+  <sample time='16:20 min' depth='18.48 m' pressure='161.29 bar' />
+  <sample time='16:40 min' depth='18.22 m' pressure='160.28 bar' />
+  <sample time='17:00 min' depth='17.82 m' pressure='159.8 bar' />
+  <sample time='17:20 min' depth='18.41 m' pressure='159.08 bar' />
+  <sample time='17:40 min' depth='18.39 m' />
+  <sample time='18:00 min' depth='18.39 m' pressure='156.83 bar' />
+  <sample time='18:20 min' depth='17.77 m' pressure='155.84 bar' />
+  <sample time='18:40 min' depth='17.31 m' pressure='155.33 bar' />
+  <sample time='19:00 min' depth='16.98 m' pressure='154.15 bar' />
+  <sample time='19:20 min' depth='16.42 m' pressure='153.18 bar' />
+  <sample time='19:40 min' depth='16.44 m' pressure='152.52 bar' />
+  <sample time='20:00 min' depth='16.79 m' pressure='151.45 bar' />
+  <sample time='20:20 min' depth='17.16 m' pressure='150.91 bar' />
+  <sample time='20:40 min' depth='17.43 m' pressure='150.24 bar' />
+  <sample time='21:00 min' depth='17.63 m' pressure='149.18 bar' />
+  <sample time='21:20 min' depth='18.05 m' pressure='148.46 bar' />
+  <sample time='21:40 min' depth='17.66 m' pressure='147.64 bar' />
+  <sample time='22:00 min' depth='17.46 m' pressure='146.43 bar' />
+  <sample time='22:20 min' depth='16.96 m' pressure='145.46 bar' />
+  <sample time='22:40 min' depth='14.82 m' pressure='144.89 bar' />
+  <sample time='23:00 min' depth='13.36 m' pressure='144.34 bar' />
+  <sample time='23:20 min' depth='12.65 m' pressure='143.8 bar' />
+  <sample time='23:40 min' depth='12.32 m' pressure='142.86 bar' />
+  <sample time='24:00 min' depth='12.85 m' pressure='142.29 bar' />
+  <sample time='24:20 min' depth='13.36 m' pressure='141.24 bar' />
+  <sample time='24:40 min' depth='12.8 m' pressure='140.44 bar' />
+  <sample time='25:00 min' depth='12.04 m' pressure='139.95 bar' />
+  <sample time='25:20 min' depth='11.19 m' pressure='139.24 bar' />
+  <sample time='25:40 min' depth='11.15 m' pressure='138.37 bar' />
+  <sample time='26:00 min' depth='11.02 m' pressure='137.93 bar' />
+  <sample time='26:20 min' depth='10.99 m' pressure='136.86 bar' />
+  <sample time='26:40 min' depth='11.29 m' temp='25.0 C' pressure='136.49 bar' />
+  <sample time='27:00 min' depth='12.04 m' pressure='136.01 bar' />
+  <sample time='27:20 min' depth='12.19 m' pressure='134.44 bar' />
+  <sample time='27:40 min' depth='12.45 m' pressure='134.08 bar' />
+  <sample time='28:00 min' depth='12.39 m' pressure='133.21 bar' />
+  <sample time='28:20 min' depth='12.16 m' pressure='132.5 bar' />
+  <sample time='28:40 min' depth='11.3 m' pressure='131.68 bar' />
+  <sample time='29:00 min' depth='10.38 m' pressure='131.14 bar' />
+  <sample time='29:20 min' depth='10.42 m' pressure='130.41 bar' />
+  <sample time='29:40 min' depth='10.32 m' pressure='129.67 bar' />
+  <sample time='30:00 min' depth='10.48 m' pressure='128.9 bar' />
+  <sample time='30:20 min' depth='10.7 m' pressure='128.24 bar' />
+  <sample time='30:40 min' depth='10.28 m' pressure='127.56 bar' />
+  <sample time='31:00 min' depth='10.49 m' pressure='126.79 bar' />
+  <sample time='31:20 min' depth='10.35 m' pressure='126.12 bar' />
+  <sample time='31:40 min' depth='9.89 m' temp='26.0 C' pressure='125.32 bar' />
+  <sample time='32:00 min' depth='10.09 m' pressure='124.81 bar' />
+  <sample time='32:20 min' depth='10.23 m' pressure='124.11 bar' />
+  <sample time='32:40 min' depth='10.24 m' pressure='123.33 bar' />
+  <sample time='33:00 min' depth='11.38 m' pressure='122.7 bar' />
+  <sample time='33:20 min' depth='12.01 m' pressure='121.8 bar' />
+  <sample time='33:40 min' depth='11.72 m' pressure='121.22 bar' />
+  <sample time='34:00 min' depth='12.38 m' pressure='120.67 bar' />
+  <sample time='34:20 min' depth='11.88 m' pressure='119.84 bar' />
+  <sample time='34:40 min' depth='11.94 m' pressure='119.04 bar' />
+  <sample time='35:00 min' depth='11.63 m' pressure='118.59 bar' />
+  <sample time='35:20 min' depth='10.91 m' pressure='118.19 bar' />
+  <sample time='35:40 min' depth='10.83 m' pressure='117.64 bar' />
+  <sample time='36:00 min' depth='10.69 m' pressure='116.9 bar' />
+  <sample time='36:20 min' depth='10.69 m' pressure='116.25 bar' />
+  <sample time='36:40 min' depth='10.49 m' pressure='115.76 bar' />
+  <sample time='37:00 min' depth='10.42 m' pressure='115.2 bar' />
+  <sample time='37:20 min' depth='10.46 m' pressure='114.87 bar' />
+  <sample time='37:40 min' depth='10.49 m' pressure='113.99 bar' />
+  <sample time='38:00 min' depth='10.68 m' pressure='113.35 bar' />
+  <sample time='38:20 min' depth='11.1 m' pressure='112.7 bar' />
+  <sample time='38:40 min' depth='11.39 m' pressure='112.26 bar' />
+  <sample time='39:00 min' depth='11.08 m' pressure='111.67 bar' />
+  <sample time='39:20 min' depth='11.41 m' pressure='110.55 bar' />
+  <sample time='39:40 min' depth='12.23 m' pressure='109.94 bar' />
+  <sample time='40:00 min' depth='12.42 m' pressure='109.43 bar' />
+  <sample time='40:20 min' depth='12.57 m' pressure='108.7 bar' />
+  <sample time='40:40 min' depth='12.65 m' pressure='107.98 bar' />
+  <sample time='41:00 min' depth='12.75 m' pressure='107.39 bar' />
+  <sample time='41:20 min' depth='12.64 m' pressure='106.64 bar' />
+  <sample time='41:40 min' depth='12.76 m' pressure='106.19 bar' />
+  <sample time='42:00 min' depth='13.24 m' pressure='105.2 bar' />
+  <sample time='42:20 min' depth='13.15 m' pressure='104.51 bar' />
+  <sample time='42:40 min' depth='13.38 m' pressure='103.85 bar' />
+  <sample time='43:00 min' depth='13.89 m' pressure='103.0 bar' />
+  <sample time='43:20 min' depth='14.12 m' pressure='102.06 bar' />
+  <sample time='43:40 min' depth='13.98 m' pressure='101.96 bar' />
+  <sample time='44:00 min' depth='13.95 m' pressure='100.92 bar' />
+  <sample time='44:20 min' depth='14.02 m' pressure='100.6 bar' />
+  <sample time='44:40 min' depth='13.68 m' pressure='99.81 bar' />
+  <sample time='45:00 min' depth='13.21 m' pressure='99.08 bar' />
+  <sample time='45:20 min' depth='12.74 m' pressure='98.66 bar' />
+  <sample time='45:40 min' depth='12.71 m' pressure='97.63 bar' />
+  <sample time='46:00 min' depth='11.91 m' pressure='97.23 bar' />
+  <sample time='46:20 min' depth='11.57 m' pressure='96.49 bar' />
+  <sample time='46:40 min' depth='11.1 m' pressure='96.0 bar' />
+  <sample time='47:00 min' depth='10.48 m' pressure='95.28 bar' />
+  <sample time='47:20 min' depth='10.51 m' pressure='94.64 bar' />
+  <sample time='47:40 min' depth='10.9 m' pressure='94.15 bar' />
+  <sample time='48:00 min' depth='11.06 m' pressure='93.75 bar' />
+  <sample time='48:20 min' depth='11.02 m' pressure='92.91 bar' />
+  <sample time='48:40 min' depth='10.37 m' pressure='92.43 bar' />
+  <sample time='49:00 min' depth='10.63 m' pressure='92.02 bar' />
+  <sample time='49:20 min' depth='11.0 m' pressure='91.61 bar' />
+  <sample time='49:40 min' depth='10.58 m' pressure='90.94 bar' />
+  <sample time='50:00 min' depth='10.69 m' pressure='90.09 bar' />
+  <sample time='50:20 min' depth='10.48 m' pressure='89.8 bar' />
+  <sample time='50:40 min' depth='10.95 m' pressure='88.82 bar' />
+  <sample time='51:00 min' depth='10.54 m' pressure='88.39 bar' />
+  <sample time='51:20 min' depth='11.26 m' pressure='87.63 bar' />
+  <sample time='51:40 min' depth='11.89 m' pressure='86.98 bar' />
+  <sample time='52:00 min' depth='11.03 m' pressure='86.26 bar' />
+  <sample time='52:20 min' depth='11.12 m' pressure='85.65 bar' />
+  <sample time='52:40 min' depth='11.29 m' pressure='84.81 bar' />
+  <sample time='53:00 min' depth='11.35 m' pressure='84.08 bar' />
+  <sample time='53:20 min' depth='11.27 m' pressure='83.69 bar' />
+  <sample time='53:40 min' depth='10.96 m' pressure='83.0 bar' />
+  <sample time='54:00 min' depth='9.95 m' pressure='82.74 bar' />
+  <sample time='54:20 min' depth='8.83 m' pressure='81.86 bar' />
+  <sample time='54:40 min' depth='8.68 m' pressure='81.19 bar' />
+  <sample time='55:00 min' depth='8.13 m' pressure='80.89 bar' />
+  <sample time='55:20 min' depth='7.79 m' pressure='80.44 bar' />
+  <sample time='55:40 min' depth='6.37 m' pressure='79.99 bar' />
+  <sample time='56:00 min' depth='5.62 m' pressure='79.63 bar' />
+  <sample time='56:20 min' depth='5.61 m' pressure='79.18 bar' />
+  <sample time='56:40 min' depth='5.47 m' pressure='78.8 bar' />
+  <sample time='57:00 min' depth='5.02 m' pressure='78.27 bar' />
+  <sample time='57:20 min' depth='5.21 m' pressure='77.81 bar' />
+  <sample time='57:40 min' depth='5.17 m' pressure='77.38 bar' />
+  <sample time='58:00 min' depth='4.99 m' pressure='76.7 bar' />
+  <sample time='58:20 min' depth='5.0 m' pressure='76.51 bar' />
+  <sample time='58:40 min' depth='4.96 m' pressure='76.08 bar' />
+  <sample time='59:00 min' depth='4.91 m' pressure='75.57 bar' />
+  <sample time='59:20 min' depth='4.76 m' pressure='75.06 bar' />
+  <sample time='59:40 min' depth='4.67 m' pressure='73.21 bar' />
+  <sample time='60:00 min' depth='4.28 m' pressure='72.89 bar' />
+  <sample time='60:20 min' depth='3.1 m' pressure='72.81 bar' />
+  <sample time='60:40 min' depth='2.27 m' pressure='72.51 bar' />
+  <sample time='61:00 min' depth='1.67 m' pressure='72.34 bar' />
+  </divecomputer>
+</dive>
+<dive number='1' sac='11.046 l/min' otu='46' cns='15%' date='2013-02-02' time='16:14:08' duration='59:20 min'>
+  <notes>Notes are here</notes>
+  <cylinder size='12.0 l' o2='33.0%' start='205.11 bar' />
+  <divecomputer model='Vyper Air' deviceid='013749e4'>
+  <depth max='22.44 m' mean='16.291 m' />
   <temperature air='28.0 C' water='26.0 C' />
   <event time='0:00 min' type='11' value='33' name='gaschange' cylinder='0' o2='33.0%' />
-  <event time='60:53 min' name='surface' />
-  <sample time='0:00 min' depth='1.4 m' temp='28.0 C' pressure='195.99 bar' />
-  <sample time='0:20 min' depth='4.98 m' pressure='194.74 bar' />
-  <sample time='0:40 min' depth='5.28 m' pressure='193.94 bar' />
-  <sample time='1:00 min' depth='5.43 m' pressure='192.84 bar' />
-  <sample time='1:20 min' depth='6.14 m' pressure='192.0 bar' />
-  <sample time='1:40 min' depth='6.16 m' temp='27.0 C' pressure='191.15 bar' />
-  <sample time='2:00 min' depth='6.06 m' pressure='190.2 bar' />
-  <sample time='2:20 min' depth='6.74 m' pressure='189.65 bar' />
-  <sample time='2:40 min' depth='7.17 m' pressure='189.2 bar' />
-  <sample time='3:00 min' depth='7.62 m' pressure='188.07 bar' />
-  <sample time='3:20 min' depth='7.83 m' temp='26.0 C' pressure='187.47 bar' />
-  <sample time='3:40 min' depth='8.44 m' pressure='186.79 bar' />
-  <sample time='4:00 min' depth='8.98 m' pressure='185.91 bar' />
-  <sample time='4:20 min' depth='9.23 m' pressure='184.96 bar' />
-  <sample time='4:40 min' depth='10.19 m' pressure='184.35 bar' />
-  <sample time='5:00 min' depth='11.77 m' pressure='183.37 bar' />
-  <sample time='5:20 min' depth='12.92 m' pressure='182.15 bar' />
-  <sample time='5:40 min' depth='14.22 m' pressure='181.19 bar' />
-  <sample time='6:00 min' depth='15.71 m' pressure='179.71 bar' />
-  <sample time='6:20 min' depth='17.62 m' pressure='179.08 bar' />
-  <sample time='6:40 min' depth='19.09 m' pressure='178.54 bar' />
-  <sample time='7:00 min' depth='20.55 m' pressure='177.23 bar' />
-  <sample time='7:20 min' depth='22.08 m' pressure='175.26 bar' />
-  <sample time='7:40 min' depth='23.01 m' pressure='174.06 bar' />
-  <sample time='8:00 min' depth='24.89 m' pressure='172.96 bar' />
-  <sample time='8:20 min' depth='25.36 m' pressure='171.69 bar' />
-  <sample time='8:40 min' depth='25.27 m' pressure='170.43 bar' />
-  <sample time='9:00 min' depth='26.06 m' pressure='169.37 bar' />
-  <sample time='9:20 min' depth='26.36 m' pressure='168.25 bar' />
-  <sample time='9:40 min' depth='27.56 m' pressure='166.71 bar' />
-  <sample time='10:00 min' depth='27.76 m' pressure='165.21 bar' />
-  <sample time='10:20 min' depth='27.7 m' pressure='163.7 bar' />
-  <sample time='10:40 min' depth='27.76 m' pressure='162.66 bar' />
-  <sample time='11:00 min' depth='27.63 m' pressure='161.57 bar' />
-  <sample time='11:20 min' depth='27.51 m' pressure='160.16 bar' />
-  <sample time='11:40 min' depth='28.4 m' pressure='158.82 bar' />
-  <sample time='12:00 min' depth='28.68 m' pressure='158.06 bar' />
-  <sample time='12:20 min' depth='28.74 m' pressure='156.65 bar' />
-  <sample time='12:40 min' depth='28.58 m' pressure='155.33 bar' />
-  <sample time='13:00 min' depth='28.33 m' pressure='154.13 bar' />
-  <sample time='13:20 min' depth='27.55 m' pressure='153.69 bar' />
-  <sample time='13:40 min' depth='27.02 m' pressure='152.5 bar' />
-  <sample time='14:00 min' depth='27.31 m' pressure='151.08 bar' />
-  <sample time='14:20 min' depth='27.38 m' pressure='149.77 bar' />
-  <sample time='14:40 min' depth='27.44 m' pressure='148.88 bar' />
-  <sample time='15:00 min' depth='27.44 m' pressure='148.02 bar' />
-  <sample time='15:20 min' depth='27.37 m' pressure='146.72 bar' />
-  <sample time='15:40 min' depth='27.09 m' pressure='145.8 bar' />
-  <sample time='16:00 min' depth='27.39 m' pressure='144.99 bar' />
-  <sample time='16:20 min' depth='27.43 m' pressure='144.29 bar' />
-  <sample time='16:40 min' depth='27.45 m' pressure='143.39 bar' />
-  <sample time='17:00 min' depth='27.43 m' pressure='142.57 bar' />
-  <sample time='17:20 min' depth='27.38 m' pressure='141.74 bar' />
-  <sample time='17:40 min' depth='27.52 m' pressure='140.48 bar' />
-  <sample time='18:00 min' depth='26.52 m' pressure='139.52 bar' />
-  <sample time='18:20 min' depth='26.36 m' pressure='138.33 bar' />
-  <sample time='18:40 min' depth='26.21 m' pressure='137.14 bar' />
-  <sample time='19:00 min' depth='26.27 m' pressure='136.11 bar' />
-  <sample time='19:20 min' depth='25.83 m' pressure='135.01 bar' />
-  <sample time='19:40 min' depth='25.68 m' pressure='134.06 bar' />
-  <sample time='20:00 min' depth='25.19 m' pressure='133.28 bar' />
-  <sample time='20:20 min' depth='25.77 m' pressure='132.47 bar' />
-  <sample time='20:40 min' depth='25.72 m' pressure='131.17 bar' />
-  <sample time='21:00 min' depth='25.69 m' pressure='130.39 bar' />
-  <sample time='21:20 min' depth='25.78 m' pressure='129.51 bar' />
-  <sample time='21:40 min' depth='25.71 m' pressure='128.73 bar' />
-  <sample time='22:00 min' depth='25.2 m' pressure='128.35 bar' />
-  <sample time='22:20 min' depth='24.63 m' pressure='126.95 bar' />
-  <sample time='22:40 min' depth='24.38 m' pressure='126.09 bar' />
-  <sample time='23:00 min' depth='24.34 m' pressure='125.38 bar' />
-  <sample time='23:20 min' depth='23.77 m' pressure='124.43 bar' />
-  <sample time='23:40 min' depth='23.29 m' pressure='122.67 bar' />
-  <sample time='24:00 min' depth='23.05 m' pressure='121.7 bar' />
-  <sample time='24:20 min' depth='22.26 m' pressure='120.93 bar' />
-  <sample time='24:40 min' depth='21.48 m' pressure='120.07 bar' />
-  <sample time='25:00 min' depth='21.41 m' pressure='119.12 bar' />
-  <sample time='25:20 min' depth='21.04 m' pressure='118.09 bar' />
-  <sample time='25:40 min' depth='21.48 m' pressure='117.24 bar' />
-  <sample time='26:00 min' depth='21.85 m' pressure='116.49 bar' />
-  <sample time='26:20 min' depth='22.0 m' pressure='115.51 bar' />
-  <sample time='26:40 min' depth='20.98 m' pressure='114.75 bar' />
-  <sample time='27:00 min' depth='21.06 m' pressure='113.91 bar' />
-  <sample time='27:20 min' depth='20.78 m' pressure='112.91 bar' />
-  <sample time='27:40 min' depth='20.58 m' pressure='112.3 bar' />
-  <sample time='28:00 min' depth='20.11 m' pressure='111.44 bar' />
-  <sample time='28:20 min' depth='20.36 m' pressure='110.57 bar' />
-  <sample time='28:40 min' depth='20.71 m' pressure='110.01 bar' />
-  <sample time='29:00 min' depth='21.26 m' pressure='109.05 bar' />
-  <sample time='29:20 min' depth='20.83 m' pressure='107.7 bar' />
-  <sample time='29:40 min' depth='21.07 m' pressure='107.09 bar' />
-  <sample time='30:00 min' depth='21.34 m' pressure='105.96 bar' />
-  <sample time='30:20 min' depth='20.72 m' pressure='104.95 bar' />
-  <sample time='30:40 min' depth='20.84 m' pressure='104.0 bar' />
-  <sample time='31:00 min' depth='20.69 m' pressure='103.3 bar' />
-  <sample time='31:20 min' depth='20.99 m' pressure='102.88 bar' />
-  <sample time='31:40 min' depth='21.52 m' temp='25.0 C' pressure='101.79 bar' />
-  <sample time='32:00 min' depth='21.84 m' pressure='100.94 bar' />
-  <sample time='32:20 min' depth='21.73 m' pressure='100.07 bar' />
-  <sample time='32:40 min' depth='21.37 m' pressure='99.12 bar' />
-  <sample time='33:00 min' depth='21.08 m' pressure='98.3 bar' />
-  <sample time='33:20 min' depth='21.08 m' temp='26.0 C' pressure='97.57 bar' />
-  <sample time='33:40 min' depth='21.12 m' pressure='96.84 bar' />
-  <sample time='34:00 min' depth='20.95 m' pressure='96.39 bar' />
-  <sample time='34:20 min' depth='21.33 m' pressure='96.1 bar' />
-  <sample time='34:40 min' depth='21.97 m' pressure='94.62 bar' />
-  <sample time='35:00 min' depth='22.07 m' temp='25.0 C' pressure='93.36 bar' />
-  <sample time='35:20 min' depth='21.9 m' pressure='92.32 bar' />
-  <sample time='35:40 min' depth='21.35 m' pressure='91.61 bar' />
-  <sample time='36:00 min' depth='20.09 m' pressure='90.78 bar' />
-  <sample time='36:20 min' depth='19.49 m' pressure='89.83 bar' />
-  <sample time='36:40 min' depth='17.62 m' pressure='89.36 bar' />
-  <sample time='37:00 min' depth='16.54 m' pressure='88.41 bar' />
-  <sample time='37:20 min' depth='15.22 m' pressure='87.92 bar' />
-  <sample time='37:40 min' depth='15.02 m' pressure='87.35 bar' />
-  <sample time='38:00 min' depth='14.49 m' pressure='86.63 bar' />
-  <sample time='38:20 min' depth='14.96 m' temp='26.0 C' pressure='85.7 bar' />
-  <sample time='38:40 min' depth='14.6 m' pressure='85.3 bar' />
-  <sample time='39:00 min' depth='14.93 m' pressure='84.56 bar' />
-  <sample time='39:20 min' depth='14.55 m' pressure='83.94 bar' />
-  <sample time='39:40 min' depth='14.83 m' pressure='83.28 bar' />
-  <sample time='40:00 min' depth='14.75 m' pressure='82.74 bar' />
-  <sample time='40:20 min' depth='15.04 m' pressure='82.07 bar' />
-  <sample time='40:40 min' depth='15.76 m' pressure='81.15 bar' />
-  <sample time='41:00 min' depth='16.58 m' pressure='80.53 bar' />
-  <sample time='41:20 min' depth='16.08 m' pressure='79.89 bar' />
-  <sample time='41:40 min' depth='16.32 m' pressure='79.0 bar' />
-  <sample time='42:00 min' depth='16.28 m' pressure='78.38 bar' />
-  <sample time='42:20 min' depth='15.97 m' pressure='77.79 bar' />
-  <sample time='42:40 min' depth='16.44 m' pressure='76.9 bar' />
-  <sample time='43:00 min' depth='16.26 m' pressure='76.32 bar' />
-  <sample time='43:20 min' depth='15.9 m' pressure='75.55 bar' />
-  <sample time='43:40 min' depth='16.03 m' pressure='74.86 bar' />
-  <sample time='44:00 min' depth='15.95 m' pressure='73.89 bar' />
-  <sample time='44:20 min' depth='15.82 m' pressure='73.37 bar' />
-  <sample time='44:40 min' depth='15.93 m' pressure='72.71 bar' />
-  <sample time='45:00 min' depth='15.85 m' pressure='71.91 bar' />
-  <sample time='45:20 min' depth='16.26 m' pressure='71.05 bar' />
-  <sample time='45:40 min' depth='15.54 m' pressure='70.49 bar' />
-  <sample time='46:00 min' depth='15.98 m' pressure='70.0 bar' />
-  <sample time='46:20 min' depth='16.02 m' pressure='69.29 bar' />
-  <sample time='46:40 min' depth='16.03 m' pressure='68.39 bar' />
-  <sample time='47:00 min' depth='16.1 m' pressure='67.68 bar' />
-  <sample time='47:20 min' depth='15.79 m' />
-  <sample time='47:40 min' depth='16.25 m' />
-  <sample time='48:00 min' depth='16.26 m' />
-  <sample time='48:20 min' depth='15.01 m' />
-  <sample time='48:40 min' depth='13.48 m' pressure='66.55 bar' />
-  <sample time='49:00 min' depth='11.94 m' />
-  <sample time='49:20 min' depth='10.95 m' />
-  <sample time='49:40 min' depth='9.16 m' />
-  <sample time='50:00 min' depth='8.17 m' />
-  <sample time='50:20 min' depth='7.06 m' />
-  <sample time='50:40 min' depth='5.3 m' pressure='62.07 bar' />
-  <sample time='51:00 min' depth='5.37 m' pressure='60.67 bar' />
-  <sample time='51:20 min' depth='5.79 m' pressure='60.31 bar' />
-  <sample time='51:40 min' depth='5.98 m' pressure='59.71 bar' />
-  <sample time='52:00 min' depth='5.8 m' pressure='59.39 bar' />
-  <sample time='52:20 min' depth='5.94 m' pressure='58.82 bar' />
-  <sample time='52:40 min' depth='5.68 m' pressure='58.73 bar' />
-  <sample time='53:00 min' depth='5.64 m' pressure='58.44 bar' />
-  <sample time='53:20 min' depth='5.82 m' pressure='57.57 bar' />
-  <sample time='53:40 min' depth='5.81 m' pressure='57.24 bar' />
-  <sample time='54:00 min' depth='5.72 m' pressure='56.84 bar' />
-  <sample time='54:20 min' depth='5.68 m' pressure='56.57 bar' />
-  <sample time='54:40 min' depth='5.26 m' pressure='56.42 bar' />
-  <sample time='55:00 min' depth='5.44 m' />
-  <sample time='55:20 min' depth='5.85 m' />
-  <sample time='55:40 min' depth='5.88 m' />
-  <sample time='56:00 min' depth='5.87 m' />
-  <sample time='56:20 min' depth='5.54 m' />
-  <sample time='56:40 min' depth='5.62 m' />
-  <sample time='57:00 min' depth='5.59 m' />
-  <sample time='57:20 min' depth='5.61 m' />
-  <sample time='57:40 min' depth='5.17 m' />
-  <sample time='58:00 min' depth='4.75 m' />
-  <sample time='58:20 min' depth='5.1 m' />
-  <sample time='58:40 min' depth='5.22 m' />
-  <sample time='59:00 min' depth='5.17 m' />
-  <sample time='59:20 min' depth='4.95 m' pressure='54.1 bar' />
-  <sample time='59:40 min' depth='4.41 m' />
-  <sample time='60:00 min' depth='3.48 m' />
-  <sample time='60:20 min' depth='2.28 m' pressure='48.23 bar' />
-  <sample time='60:40 min' depth='1.89 m' pressure='47.52 bar' />
+  <event time='59:32 min' name='surface' />
+  <sample time='0:00 min' depth='1.39 m' temp='28.0 C' pressure='206.52 bar' />
+  <sample time='0:20 min' depth='4.63 m' pressure='205.11 bar' />
+  <sample time='0:40 min' depth='7.66 m' pressure='203.6 bar' />
+  <sample time='1:00 min' depth='11.76 m' pressure='201.95 bar' />
+  <sample time='1:20 min' depth='16.77 m' pressure='200.03 bar' />
+  <sample time='1:40 min' depth='20.82 m' temp='27.0 C' pressure='198.3 bar' />
+  <sample time='2:00 min' depth='21.21 m' pressure='195.75 bar' />
+  <sample time='2:20 min' depth='21.89 m' pressure='194.02 bar' />
+  <sample time='2:40 min' depth='21.67 m' pressure='192.43 bar' />
+  <sample time='3:00 min' depth='21.7 m' pressure='191.11 bar' />
+  <sample time='3:20 min' depth='22.05 m' temp='26.0 C' pressure='189.73 bar' />
+  <sample time='3:40 min' depth='21.94 m' pressure='188.5 bar' />
+  <sample time='4:00 min' depth='21.5 m' pressure='187.16 bar' />
+  <sample time='4:20 min' depth='21.22 m' pressure='186.05 bar' />
+  <sample time='4:40 min' depth='21.36 m' pressure='185.17 bar' />
+  <sample time='5:00 min' depth='21.4 m' pressure='184.02 bar' />
+  <sample time='5:20 min' depth='21.73 m' pressure='182.64 bar' />
+  <sample time='5:40 min' depth='21.44 m' pressure='181.76 bar' />
+  <sample time='6:00 min' depth='21.49 m' pressure='180.84 bar' />
+  <sample time='6:20 min' depth='21.13 m' pressure='179.67 bar' />
+  <sample time='6:40 min' depth='21.33 m' pressure='178.53 bar' />
+  <sample time='7:00 min' depth='22.04 m' pressure='178.31 bar' />
+  <sample time='7:20 min' depth='22.41 m' pressure='177.35 bar' />
+  <sample time='7:40 min' depth='22.02 m' pressure='175.77 bar' />
+  <sample time='8:00 min' depth='21.72 m' pressure='174.27 bar' />
+  <sample time='8:20 min' depth='21.26 m' pressure='173.85 bar' />
+  <sample time='8:40 min' depth='20.89 m' pressure='172.56 bar' />
+  <sample time='9:00 min' depth='21.1 m' pressure='171.35 bar' />
+  <sample time='9:20 min' depth='21.24 m' pressure='170.33 bar' />
+  <sample time='9:40 min' depth='20.36 m' pressure='169.29 bar' />
+  <sample time='10:00 min' depth='20.15 m' pressure='168.59 bar' />
+  <sample time='10:20 min' depth='20.04 m' pressure='167.8 bar' />
+  <sample time='10:40 min' depth='19.95 m' pressure='166.2 bar' />
+  <sample time='11:00 min' depth='19.55 m' pressure='165.48 bar' />
+  <sample time='11:20 min' depth='19.36 m' pressure='164.12 bar' />
+  <sample time='11:40 min' depth='18.59 m' pressure='163.4 bar' />
+  <sample time='12:00 min' depth='18.04 m' pressure='162.63 bar' />
+  <sample time='12:20 min' depth='17.57 m' pressure='161.95 bar' />
+  <sample time='12:40 min' depth='17.2 m' pressure='160.65 bar' />
+  <sample time='13:00 min' depth='16.63 m' pressure='159.58 bar' />
+  <sample time='13:20 min' depth='17.12 m' pressure='158.25 bar' />
+  <sample time='13:40 min' depth='17.04 m' pressure='157.56 bar' />
+  <sample time='14:00 min' depth='17.15 m' pressure='156.6 bar' />
+  <sample time='14:20 min' depth='17.07 m' pressure='156.06 bar' />
+  <sample time='14:40 min' depth='16.71 m' pressure='155.24 bar' />
+  <sample time='15:00 min' depth='17.02 m' pressure='154.44 bar' />
+  <sample time='15:20 min' depth='16.76 m' pressure='153.71 bar' />
+  <sample time='15:40 min' depth='16.43 m' pressure='152.75 bar' />
+  <sample time='16:00 min' depth='16.81 m' pressure='152.09 bar' />
+  <sample time='16:20 min' depth='16.95 m' pressure='151.12 bar' />
+  <sample time='16:40 min' depth='17.06 m' pressure='150.37 bar' />
+  <sample time='17:00 min' depth='16.81 m' pressure='149.38 bar' />
+  <sample time='17:20 min' depth='17.01 m' pressure='148.7 bar' />
+  <sample time='17:40 min' depth='17.22 m' pressure='147.72 bar' />
+  <sample time='18:00 min' depth='16.86 m' pressure='146.86 bar' />
+  <sample time='18:20 min' depth='17.12 m' pressure='146.25 bar' />
+  <sample time='18:40 min' depth='17.28 m' pressure='145.01 bar' />
+  <sample time='19:00 min' depth='17.02 m' pressure='144.55 bar' />
+  <sample time='19:20 min' depth='17.12 m' pressure='143.39 bar' />
+  <sample time='19:40 min' depth='16.87 m' pressure='142.35 bar' />
+  <sample time='20:00 min' depth='17.05 m' pressure='141.57 bar' />
+  <sample time='20:20 min' depth='17.37 m' pressure='140.85 bar' />
+  <sample time='20:40 min' depth='17.34 m' pressure='140.16 bar' />
+  <sample time='21:00 min' depth='17.47 m' pressure='139.23 bar' />
+  <sample time='21:20 min' depth='17.45 m' pressure='138.24 bar' />
+  <sample time='21:40 min' depth='17.37 m' pressure='137.58 bar' />
+  <sample time='22:00 min' depth='16.97 m' pressure='136.78 bar' />
+  <sample time='22:20 min' depth='16.88 m' pressure='135.6 bar' />
+  <sample time='22:40 min' depth='17.03 m' pressure='134.95 bar' />
+  <sample time='23:00 min' depth='17.17 m' pressure='133.88 bar' />
+  <sample time='23:20 min' depth='17.11 m' pressure='133.21 bar' />
+  <sample time='23:40 min' depth='17.13 m' pressure='132.32 bar' />
+  <sample time='24:00 min' depth='17.12 m' pressure='131.63 bar' />
+  <sample time='24:20 min' depth='17.04 m' pressure='130.81 bar' />
+  <sample time='24:40 min' depth='16.86 m' pressure='130.33 bar' />
+  <sample time='25:00 min' depth='16.98 m' pressure='129.12 bar' />
+  <sample time='25:20 min' depth='16.86 m' pressure='128.34 bar' />
+  <sample time='25:40 min' depth='16.86 m' pressure='127.56 bar' />
+  <sample time='26:00 min' depth='16.96 m' pressure='126.87 bar' />
+  <sample time='26:20 min' depth='17.17 m' pressure='126.32 bar' />
+  <sample time='26:40 min' depth='16.74 m' pressure='125.03 bar' />
+  <sample time='27:00 min' depth='17.2 m' pressure='124.31 bar' />
+  <sample time='27:20 min' depth='17.26 m' pressure='123.65 bar' />
+  <sample time='27:40 min' depth='17.24 m' pressure='123.35 bar' />
+  <sample time='28:00 min' depth='17.31 m' pressure='122.17 bar' />
+  <sample time='28:20 min' depth='17.4 m' pressure='121.34 bar' />
+  <sample time='28:40 min' depth='17.43 m' pressure='120.7 bar' />
+  <sample time='29:00 min' depth='17.43 m' pressure='120.28 bar' />
+  <sample time='29:20 min' depth='17.43 m' pressure='119.61 bar' />
+  <sample time='29:40 min' depth='17.45 m' pressure='119.26 bar' />
+  <sample time='30:00 min' depth='17.44 m' pressure='119.04 bar' />
+  <sample time='30:20 min' depth='17.06 m' pressure='117.96 bar' />
+  <sample time='30:40 min' depth='16.59 m' pressure='117.1 bar' />
+  <sample time='31:00 min' depth='16.98 m' pressure='115.9 bar' />
+  <sample time='31:20 min' depth='16.88 m' pressure='115.17 bar' />
+  <sample time='31:40 min' depth='16.66 m' pressure='114.41 bar' />
+  <sample time='32:00 min' depth='16.65 m' pressure='113.8 bar' />
+  <sample time='32:20 min' depth='16.76 m' pressure='112.87 bar' />
+  <sample time='32:40 min' depth='17.25 m' pressure='112.23 bar' />
+  <sample time='33:00 min' depth='17.0 m' pressure='111.6 bar' />
+  <sample time='33:20 min' depth='16.59 m' pressure='110.69 bar' />
+  <sample time='33:40 min' depth='16.47 m' pressure='109.65 bar' />
+  <sample time='34:00 min' depth='16.59 m' pressure='108.94 bar' />
+  <sample time='34:20 min' depth='16.62 m' pressure='108.25 bar' />
+  <sample time='34:40 min' depth='16.98 m' pressure='107.94 bar' />
+  <sample time='35:00 min' depth='17.34 m' pressure='106.89 bar' />
+  <sample time='35:20 min' depth='17.34 m' pressure='105.79 bar' />
+  <sample time='35:40 min' depth='17.29 m' pressure='105.52 bar' />
+  <sample time='36:00 min' depth='17.26 m' pressure='104.84 bar' />
+  <sample time='36:20 min' depth='17.25 m' pressure='104.07 bar' />
+  <sample time='36:40 min' depth='17.39 m' pressure='103.01 bar' />
+  <sample time='37:00 min' depth='17.02 m' pressure='102.24 bar' />
+  <sample time='37:20 min' depth='16.87 m' pressure='101.45 bar' />
+  <sample time='37:40 min' depth='16.75 m' pressure='100.98 bar' />
+  <sample time='38:00 min' depth='16.51 m' pressure='99.94 bar' />
+  <sample time='38:20 min' depth='16.78 m' pressure='99.38 bar' />
+  <sample time='38:40 min' depth='16.93 m' pressure='98.77 bar' />
+  <sample time='39:00 min' depth='16.64 m' pressure='98.13 bar' />
+  <sample time='39:20 min' depth='16.35 m' pressure='97.1 bar' />
+  <sample time='39:40 min' depth='16.84 m' pressure='96.32 bar' />
+  <sample time='40:00 min' depth='16.93 m' pressure='95.61 bar' />
+  <sample time='40:20 min' depth='16.92 m' pressure='94.89 bar' />
+  <sample time='40:40 min' depth='16.96 m' pressure='93.88 bar' />
+  <sample time='41:00 min' depth='16.99 m' pressure='93.26 bar' />
+  <sample time='41:20 min' depth='16.96 m' pressure='92.73 bar' />
+  <sample time='41:40 min' depth='16.57 m' pressure='91.96 bar' />
+  <sample time='42:00 min' depth='16.07 m' pressure='91.15 bar' />
+  <sample time='42:20 min' depth='15.95 m' pressure='90.42 bar' />
+  <sample time='42:40 min' depth='16.24 m' pressure='89.9 bar' />
+  <sample time='43:00 min' depth='16.38 m' pressure='88.92 bar' />
+  <sample time='43:20 min' depth='16.67 m' pressure='88.2 bar' />
+  <sample time='43:40 min' depth='16.61 m' pressure='87.41 bar' />
+  <sample time='44:00 min' depth='17.17 m' pressure='86.42 bar' />
+  <sample time='44:20 min' depth='17.24 m' pressure='85.9 bar' />
+  <sample time='44:40 min' depth='17.41 m' pressure='85.16 bar' />
+  <sample time='45:00 min' depth='17.45 m' pressure='84.36 bar' />
+  <sample time='45:20 min' depth='17.2 m' pressure='83.57 bar' />
+  <sample time='45:40 min' depth='16.97 m' pressure='82.76 bar' />
+  <sample time='46:00 min' depth='17.45 m' pressure='81.8 bar' />
+  <sample time='46:20 min' depth='17.26 m' pressure='81.25 bar' />
+  <sample time='46:40 min' depth='17.35 m' pressure='80.64 bar' />
+  <sample time='47:00 min' depth='17.7 m' pressure='79.66 bar' />
+  <sample time='47:20 min' depth='17.06 m' pressure='78.83 bar' />
+  <sample time='47:40 min' depth='17.1 m' pressure='78.14 bar' />
+  <sample time='48:00 min' depth='16.99 m' pressure='77.16 bar' />
+  <sample time='48:20 min' depth='17.22 m' pressure='76.68 bar' />
+  <sample time='48:40 min' depth='17.01 m' pressure='75.75 bar' />
+  <sample time='49:00 min' depth='17.31 m' pressure='74.8 bar' />
+  <sample time='49:20 min' depth='17.39 m' pressure='74.08 bar' />
+  <sample time='49:40 min' depth='17.43 m' pressure='73.52 bar' />
+  <sample time='50:00 min' depth='16.83 m' pressure='73.01 bar' />
+  <sample time='50:20 min' depth='16.52 m' pressure='72.01 bar' />
+  <sample time='50:40 min' depth='16.59 m' pressure='71.01 bar' />
+  <sample time='51:00 min' depth='16.49 m' pressure='69.98 bar' />
+  <sample time='51:20 min' depth='16.04 m' pressure='69.34 bar' />
+  <sample time='51:40 min' depth='15.55 m' pressure='68.15 bar' />
+  <sample time='52:00 min' depth='15.03 m' pressure='67.46 bar' />
+  <sample time='52:20 min' depth='14.18 m' pressure='66.65 bar' />
+  <sample time='52:40 min' depth='12.88 m' pressure='65.84 bar' />
+  <sample time='53:00 min' depth='12.03 m' pressure='65.1 bar' />
+  <sample time='53:20 min' depth='11.19 m' pressure='64.53 bar' />
+  <sample time='53:40 min' depth='10.47 m' pressure='63.65 bar' />
+  <sample time='54:00 min' depth='9.12 m' pressure='62.93 bar' />
+  <sample time='54:20 min' depth='7.64 m' pressure='62.24 bar' />
+  <sample time='54:40 min' depth='6.79 m' pressure='61.55 bar' />
+  <sample time='55:00 min' depth='6.02 m' pressure='61.15 bar' />
+  <sample time='55:20 min' depth='5.47 m' pressure='60.67 bar' />
+  <sample time='55:40 min' depth='5.36 m' pressure='60.21 bar' />
+  <sample time='56:00 min' depth='5.49 m' pressure='59.39 bar' />
+  <sample time='56:20 min' depth='5.31 m' pressure='59.21 bar' />
+  <sample time='56:40 min' depth='5.33 m' pressure='56.0 bar' />
+  <sample time='57:00 min' depth='5.31 m' pressure='56.45 bar' />
+  <sample time='57:20 min' depth='5.28 m' pressure='56.2 bar' />
+  <sample time='57:40 min' depth='4.93 m' pressure='55.6 bar' />
+  <sample time='58:00 min' depth='4.88 m' pressure='55.3 bar' />
+  <sample time='58:20 min' depth='4.63 m' pressure='54.78 bar' />
+  <sample time='58:40 min' depth='3.75 m' pressure='54.37 bar' />
+  <sample time='59:00 min' depth='2.69 m' pressure='54.08 bar' />
+  <sample time='59:20 min' depth='1.88 m' pressure='53.87 bar' />
   </divecomputer>
 </dive>
 </dives>

--- a/dives/mergedVyperOstc.xml
+++ b/dives/mergedVyperOstc.xml
@@ -101,97 +101,6 @@
   <sample time='76:56 min' depth='0.01 m' ndl='0:00 min' cns='0%' />
   </divecomputer>
 </dive>
-<dive number='2' otu='40' cns='22%' date='2017-02-03' time='10:24:00' duration='66:00 min'>
-  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
-  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
-  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='31.0%' />
-  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
-  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
-  <divecomputer model='Heinrichs Weikamp OSTC Sport' deviceid='8e8f3f68' diveid='7ab00781'>
-  <depth max='27.44 m' mean='14.427 m' />
-  <temperature water='26.2 C' />
-  <surface pressure='1.009 bar' />
-  <extradata key='Battery at end' value='1.50' />
-  <extradata key='Desat time' value='38:03' />
-  <extradata key='FW Version' value='10.31' />
-  <extradata key='Serial' value='10321' />
-  <extradata key='Deco model' value='ZH-L16-GF' />
-  <extradata key='Deco model info' value='GF 30/80' />
-  <event time='0:02 min' type='25' flags='2' name='gaschange' cylinder='1' o2='32.0%' />
-  <sample time='0:02 min' depth='2.505 m' cns='17%' />
-  <sample time='1:00 min' depth='5.831 m' temp='27.3 C' />
-  <sample time='2:00 min' depth='7.663 m' />
-  <sample time='3:00 min' depth='8.059 m' />
-  <sample time='4:00 min' depth='8.306 m' />
-  <sample time='5:00 min' depth='8.801 m' temp='27.4 C' />
-  <sample time='6:00 min' depth='8.772 m' />
-  <sample time='7:00 min' depth='8.989 m' />
-  <sample time='8:00 min' depth='9.366 m' />
-  <sample time='9:00 min' depth='9.504 m' />
-  <sample time='10:00 min' depth='9.88 m' />
-  <sample time='11:00 min' depth='9.969 m' />
-  <sample time='12:00 min' depth='13.464 m' ndl='124:00 min' />
-  <sample time='13:00 min' depth='16.365 m' temp='26.8 C' ndl='68:00 min' />
-  <sample time='14:00 min' depth='17.315 m' temp='26.5 C' ndl='59:00 min' />
-  <sample time='15:00 min' depth='17.81 m' />
-  <sample time='16:00 min' depth='18.543 m' ndl='48:00 min' />
-  <sample time='17:00 min' depth='23.265 m' ndl='24:00 min' />
-  <sample time='18:00 min' depth='26.928 m' temp='26.2 C' ndl='14:00 min' cns='11%' />
-  <sample time='19:00 min' depth='26.998 m' ndl='13:00 min' />
-  <sample time='20:00 min' depth='26.909 m' />
-  <sample time='21:00 min' depth='26.493 m' />
-  <sample time='22:00 min' depth='24.117 m' />
-  <sample time='23:00 min' depth='23.176 m' ndl='17:00 min' />
-  <sample time='24:00 min' depth='21.671 m' ndl='21:00 min' />
-  <sample time='25:00 min' depth='20.82 m' ndl='23:00 min' />
-  <sample time='26:00 min' depth='24.414 m' />
-  <sample time='27:00 min' depth='23.711 m' ndl='13:00 min' />
-  <sample time='28:00 min' depth='24.513 m' ndl='10:00 min' cns='15%' />
-  <sample time='29:00 min' depth='24.948 m' />
-  <sample time='30:00 min' depth='24.315 m' ndl='9:00 min' />
-  <sample time='31:00 min' depth='21.305 m' />
-  <sample time='32:00 min' depth='21.582 m' ndl='13:00 min' />
-  <sample time='33:00 min' depth='20.672 m' />
-  <sample time='34:00 min' depth='20.483 m' />
-  <sample time='35:00 min' depth='18.682 m' ndl='21:00 min' />
-  <sample time='36:00 min' depth='18.79 m' />
-  <sample time='37:00 min' depth='18.781 m' ndl='19:00 min' />
-  <sample time='38:00 min' depth='16.563 m' ndl='30:00 min' />
-  <sample time='39:00 min' depth='15.573 m' ndl='35:00 min' />
-  <sample time='40:00 min' depth='15.276 m' ndl='38:00 min' />
-  <sample time='41:00 min' depth='15.078 m' temp='26.4 C' />
-  <sample time='42:00 min' depth='14.316 m' ndl='47:00 min' />
-  <sample time='43:00 min' depth='14.217 m' ndl='49:00 min' />
-  <sample time='44:00 min' depth='14.425 m' ndl='44:00 min' />
-  <sample time='45:00 min' depth='12.266 m' ndl='104:00 min' />
-  <sample time='46:00 min' depth='10.831 m' ndl='233:00 min' />
-  <sample time='47:00 min' depth='11.316 m' ndl='172:00 min' />
-  <sample time='48:00 min' depth='10.217 m' temp='26.6 C' ndl='240:00 min' />
-  <sample time='49:00 min' depth='9.771 m' />
-  <sample time='50:00 min' depth='9.504 m' />
-  <sample time='51:00 min' depth='9.781 m' />
-  <sample time='52:00 min' depth='9.979 m' temp='27.0 C' />
-  <sample time='53:00 min' depth='9.771 m' />
-  <sample time='54:00 min' depth='9.712 m' />
-  <sample time='55:00 min' depth='9.435 m' />
-  <sample time='56:00 min' depth='9.633 m' />
-  <sample time='57:00 min' depth='9.177 m' />
-  <sample time='58:00 min' depth='8.682 m' />
-  <sample time='59:00 min' depth='8.653 m' />
-  <sample time='60:00 min' depth='8.752 m' cns='22%' />
-  <sample time='61:00 min' depth='6.188 m' />
-  <sample time='62:00 min' depth='5.495 m' />
-  <sample time='63:00 min' depth='5.425 m' />
-  <sample time='64:00 min' depth='5.326 m' />
-  <sample time='65:00 min' depth='4.356 m' />
-  <sample time='66:00 min' depth='0.178 m' />
-  <sample time='67:00 min' depth='0.238 m' />
-  <sample time='68:00 min' depth='0.0 m' />
-  <sample time='69:00 min' depth='0.0 m' />
-  <sample time='70:00 min' depth='0.0 m' temp='27.3 C' />
-  <sample time='70:46 min' depth='0.0 m' ndl='0:00 min' cns='0%' />
-  </divecomputer>
-</dive>
 <dive number='1' sac='9.026 l/min' otu='54' cns='17%' date='2017-02-03' time='06:59:41' duration='71:40 min'>
   <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
   <divecomputer model='Suunto Vyper Air' deviceid='f95a40f1' diveid='c51cb31b'>
@@ -416,6 +325,97 @@
   <sample time='71:00 min' depth='3.45 m' pressure='53.81 bar' />
   <sample time='71:20 min' depth='2.96 m' pressure='53.3 bar' />
   <sample time='71:40 min' depth='1.5 m' pressure='53.05 bar' cns='0%' />
+  </divecomputer>
+</dive>
+<dive number='2' otu='40' cns='22%' date='2017-02-03' time='10:24:00' duration='66:00 min'>
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='32.0%' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' o2='31.0%' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
+  <cylinder size='11.094 l' workpressure='206.843 bar' description='AL80' />
+  <divecomputer model='Heinrichs Weikamp OSTC Sport' deviceid='8e8f3f68' diveid='7ab00781'>
+  <depth max='27.44 m' mean='14.427 m' />
+  <temperature water='26.2 C' />
+  <surface pressure='1.009 bar' />
+  <extradata key='Battery at end' value='1.50' />
+  <extradata key='Desat time' value='38:03' />
+  <extradata key='FW Version' value='10.31' />
+  <extradata key='Serial' value='10321' />
+  <extradata key='Deco model' value='ZH-L16-GF' />
+  <extradata key='Deco model info' value='GF 30/80' />
+  <event time='0:02 min' type='25' flags='2' name='gaschange' cylinder='1' o2='32.0%' />
+  <sample time='0:02 min' depth='2.505 m' cns='17%' />
+  <sample time='1:00 min' depth='5.831 m' temp='27.3 C' />
+  <sample time='2:00 min' depth='7.663 m' />
+  <sample time='3:00 min' depth='8.059 m' />
+  <sample time='4:00 min' depth='8.306 m' />
+  <sample time='5:00 min' depth='8.801 m' temp='27.4 C' />
+  <sample time='6:00 min' depth='8.772 m' />
+  <sample time='7:00 min' depth='8.989 m' />
+  <sample time='8:00 min' depth='9.366 m' />
+  <sample time='9:00 min' depth='9.504 m' />
+  <sample time='10:00 min' depth='9.88 m' />
+  <sample time='11:00 min' depth='9.969 m' />
+  <sample time='12:00 min' depth='13.464 m' ndl='124:00 min' />
+  <sample time='13:00 min' depth='16.365 m' temp='26.8 C' ndl='68:00 min' />
+  <sample time='14:00 min' depth='17.315 m' temp='26.5 C' ndl='59:00 min' />
+  <sample time='15:00 min' depth='17.81 m' />
+  <sample time='16:00 min' depth='18.543 m' ndl='48:00 min' />
+  <sample time='17:00 min' depth='23.265 m' ndl='24:00 min' />
+  <sample time='18:00 min' depth='26.928 m' temp='26.2 C' ndl='14:00 min' cns='11%' />
+  <sample time='19:00 min' depth='26.998 m' ndl='13:00 min' />
+  <sample time='20:00 min' depth='26.909 m' />
+  <sample time='21:00 min' depth='26.493 m' />
+  <sample time='22:00 min' depth='24.117 m' />
+  <sample time='23:00 min' depth='23.176 m' ndl='17:00 min' />
+  <sample time='24:00 min' depth='21.671 m' ndl='21:00 min' />
+  <sample time='25:00 min' depth='20.82 m' ndl='23:00 min' />
+  <sample time='26:00 min' depth='24.414 m' />
+  <sample time='27:00 min' depth='23.711 m' ndl='13:00 min' />
+  <sample time='28:00 min' depth='24.513 m' ndl='10:00 min' cns='15%' />
+  <sample time='29:00 min' depth='24.948 m' />
+  <sample time='30:00 min' depth='24.315 m' ndl='9:00 min' />
+  <sample time='31:00 min' depth='21.305 m' />
+  <sample time='32:00 min' depth='21.582 m' ndl='13:00 min' />
+  <sample time='33:00 min' depth='20.672 m' />
+  <sample time='34:00 min' depth='20.483 m' />
+  <sample time='35:00 min' depth='18.682 m' ndl='21:00 min' />
+  <sample time='36:00 min' depth='18.79 m' />
+  <sample time='37:00 min' depth='18.781 m' ndl='19:00 min' />
+  <sample time='38:00 min' depth='16.563 m' ndl='30:00 min' />
+  <sample time='39:00 min' depth='15.573 m' ndl='35:00 min' />
+  <sample time='40:00 min' depth='15.276 m' ndl='38:00 min' />
+  <sample time='41:00 min' depth='15.078 m' temp='26.4 C' />
+  <sample time='42:00 min' depth='14.316 m' ndl='47:00 min' />
+  <sample time='43:00 min' depth='14.217 m' ndl='49:00 min' />
+  <sample time='44:00 min' depth='14.425 m' ndl='44:00 min' />
+  <sample time='45:00 min' depth='12.266 m' ndl='104:00 min' />
+  <sample time='46:00 min' depth='10.831 m' ndl='233:00 min' />
+  <sample time='47:00 min' depth='11.316 m' ndl='172:00 min' />
+  <sample time='48:00 min' depth='10.217 m' temp='26.6 C' ndl='240:00 min' />
+  <sample time='49:00 min' depth='9.771 m' />
+  <sample time='50:00 min' depth='9.504 m' />
+  <sample time='51:00 min' depth='9.781 m' />
+  <sample time='52:00 min' depth='9.979 m' temp='27.0 C' />
+  <sample time='53:00 min' depth='9.771 m' />
+  <sample time='54:00 min' depth='9.712 m' />
+  <sample time='55:00 min' depth='9.435 m' />
+  <sample time='56:00 min' depth='9.633 m' />
+  <sample time='57:00 min' depth='9.177 m' />
+  <sample time='58:00 min' depth='8.682 m' />
+  <sample time='59:00 min' depth='8.653 m' />
+  <sample time='60:00 min' depth='8.752 m' cns='22%' />
+  <sample time='61:00 min' depth='6.188 m' />
+  <sample time='62:00 min' depth='5.495 m' />
+  <sample time='63:00 min' depth='5.425 m' />
+  <sample time='64:00 min' depth='5.326 m' />
+  <sample time='65:00 min' depth='4.356 m' />
+  <sample time='66:00 min' depth='0.178 m' />
+  <sample time='67:00 min' depth='0.238 m' />
+  <sample time='68:00 min' depth='0.0 m' />
+  <sample time='69:00 min' depth='0.0 m' />
+  <sample time='70:00 min' depth='0.0 m' temp='27.3 C' />
+  <sample time='70:46 min' depth='0.0 m' ndl='0:00 min' cns='0%' />
   </divecomputer>
 </dive>
 <dive number='2' sac='9.173 l/min' otu='41' cns='17%' date='2017-02-03' time='10:25:16' duration='65:40 min'>

--- a/dives/test40-42.xml
+++ b/dives/test40-42.xml
@@ -32,745 +32,6 @@
   <sample time='41:00 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='3' date='2014-10-01' time='10:02:00' duration='48:00 min'>
-  <buddy>Tomaz</buddy>
-  <suit>none</suit>
-  <divecomputer model='csv' last-manual-time='48:00 min'>
-  <depth max='13.3 m' mean='11.5 m' />
-  <sample time='0:00 min' depth='0.0 m' />
-  <sample time='1:29 min' depth='13.3 m' />
-  <sample time='39:02 min' depth='13.3 m' />
-  <sample time='40:02 min' depth='4.389 m' />
-  <sample time='47:31 min' depth='4.389 m' />
-  <sample time='48:00 min' depth='0.0 m' />
-  </divecomputer>
-</dive>
-<dive number='4' otu='13' cns='5%' date='2014-10-01' time='14:19:00' duration='34:00 min'>
-  <buddy>Don</buddy>
-  <suit>dry, Whites Fusion</suit>
-  <divecomputer model='csv' last-manual-time='34:00 min'>
-  <depth max='24.9 m' mean='20.1 m' />
-  <sample time='0:00 min' depth='0.0 m' />
-  <sample time='2:46 min' depth='24.9 m' />
-  <sample time='25:35 min' depth='24.9 m' />
-  <sample time='27:26 min' depth='8.217 m' />
-  <sample time='33:05 min' depth='8.217 m' />
-  <sample time='34:00 min' depth='0.0 m' />
-  </divecomputer>
-</dive>
-<dive number='417' otu='138' cns='54%' divesiteid='deadbeef' date='2015-05-23' time='13:23:00' duration='100:00 min'>
-  <notes>{\rtf1\ansi\ansicpg1252\deff0\deflang1035{\fonttbl{\f0\fnil\fcharset0 Microsoft Sans Serif;}}
-\viewkind4\uc1\pard\f0\fs17\par
-}</notes>
-  <cylinder o2='50.0%' he='6.0%' />
-  <cylinder o2='16.0%' he='55.0%' />
-  <cylinder o2='25.0%' he='26.0%' />
-  <cylinder o2='16.0%' he='55.0%' />
-  <cylinder o2='25.0%' he='26.0%' />
-  <cylinder o2='50.0%' he='6.0%' />
-  <cylinder o2='100.0%' />
-  <divetemperature air='11.0 C' water='5.0 C'/>
-  <divecomputer model='OSTC'>
-  <depth max='81.5 m' mean='22.379 m' />
-  <temperature water='5.1 C' />
-  <event time='0:00 min' type='25' value='393266' name='gaschange' cylinder='0' o2='50.0%' he='6.0%' />
-  <event time='10:30 min' type='25' value='3604496' name='gaschange' cylinder='1' o2='16.0%' he='55.0%' />
-  <event time='15:50 min' type='25' value='1703961' name='gaschange' cylinder='2' o2='25.0%' he='26.0%' />
-  <event time='19:20 min' type='25' value='3604496' name='gaschange' cylinder='1' o2='16.0%' he='55.0%' />
-  <event time='40:10 min' type='25' value='1703961' name='gaschange' cylinder='2' o2='25.0%' he='26.0%' />
-  <event time='49:20 min' type='25' value='393266' name='gaschange' cylinder='0' o2='50.0%' he='6.0%' />
-  <event time='72:00 min' type='11' value='100' name='gaschange' cylinder='6' o2='100.0%' />
-  <sample time='0:00 min' depth='2.68 m' temp='11.1 C' ndl='240:00 min' />
-  <sample time='0:10 min' depth='3.46 m' />
-  <sample time='0:20 min' depth='4.17 m' />
-  <sample time='0:30 min' depth='3.74 m' />
-  <sample time='0:40 min' depth='3.44 m' />
-  <sample time='0:50 min' depth='3.9 m' />
-  <sample time='1:00 min' depth='4.57 m' />
-  <sample time='1:10 min' depth='4.84 m' />
-  <sample time='1:20 min' depth='5.78 m' />
-  <sample time='1:30 min' depth='6.5 m' />
-  <sample time='1:40 min' depth='7.19 m' />
-  <sample time='1:50 min' depth='7.66 m' temp='10.2 C' />
-  <sample time='2:00 min' depth='7.73 m' />
-  <sample time='2:10 min' depth='7.9 m' />
-  <sample time='2:20 min' depth='7.8 m' />
-  <sample time='2:30 min' depth='7.68 m' />
-  <sample time='2:40 min' depth='7.31 m' />
-  <sample time='2:50 min' depth='7.35 m' temp='9.6 C' />
-  <sample time='3:00 min' depth='7.59 m' />
-  <sample time='3:10 min' depth='7.84 m' />
-  <sample time='3:20 min' depth='8.08 m' />
-  <sample time='3:30 min' depth='8.24 m' />
-  <sample time='3:40 min' depth='8.44 m' />
-  <sample time='3:50 min' depth='8.51 m' temp='9.2 C' cns='1%' />
-  <sample time='4:00 min' depth='8.71 m' />
-  <sample time='4:10 min' depth='9.23 m' />
-  <sample time='4:20 min' depth='9.57 m' />
-  <sample time='4:30 min' depth='9.95 m' />
-  <sample time='4:40 min' depth='9.96 m' />
-  <sample time='4:50 min' depth='9.92 m' temp='8.9 C' />
-  <sample time='5:00 min' depth='10.0 m' />
-  <sample time='5:10 min' depth='10.35 m' />
-  <sample time='5:20 min' depth='10.43 m' />
-  <sample time='5:30 min' depth='10.57 m' />
-  <sample time='5:40 min' depth='10.76 m' />
-  <sample time='5:50 min' depth='11.45 m' temp='8.6 C' cns='2%' />
-  <sample time='6:00 min' depth='11.7 m' />
-  <sample time='6:10 min' depth='11.84 m' />
-  <sample time='6:20 min' depth='11.95 m' />
-  <sample time='6:30 min' depth='12.47 m' />
-  <sample time='6:40 min' depth='12.66 m' />
-  <sample time='6:50 min' depth='13.01 m' temp='8.2 C' />
-  <sample time='7:00 min' depth='13.09 m' />
-  <sample time='7:10 min' depth='13.52 m' />
-  <sample time='7:20 min' depth='14.08 m' />
-  <sample time='7:30 min' depth='14.32 m' />
-  <sample time='7:40 min' depth='15.0 m' />
-  <sample time='7:50 min' depth='15.15 m' temp='7.7 C' />
-  <sample time='8:00 min' depth='15.7 m' />
-  <sample time='8:10 min' depth='15.47 m' />
-  <sample time='8:20 min' depth='16.18 m' />
-  <sample time='8:30 min' depth='16.61 m' />
-  <sample time='8:40 min' depth='17.09 m' />
-  <sample time='8:50 min' depth='17.75 m' temp='7.0 C' />
-  <sample time='9:00 min' depth='18.21 m' />
-  <sample time='9:10 min' depth='18.65 m' />
-  <sample time='9:20 min' depth='19.03 m' />
-  <sample time='9:30 min' depth='19.31 m' />
-  <sample time='9:40 min' depth='19.88 m' />
-  <sample time='9:50 min' depth='19.84 m' temp='6.6 C' cns='4%' />
-  <sample time='10:00 min' depth='20.19 m' />
-  <sample time='10:10 min' depth='20.63 m' />
-  <sample time='10:20 min' depth='21.17 m' />
-  <sample time='10:30 min' depth='21.48 m' />
-  <sample time='10:40 min' depth='21.66 m' />
-  <sample time='10:50 min' depth='21.87 m' temp='6.3 C' ndl='10:00 min' />
-  <sample time='11:00 min' depth='22.01 m' />
-  <sample time='11:10 min' depth='22.06 m' />
-  <sample time='11:20 min' depth='21.9 m' />
-  <sample time='11:30 min' depth='22.16 m' />
-  <sample time='11:40 min' depth='22.26 m' />
-  <sample time='11:50 min' depth='22.75 m' temp='5.9 C' ndl='9:00 min' />
-  <sample time='12:00 min' depth='22.41 m' />
-  <sample time='12:10 min' depth='22.4 m' />
-  <sample time='12:20 min' depth='22.41 m' />
-  <sample time='12:30 min' depth='22.2 m' />
-  <sample time='12:40 min' depth='22.4 m' />
-  <sample time='12:50 min' depth='22.7 m' temp='5.7 C' ndl='8:00 min' />
-  <sample time='13:00 min' depth='22.93 m' />
-  <sample time='13:10 min' depth='22.56 m' />
-  <sample time='13:20 min' depth='22.69 m' />
-  <sample time='13:30 min' depth='23.0 m' />
-  <sample time='13:40 min' depth='23.7 m' />
-  <sample time='13:50 min' depth='23.51 m' temp='5.6 C' ndl='6:00 min' cns='5%' />
-  <sample time='14:00 min' depth='23.1 m' />
-  <sample time='14:10 min' depth='23.33 m' />
-  <sample time='14:20 min' depth='22.58 m' />
-  <sample time='14:30 min' depth='22.04 m' />
-  <sample time='14:40 min' depth='22.36 m' />
-  <sample time='14:50 min' depth='22.21 m' temp='5.5 C' />
-  <sample time='15:00 min' depth='21.95 m' />
-  <sample time='15:10 min' depth='21.3 m' />
-  <sample time='15:20 min' depth='21.26 m' />
-  <sample time='15:30 min' depth='21.14 m' />
-  <sample time='15:40 min' depth='21.21 m' />
-  <sample time='15:50 min' depth='21.66 m' temp='5.4 C' ndl='18:00 min' />
-  <sample time='16:00 min' depth='22.33 m' />
-  <sample time='16:10 min' depth='22.39 m' />
-  <sample time='16:20 min' depth='22.62 m' />
-  <sample time='16:30 min' depth='22.96 m' />
-  <sample time='16:40 min' depth='23.97 m' />
-  <sample time='16:50 min' depth='24.88 m' temp='5.3 C' ndl='11:00 min' />
-  <sample time='17:00 min' depth='25.78 m' />
-  <sample time='17:10 min' depth='26.66 m' />
-  <sample time='17:20 min' depth='27.43 m' />
-  <sample time='17:30 min' depth='27.81 m' />
-  <sample time='17:40 min' depth='28.32 m' />
-  <sample time='17:50 min' depth='29.01 m' temp='5.2 C' ndl='6:00 min' />
-  <sample time='18:00 min' depth='29.63 m' />
-  <sample time='18:10 min' depth='30.61 m' />
-  <sample time='18:20 min' depth='31.92 m' />
-  <sample time='18:30 min' depth='33.94 m' />
-  <sample time='18:40 min' depth='36.17 m' />
-  <sample time='18:50 min' depth='37.79 m' ndl='3:00 min' />
-  <sample time='19:00 min' depth='38.85 m' />
-  <sample time='19:10 min' depth='39.56 m' />
-  <sample time='19:20 min' depth='40.67 m' />
-  <sample time='19:30 min' depth='41.84 m' />
-  <sample time='19:40 min' depth='42.95 m' />
-  <sample time='19:50 min' depth='44.55 m' ndl='0:00 min' in_deco='1' stoptime='1:00 min' stopdepth='3.0 m' cns='6%' />
-  <sample time='20:00 min' depth='46.24 m' />
-  <sample time='20:10 min' depth='47.53 m' />
-  <sample time='20:20 min' depth='49.53 m' />
-  <sample time='20:30 min' depth='50.56 m' />
-  <sample time='20:40 min' depth='52.49 m' />
-  <sample time='20:50 min' depth='53.64 m' stopdepth='15.0 m' />
-  <sample time='21:00 min' depth='54.95 m' />
-  <sample time='21:10 min' depth='57.28 m' />
-  <sample time='21:20 min' depth='58.94 m' />
-  <sample time='21:30 min' depth='61.03 m' />
-  <sample time='21:40 min' depth='62.84 m' />
-  <sample time='21:50 min' depth='64.2 m' temp='5.3 C' stopdepth='21.0 m' cns='7%' />
-  <sample time='22:00 min' depth='66.32 m' />
-  <sample time='22:10 min' depth='68.55 m' />
-  <sample time='22:20 min' depth='70.44 m' />
-  <sample time='22:30 min' depth='71.79 m' />
-  <sample time='22:40 min' depth='73.4 m' />
-  <sample time='22:50 min' depth='75.13 m' stopdepth='24.0 m' />
-  <sample time='23:00 min' depth='76.46 m' />
-  <sample time='23:10 min' depth='78.25 m' />
-  <sample time='23:20 min' depth='79.35 m' />
-  <sample time='23:30 min' depth='79.4 m' />
-  <sample time='23:40 min' depth='79.48 m' />
-  <sample time='23:50 min' depth='79.57 m' stopdepth='27.0 m' cns='8%' />
-  <sample time='24:00 min' depth='78.89 m' />
-  <sample time='24:10 min' depth='78.34 m' />
-  <sample time='24:20 min' depth='78.09 m' />
-  <sample time='24:30 min' depth='78.2 m' />
-  <sample time='24:40 min' depth='78.39 m' />
-  <sample time='24:50 min' depth='78.66 m' temp='5.2 C' stopdepth='30.0 m' />
-  <sample time='25:00 min' depth='78.75 m' />
-  <sample time='25:10 min' depth='78.92 m' />
-  <sample time='25:20 min' depth='78.73 m' />
-  <sample time='25:30 min' depth='78.29 m' />
-  <sample time='25:40 min' depth='78.04 m' />
-  <sample time='25:50 min' depth='78.15 m' cns='9%' />
-  <sample time='26:00 min' depth='78.49 m' />
-  <sample time='26:10 min' depth='78.46 m' />
-  <sample time='26:20 min' depth='78.21 m' />
-  <sample time='26:30 min' depth='78.15 m' />
-  <sample time='26:40 min' depth='78.27 m' />
-  <sample time='26:50 min' depth='78.07 m' stopdepth='33.0 m' />
-  <sample time='27:00 min' depth='77.94 m' />
-  <sample time='27:10 min' depth='78.03 m' />
-  <sample time='27:20 min' depth='78.24 m' />
-  <sample time='27:30 min' depth='78.26 m' />
-  <sample time='27:40 min' depth='78.34 m' />
-  <sample time='27:50 min' depth='78.28 m' cns='10%' />
-  <sample time='28:00 min' depth='78.34 m' />
-  <sample time='28:10 min' depth='78.44 m' />
-  <sample time='28:20 min' depth='78.35 m' />
-  <sample time='28:30 min' depth='78.45 m' />
-  <sample time='28:40 min' depth='78.18 m' />
-  <sample time='28:50 min' depth='77.78 m' temp='5.1 C' stopdepth='36.0 m' />
-  <sample time='29:00 min' depth='77.78 m' />
-  <sample time='29:10 min' depth='76.76 m' />
-  <sample time='29:20 min' depth='75.75 m' />
-  <sample time='29:30 min' depth='74.95 m' />
-  <sample time='29:40 min' depth='74.33 m' />
-  <sample time='29:50 min' depth='74.1 m' temp='5.2 C' cns='12%' />
-  <sample time='30:00 min' depth='73.76 m' />
-  <sample time='30:10 min' depth='73.1 m' />
-  <sample time='30:20 min' depth='71.91 m' />
-  <sample time='30:30 min' depth='70.79 m' />
-  <sample time='30:40 min' depth='69.68 m' />
-  <sample time='30:50 min' depth='69.23 m' temp='5.3 C' />
-  <sample time='31:00 min' depth='68.51 m' />
-  <sample time='31:10 min' depth='68.6 m' />
-  <sample time='31:20 min' depth='68.43 m' />
-  <sample time='31:30 min' depth='67.49 m' />
-  <sample time='31:40 min' depth='66.86 m' />
-  <sample time='31:50 min' depth='65.99 m' temp='5.4 C' cns='13%' />
-  <sample time='32:00 min' depth='65.48 m' />
-  <sample time='32:10 min' depth='65.02 m' />
-  <sample time='32:20 min' depth='64.73 m' />
-  <sample time='32:30 min' depth='64.54 m' />
-  <sample time='32:40 min' depth='63.49 m' />
-  <sample time='32:50 min' depth='62.18 m' />
-  <sample time='33:00 min' depth='61.19 m' />
-  <sample time='33:10 min' depth='60.9 m' />
-  <sample time='33:20 min' depth='60.05 m' />
-  <sample time='33:30 min' depth='58.42 m' />
-  <sample time='33:40 min' depth='58.14 m' />
-  <sample time='33:50 min' depth='56.7 m' temp='5.5 C' cns='14%' />
-  <sample time='34:00 min' depth='56.22 m' />
-  <sample time='34:10 min' depth='55.46 m' />
-  <sample time='34:20 min' depth='55.09 m' />
-  <sample time='34:30 min' depth='54.36 m' />
-  <sample time='34:40 min' depth='53.51 m' />
-  <sample time='34:50 min' depth='52.79 m' />
-  <sample time='35:00 min' depth='51.86 m' />
-  <sample time='35:10 min' depth='51.22 m' />
-  <sample time='35:20 min' depth='50.37 m' />
-  <sample time='35:30 min' depth='49.57 m' />
-  <sample time='35:40 min' depth='48.71 m' />
-  <sample time='35:50 min' depth='47.76 m' temp='5.6 C' />
-  <sample time='36:00 min' depth='47.4 m' />
-  <sample time='36:10 min' depth='47.14 m' />
-  <sample time='36:20 min' depth='46.89 m' />
-  <sample time='36:30 min' depth='46.17 m' />
-  <sample time='36:40 min' depth='45.25 m' />
-  <sample time='36:50 min' depth='44.97 m' />
-  <sample time='37:00 min' depth='44.06 m' />
-  <sample time='37:10 min' depth='43.26 m' />
-  <sample time='37:20 min' depth='42.15 m' />
-  <sample time='37:30 min' depth='41.4 m' />
-  <sample time='37:40 min' depth='40.29 m' />
-  <sample time='37:50 min' depth='39.63 m' cns='15%' />
-  <sample time='38:00 min' depth='39.01 m' />
-  <sample time='38:10 min' depth='38.03 m' />
-  <sample time='38:20 min' depth='36.79 m' />
-  <sample time='38:30 min' depth='36.08 m' />
-  <sample time='38:40 min' depth='35.56 m' />
-  <sample time='38:50 min' depth='34.84 m' stopdepth='33.0 m' />
-  <sample time='39:00 min' depth='33.65 m' />
-  <sample time='39:10 min' depth='32.74 m' />
-  <sample time='39:20 min' depth='31.82 m' />
-  <sample time='39:30 min' depth='31.77 m' />
-  <sample time='39:40 min' depth='31.52 m' />
-  <sample time='39:50 min' depth='31.04 m' stoptime='2:00 min' stopdepth='30.0 m' />
-  <sample time='40:00 min' depth='30.74 m' />
-  <sample time='40:10 min' depth='30.54 m' />
-  <sample time='40:20 min' depth='30.41 m' />
-  <sample time='40:30 min' depth='30.5 m' />
-  <sample time='40:40 min' depth='29.69 m' />
-  <sample time='40:50 min' depth='29.01 m' stoptime='1:00 min' />
-  <sample time='41:00 min' depth='28.62 m' />
-  <sample time='41:10 min' depth='28.33 m' />
-  <sample time='41:20 min' depth='27.86 m' />
-  <sample time='41:30 min' depth='27.68 m' />
-  <sample time='41:40 min' depth='27.38 m' />
-  <sample time='41:50 min' depth='26.92 m' temp='5.7 C' stopdepth='27.0 m' cns='16%' />
-  <sample time='42:00 min' depth='26.64 m' />
-  <sample time='42:10 min' depth='26.45 m' />
-  <sample time='42:20 min' depth='26.05 m' />
-  <sample time='42:30 min' depth='25.83 m' />
-  <sample time='42:40 min' depth='24.63 m' />
-  <sample time='42:50 min' depth='24.53 m' stopdepth='24.0 m' />
-  <sample time='43:00 min' depth='24.17 m' />
-  <sample time='43:10 min' depth='23.85 m' />
-  <sample time='43:20 min' depth='23.85 m' />
-  <sample time='43:30 min' depth='23.7 m' />
-  <sample time='43:40 min' depth='23.72 m' />
-  <sample time='43:50 min' depth='23.56 m' stoptime='2:00 min' stopdepth='21.0 m' />
-  <sample time='44:00 min' depth='23.41 m' />
-  <sample time='44:10 min' depth='23.14 m' />
-  <sample time='44:20 min' depth='23.04 m' />
-  <sample time='44:30 min' depth='22.78 m' />
-  <sample time='44:40 min' depth='22.37 m' />
-  <sample time='44:50 min' depth='22.51 m' temp='5.8 C' stoptime='1:00 min' />
-  <sample time='45:00 min' depth='22.71 m' />
-  <sample time='45:10 min' depth='22.43 m' />
-  <sample time='45:20 min' depth='22.59 m' />
-  <sample time='45:30 min' depth='22.66 m' />
-  <sample time='45:40 min' depth='22.69 m' />
-  <sample time='45:50 min' depth='22.52 m' cns='17%' />
-  <sample time='46:00 min' depth='22.43 m' />
-  <sample time='46:10 min' depth='22.68 m' />
-  <sample time='46:20 min' depth='22.5 m' />
-  <sample time='46:30 min' depth='22.13 m' />
-  <sample time='46:40 min' depth='22.17 m' />
-  <sample time='46:50 min' depth='21.97 m' stoptime='2:00 min' stopdepth='18.0 m' />
-  <sample time='47:00 min' depth='21.84 m' />
-  <sample time='47:10 min' depth='21.85 m' />
-  <sample time='47:20 min' depth='21.67 m' />
-  <sample time='47:30 min' depth='21.49 m' />
-  <sample time='47:40 min' depth='21.48 m' />
-  <sample time='47:50 min' depth='21.46 m' stoptime='1:00 min' />
-  <sample time='48:00 min' depth='21.19 m' />
-  <sample time='48:10 min' depth='20.98 m' />
-  <sample time='48:20 min' depth='20.88 m' />
-  <sample time='48:30 min' depth='20.76 m' />
-  <sample time='48:40 min' depth='20.81 m' />
-  <sample time='48:50 min' depth='20.74 m' />
-  <sample time='49:00 min' depth='20.5 m' />
-  <sample time='49:10 min' depth='20.48 m' />
-  <sample time='49:20 min' depth='20.42 m' />
-  <sample time='49:30 min' depth='20.25 m' />
-  <sample time='49:40 min' depth='20.55 m' />
-  <sample time='49:50 min' depth='20.82 m' stoptime='3:00 min' stopdepth='15.0 m' cns='18%' />
-  <sample time='50:00 min' depth='20.76 m' />
-  <sample time='50:10 min' depth='20.66 m' />
-  <sample time='50:20 min' depth='20.64 m' />
-  <sample time='50:30 min' depth='20.22 m' />
-  <sample time='50:40 min' depth='20.56 m' />
-  <sample time='50:50 min' depth='20.5 m' stoptime='2:00 min' />
-  <sample time='51:00 min' depth='20.27 m' />
-  <sample time='51:10 min' depth='20.12 m' />
-  <sample time='51:20 min' depth='20.2 m' />
-  <sample time='51:30 min' depth='20.27 m' />
-  <sample time='51:40 min' depth='20.22 m' />
-  <sample time='51:50 min' depth='20.64 m' temp='5.7 C' stoptime='1:00 min' cns='19%' />
-  <sample time='52:00 min' depth='20.75 m' />
-  <sample time='52:10 min' depth='20.5 m' />
-  <sample time='52:20 min' depth='20.31 m' />
-  <sample time='52:30 min' depth='20.08 m' />
-  <sample time='52:40 min' depth='19.85 m' />
-  <sample time='52:50 min' depth='19.54 m' stoptime='5:00 min' stopdepth='12.0 m' />
-  <sample time='53:00 min' depth='18.96 m' />
-  <sample time='53:10 min' depth='18.89 m' />
-  <sample time='53:20 min' depth='18.66 m' />
-  <sample time='53:30 min' depth='17.98 m' />
-  <sample time='53:40 min' depth='17.9 m' />
-  <sample time='53:50 min' depth='17.35 m' temp='5.8 C' stoptime='4:00 min' cns='21%' />
-  <sample time='54:00 min' depth='17.29 m' />
-  <sample time='54:10 min' depth='16.96 m' />
-  <sample time='54:20 min' depth='15.98 m' />
-  <sample time='54:30 min' depth='15.97 m' />
-  <sample time='54:40 min' depth='15.57 m' />
-  <sample time='54:50 min' depth='15.9 m' stoptime='3:00 min' />
-  <sample time='55:00 min' depth='16.09 m' />
-  <sample time='55:10 min' depth='15.59 m' />
-  <sample time='55:20 min' depth='15.54 m' />
-  <sample time='55:30 min' depth='14.99 m' />
-  <sample time='55:40 min' depth='14.76 m' />
-  <sample time='55:50 min' depth='14.54 m' temp='5.9 C' stoptime='2:00 min' cns='22%' />
-  <sample time='56:00 min' depth='13.85 m' />
-  <sample time='56:10 min' depth='13.54 m' />
-  <sample time='56:20 min' depth='13.36 m' />
-  <sample time='56:30 min' depth='13.5 m' />
-  <sample time='56:40 min' depth='13.52 m' />
-  <sample time='56:50 min' depth='13.17 m' temp='6.0 C' stoptime='1:00 min' />
-  <sample time='57:00 min' depth='12.59 m' />
-  <sample time='57:10 min' depth='12.59 m' />
-  <sample time='57:20 min' depth='12.25 m' />
-  <sample time='57:30 min' depth='12.35 m' />
-  <sample time='57:40 min' depth='12.58 m' />
-  <sample time='57:50 min' depth='12.91 m' temp='6.2 C' stoptime='8:00 min' stopdepth='9.0 m' cns='23%' />
-  <sample time='58:00 min' depth='12.96 m' />
-  <sample time='58:10 min' depth='12.64 m' />
-  <sample time='58:20 min' depth='12.76 m' />
-  <sample time='58:30 min' depth='12.73 m' />
-  <sample time='58:40 min' depth='12.59 m' />
-  <sample time='58:50 min' depth='12.2 m' temp='6.4 C' stoptime='7:00 min' />
-  <sample time='59:00 min' depth='12.05 m' />
-  <sample time='59:10 min' depth='11.82 m' />
-  <sample time='59:20 min' depth='11.48 m' />
-  <sample time='59:30 min' depth='11.65 m' />
-  <sample time='59:40 min' depth='11.42 m' />
-  <sample time='59:50 min' depth='11.57 m' temp='6.6 C' stoptime='6:00 min' cns='24%' />
-  <sample time='60:00 min' depth='11.47 m' />
-  <sample time='60:10 min' depth='11.14 m' />
-  <sample time='60:20 min' depth='10.78 m' />
-  <sample time='60:30 min' depth='10.56 m' />
-  <sample time='60:40 min' depth='10.3 m' />
-  <sample time='60:50 min' depth='10.33 m' temp='6.7 C' stoptime='5:00 min' />
-  <sample time='61:00 min' depth='10.45 m' />
-  <sample time='61:10 min' depth='10.19 m' />
-  <sample time='61:20 min' depth='9.95 m' />
-  <sample time='61:30 min' depth='9.8 m' />
-  <sample time='61:40 min' depth='9.75 m' />
-  <sample time='61:50 min' depth='9.49 m' temp='6.9 C' stoptime='4:00 min' />
-  <sample time='62:00 min' depth='9.61 m' />
-  <sample time='62:10 min' depth='9.44 m' />
-  <sample time='62:20 min' depth='9.3 m' />
-  <sample time='62:30 min' depth='9.12 m' />
-  <sample time='62:40 min' depth='9.34 m' />
-  <sample time='62:50 min' depth='9.46 m' temp='7.0 C' stoptime='3:00 min' />
-  <sample time='63:00 min' depth='9.63 m' />
-  <sample time='63:10 min' depth='9.6 m' />
-  <sample time='63:20 min' depth='9.55 m' />
-  <sample time='63:30 min' depth='9.51 m' />
-  <sample time='63:40 min' depth='9.45 m' />
-  <sample time='63:50 min' depth='9.42 m' temp='7.1 C' stoptime='2:00 min' cns='25%' />
-  <sample time='64:00 min' depth='9.46 m' />
-  <sample time='64:10 min' depth='9.51 m' />
-  <sample time='64:20 min' depth='9.52 m' />
-  <sample time='64:30 min' depth='9.75 m' />
-  <sample time='64:40 min' depth='9.62 m' />
-  <sample time='64:50 min' depth='9.84 m' stoptime='1:00 min' />
-  <sample time='65:00 min' depth='9.64 m' />
-  <sample time='65:10 min' depth='9.48 m' />
-  <sample time='65:20 min' depth='9.48 m' />
-  <sample time='65:30 min' depth='9.37 m' />
-  <sample time='65:40 min' depth='8.93 m' />
-  <sample time='65:50 min' depth='8.88 m' stoptime='9:00 min' stopdepth='6.0 m' cns='26%' />
-  <sample time='66:00 min' depth='8.69 m' />
-  <sample time='66:10 min' depth='8.74 m' />
-  <sample time='66:20 min' depth='8.65 m' />
-  <sample time='66:30 min' depth='8.33 m' />
-  <sample time='66:40 min' depth='7.98 m' />
-  <sample time='66:50 min' depth='7.87 m' temp='7.2 C' stoptime='8:00 min' />
-  <sample time='67:00 min' depth='7.63 m' />
-  <sample time='67:10 min' depth='7.88 m' />
-  <sample time='67:20 min' depth='7.78 m' />
-  <sample time='67:30 min' depth='7.39 m' />
-  <sample time='67:40 min' depth='7.3 m' />
-  <sample time='67:50 min' depth='7.33 m' temp='7.3 C' stoptime='7:00 min' />
-  <sample time='68:00 min' depth='7.16 m' />
-  <sample time='68:10 min' depth='7.18 m' />
-  <sample time='68:20 min' depth='7.37 m' />
-  <sample time='68:30 min' depth='7.22 m' />
-  <sample time='68:40 min' depth='7.54 m' />
-  <sample time='68:50 min' depth='7.23 m' temp='7.4 C' />
-  <sample time='69:00 min' depth='7.24 m' />
-  <sample time='69:10 min' depth='7.26 m' />
-  <sample time='69:20 min' depth='7.06 m' />
-  <sample time='69:30 min' depth='7.3 m' />
-  <sample time='69:40 min' depth='6.95 m' />
-  <sample time='69:50 min' depth='7.2 m' temp='7.5 C' stoptime='6:00 min' cns='27%' />
-  <sample time='70:00 min' depth='6.79 m' />
-  <sample time='70:10 min' depth='6.54 m' />
-  <sample time='70:20 min' depth='6.77 m' />
-  <sample time='70:30 min' depth='6.34 m' />
-  <sample time='70:40 min' depth='6.39 m' />
-  <sample time='70:50 min' depth='6.26 m' temp='7.6 C' stoptime='5:00 min' />
-  <sample time='71:00 min' depth='6.28 m' />
-  <sample time='71:10 min' depth='6.27 m' />
-  <sample time='71:20 min' depth='6.29 m' />
-  <sample time='71:30 min' depth='5.92 m' />
-  <sample time='71:40 min' depth='5.7 m' />
-  <sample time='71:50 min' depth='5.84 m' temp='7.8 C' />
-  <sample time='72:00 min' depth='5.89 m' />
-  <sample time='72:10 min' depth='6.07 m' />
-  <sample time='72:20 min' depth='5.76 m' />
-  <sample time='72:30 min' depth='5.77 m' />
-  <sample time='72:40 min' depth='5.83 m' />
-  <sample time='72:50 min' depth='5.87 m' temp='7.9 C' stoptime='4:00 min' />
-  <sample time='73:00 min' depth='5.88 m' />
-  <sample time='73:10 min' depth='5.84 m' />
-  <sample time='73:20 min' depth='5.73 m' />
-  <sample time='73:30 min' depth='5.8 m' />
-  <sample time='73:40 min' depth='5.68 m' />
-  <sample time='73:50 min' depth='6.02 m' stoptime='3:00 min' cns='30%' />
-  <sample time='74:00 min' depth='5.84 m' />
-  <sample time='74:10 min' depth='5.84 m' />
-  <sample time='74:20 min' depth='6.13 m' />
-  <sample time='74:30 min' depth='5.99 m' />
-  <sample time='74:40 min' depth='5.99 m' />
-  <sample time='74:50 min' depth='5.94 m' temp='8.0 C' stoptime='2:00 min' />
-  <sample time='75:00 min' depth='5.95 m' />
-  <sample time='75:10 min' depth='6.11 m' />
-  <sample time='75:20 min' depth='6.16 m' />
-  <sample time='75:30 min' depth='6.12 m' />
-  <sample time='75:40 min' depth='6.21 m' />
-  <sample time='75:50 min' depth='6.4 m' temp='8.1 C' stoptime='1:00 min' cns='33%' />
-  <sample time='76:00 min' depth='5.83 m' />
-  <sample time='76:10 min' depth='5.74 m' />
-  <sample time='76:20 min' depth='6.0 m' />
-  <sample time='76:30 min' depth='5.96 m' />
-  <sample time='76:40 min' depth='6.17 m' />
-  <sample time='76:50 min' depth='5.99 m' temp='8.2 C' stoptime='16:00 min' stopdepth='3.0 m' />
-  <sample time='77:00 min' depth='6.0 m' />
-  <sample time='77:10 min' depth='6.17 m' />
-  <sample time='77:20 min' depth='5.92 m' />
-  <sample time='77:30 min' depth='5.77 m' />
-  <sample time='77:40 min' depth='5.75 m' />
-  <sample time='77:50 min' depth='5.52 m' stoptime='15:00 min' cns='36%' />
-  <sample time='78:00 min' depth='5.19 m' />
-  <sample time='78:10 min' depth='5.23 m' />
-  <sample time='78:20 min' depth='5.14 m' />
-  <sample time='78:30 min' depth='4.86 m' />
-  <sample time='78:40 min' depth='4.98 m' />
-  <sample time='78:50 min' depth='4.9 m' stoptime='14:00 min' />
-  <sample time='79:00 min' depth='4.68 m' />
-  <sample time='79:10 min' depth='4.59 m' />
-  <sample time='79:20 min' depth='4.51 m' />
-  <sample time='79:30 min' depth='4.61 m' />
-  <sample time='79:40 min' depth='4.73 m' />
-  <sample time='79:50 min' depth='4.63 m' temp='8.3 C' stoptime='13:00 min' cns='37%' />
-  <sample time='80:00 min' depth='4.68 m' />
-  <sample time='80:10 min' depth='4.63 m' />
-  <sample time='80:20 min' depth='4.49 m' />
-  <sample time='80:30 min' depth='4.44 m' />
-  <sample time='80:40 min' depth='4.43 m' />
-  <sample time='80:50 min' depth='4.53 m' temp='8.5 C' stoptime='12:00 min' />
-  <sample time='81:00 min' depth='4.69 m' />
-  <sample time='81:10 min' depth='4.55 m' />
-  <sample time='81:20 min' depth='4.6 m' />
-  <sample time='81:30 min' depth='4.48 m' />
-  <sample time='81:40 min' depth='4.52 m' />
-  <sample time='81:50 min' depth='4.35 m' stoptime='11:00 min' cns='39%' />
-  <sample time='82:00 min' depth='4.39 m' />
-  <sample time='82:10 min' depth='4.15 m' />
-  <sample time='82:20 min' depth='4.12 m' />
-  <sample time='82:30 min' depth='4.03 m' />
-  <sample time='82:40 min' depth='3.72 m' />
-  <sample time='82:50 min' depth='3.58 m' temp='8.6 C' stoptime='10:00 min' />
-  <sample time='83:00 min' depth='3.7 m' />
-  <sample time='83:10 min' depth='3.8 m' />
-  <sample time='83:20 min' depth='3.42 m' />
-  <sample time='83:30 min' depth='3.31 m' />
-  <sample time='83:40 min' depth='3.44 m' />
-  <sample time='83:50 min' depth='3.79 m' temp='8.7 C' stoptime='9:00 min' cns='40%' />
-  <sample time='84:00 min' depth='3.89 m' />
-  <sample time='84:10 min' depth='3.82 m' />
-  <sample time='84:20 min' depth='3.62 m' />
-  <sample time='84:30 min' depth='3.7 m' />
-  <sample time='84:40 min' depth='3.48 m' />
-  <sample time='84:50 min' depth='3.51 m' temp='8.8 C' stoptime='8:00 min' />
-  <sample time='85:00 min' depth='3.68 m' />
-  <sample time='85:10 min' depth='3.52 m' />
-  <sample time='85:20 min' depth='3.98 m' />
-  <sample time='85:30 min' depth='3.83 m' />
-  <sample time='85:40 min' depth='3.42 m' />
-  <sample time='85:50 min' depth='3.33 m' stoptime='7:00 min' cns='41%' />
-  <sample time='86:00 min' depth='3.49 m' />
-  <sample time='86:10 min' depth='3.36 m' />
-  <sample time='86:20 min' depth='3.54 m' />
-  <sample time='86:30 min' depth='3.58 m' />
-  <sample time='86:40 min' depth='3.42 m' />
-  <sample time='86:50 min' depth='3.94 m' temp='8.9 C' stoptime='6:00 min' />
-  <sample time='87:00 min' depth='4.09 m' />
-  <sample time='87:10 min' depth='4.14 m' />
-  <sample time='87:20 min' depth='4.01 m' />
-  <sample time='87:30 min' depth='4.06 m' />
-  <sample time='87:40 min' depth='4.28 m' />
-  <sample time='87:50 min' depth='4.27 m' stoptime='5:00 min' cns='42%' />
-  <sample time='88:00 min' depth='4.05 m' />
-  <sample time='88:10 min' depth='4.22 m' />
-  <sample time='88:20 min' depth='4.39 m' />
-  <sample time='88:30 min' depth='4.13 m' />
-  <sample time='88:40 min' depth='4.31 m' />
-  <sample time='88:50 min' depth='4.41 m' stoptime='4:00 min' />
-  <sample time='89:00 min' depth='4.22 m' />
-  <sample time='89:10 min' depth='3.98 m' />
-  <sample time='89:20 min' depth='4.06 m' />
-  <sample time='89:30 min' depth='4.32 m' />
-  <sample time='89:40 min' depth='4.55 m' />
-  <sample time='89:50 min' depth='4.67 m' stoptime='3:00 min' cns='44%' />
-  <sample time='90:00 min' depth='4.68 m' />
-  <sample time='90:10 min' depth='4.83 m' />
-  <sample time='90:20 min' depth='4.84 m' />
-  <sample time='90:30 min' depth='5.05 m' />
-  <sample time='90:40 min' depth='5.52 m' />
-  <sample time='90:50 min' depth='5.33 m' stoptime='2:00 min' />
-  <sample time='91:00 min' depth='5.09 m' />
-  <sample time='91:10 min' depth='4.81 m' />
-  <sample time='91:20 min' depth='4.69 m' />
-  <sample time='91:30 min' depth='4.52 m' />
-  <sample time='91:40 min' depth='4.48 m' />
-  <sample time='91:50 min' depth='4.55 m' stoptime='1:00 min' cns='45%' />
-  <sample time='92:00 min' depth='4.66 m' />
-  <sample time='92:10 min' depth='4.66 m' />
-  <sample time='92:20 min' depth='4.72 m' />
-  <sample time='92:30 min' depth='4.68 m' />
-  <sample time='92:40 min' depth='4.76 m' />
-  <sample time='92:50 min' depth='4.84 m' temp='9.0 C' ndl='240:00 min' in_deco='0' stoptime='0:00 min' stopdepth='0.0 m' />
-  <sample time='93:00 min' depth='4.87 m' />
-  <sample time='93:10 min' depth='4.99 m' />
-  <sample time='93:20 min' depth='5.08 m' />
-  <sample time='93:30 min' depth='4.91 m' />
-  <sample time='93:40 min' depth='5.04 m' />
-  <sample time='93:50 min' depth='4.97 m' cns='47%' />
-  <sample time='94:00 min' depth='5.16 m' />
-  <sample time='94:10 min' depth='4.91 m' />
-  <sample time='94:20 min' depth='4.92 m' />
-  <sample time='94:30 min' depth='4.81 m' />
-  <sample time='94:40 min' depth='4.68 m' />
-  <sample time='94:50 min' depth='5.18 m' />
-  <sample time='95:00 min' depth='5.21 m' />
-  <sample time='95:10 min' depth='4.65 m' />
-  <sample time='95:20 min' depth='4.14 m' />
-  <sample time='95:30 min' depth='3.99 m' />
-  <sample time='95:40 min' depth='3.8 m' />
-  <sample time='95:50 min' depth='3.5 m' temp='9.1 C' cns='48%' />
-  <sample time='96:00 min' depth='3.37 m' />
-  <sample time='96:10 min' depth='3.39 m' />
-  <sample time='96:20 min' depth='2.94 m' />
-  <sample time='96:30 min' depth='2.82 m' />
-  <sample time='96:40 min' depth='2.8 m' />
-  <sample time='96:50 min' depth='2.71 m' />
-  <sample time='97:00 min' depth='2.13 m' />
-  <sample time='97:10 min' depth='1.8 m' />
-  <sample time='97:20 min' depth='1.99 m' />
-  <sample time='97:30 min' depth='1.88 m' />
-  <sample time='97:40 min' depth='1.18 m' />
-  <sample time='97:50 min' depth='1.47 m' temp='9.2 C' cns='49%' />
-  <sample time='98:00 min' depth='1.12 m' />
-  <sample time='98:10 min' depth='1.17 m' />
-  <sample time='98:20 min' depth='1.04 m' />
-  <sample time='98:30 min' depth='0.85 m' />
-  <sample time='98:40 min' depth='0.48 m' />
-  <sample time='98:50 min' depth='0.0 m' temp='9.4 C' />
-  <sample time='99:00 min' depth='0.0 m' />
-  <sample time='99:10 min' depth='0.03 m' />
-  <sample time='99:20 min' depth='0.0 m' />
-  <sample time='99:30 min' depth='0.0 m' />
-  <sample time='99:40 min' depth='0.0 m' />
-  <sample time='99:50 min' depth='0.0 m' temp='10.0 C' cns='50%' />
-  <sample time='100:00 min' depth='0.0 m' />
-  <sample time='100:10 min' depth='0.0 m' />
-  <sample time='100:20 min' depth='0.0 m' />
-  <sample time='100:30 min' depth='0.0 m' />
-  <sample time='100:40 min' depth='0.0 m' />
-  <sample time='100:50 min' depth='0.0 m' temp='10.2 C' />
-  <sample time='101:00 min' depth='0.0 m' />
-  <sample time='101:10 min' depth='0.0 m' />
-  <sample time='101:20 min' depth='0.0 m' />
-  <sample time='101:30 min' depth='0.0 m' />
-  <sample time='101:40 min' depth='0.0 m' />
-  <sample time='101:50 min' depth='0.0 m' temp='10.4 C' />
-  <sample time='102:00 min' depth='0.0 m' />
-  <sample time='102:10 min' depth='0.06 m' />
-  <sample time='102:20 min' depth='0.01 m' />
-  <sample time='102:30 min' depth='0.02 m' />
-  <sample time='102:40 min' depth='0.0 m' />
-  <sample time='102:50 min' depth='0.1 m' temp='10.6 C' />
-  <sample time='103:00 min' depth='0.17 m' />
-  <sample time='103:10 min' depth='0.02 m' />
-  <sample time='103:20 min' depth='0.09 m' />
-  <sample time='103:30 min' depth='0.02 m' />
-  <sample time='103:40 min' depth='0.4 m' />
-  <sample time='103:50 min' depth='0.22 m' temp='10.8 C' cns='51%' />
-  <sample time='104:00 min' depth='0.02 m' />
-  <sample time='104:10 min' depth='0.01 m' />
-  <sample time='104:20 min' depth='0.02 m' />
-  <sample time='104:30 min' depth='0.0 m' />
-  <sample time='104:40 min' depth='0.27 m' />
-  <sample time='104:50 min' depth='0.27 m' />
-  <sample time='105:00 min' depth='0.09 m' />
-  <sample time='105:10 min' depth='0.01 m' />
-  <sample time='105:20 min' depth='1.13 m' />
-  <sample time='105:30 min' depth='1.18 m' />
-  <sample time='105:40 min' depth='0.85 m' />
-  <sample time='105:50 min' depth='0.24 m' cns='52%' />
-  <sample time='106:00 min' depth='1.02 m' />
-  <sample time='106:10 min' depth='0.99 m' />
-  <sample time='106:20 min' depth='0.85 m' />
-  <sample time='106:30 min' depth='0.0 m' />
-  <sample time='106:40 min' depth='0.0 m' />
-  <sample time='106:50 min' depth='0.01 m' />
-  <sample time='107:00 min' depth='0.0 m' />
-  <sample time='107:10 min' depth='0.0 m' />
-  <sample time='107:20 min' depth='0.0 m' />
-  <sample time='107:30 min' depth='0.0 m' />
-  <sample time='107:40 min' depth='0.0 m' />
-  <sample time='107:50 min' depth='0.0 m' />
-  <sample time='108:00 min' depth='0.0 m' />
-  <sample time='108:10 min' depth='0.0 m' />
-  <sample time='108:20 min' depth='0.0 m' />
-  <sample time='108:30 min' depth='0.0 m' />
-  <sample time='108:40 min' depth='0.0 m' />
-  <sample time='108:50 min' depth='0.0 m' />
-  <sample time='109:00 min' depth='0.0 m' />
-  <sample time='109:10 min' depth='0.0 m' />
-  <sample time='109:20 min' depth='0.0 m' />
-  <sample time='109:30 min' depth='0.0 m' />
-  <sample time='109:40 min' depth='0.0 m' />
-  <sample time='109:50 min' depth='0.0 m' cns='53%' />
-  <sample time='110:00 min' depth='0.0 m' />
-  <sample time='110:10 min' depth='0.0 m' />
-  <sample time='110:20 min' depth='0.0 m' />
-  <sample time='110:30 min' depth='0.0 m' />
-  <sample time='110:40 min' depth='0.0 m' />
-  <sample time='110:50 min' depth='0.0 m' temp='10.9 C' />
-  <sample time='111:00 min' depth='0.0 m' />
-  <sample time='111:10 min' depth='0.0 m' />
-  <sample time='111:20 min' depth='0.0 m' />
-  <sample time='111:30 min' depth='0.0 m' />
-  <sample time='111:40 min' depth='0.0 m' />
-  <sample time='111:50 min' depth='0.0 m' temp='11.0 C' cns='54%' />
-  <sample time='112:00 min' depth='0.0 m' />
-  <sample time='112:10 min' depth='0.0 m' />
-  <sample time='112:20 min' depth='0.0 m' />
-  <sample time='112:30 min' depth='0.0 m' />
-  <sample time='112:40 min' depth='0.0 m' />
-  <sample time='112:50 min' depth='0.0 m' temp='11.1 C' />
-  <sample time='113:00 min' depth='0.0 m' />
-  <sample time='113:10 min' depth='0.0 m' />
-  <sample time='113:20 min' depth='0.0 m' />
-  <sample time='113:30 min' depth='0.0 m' />
-  <sample time='113:40 min' depth='0.0 m' />
-  <sample time='113:50 min' depth='0.0 m' />
-  <sample time='114:00 min' depth='0.0 m' />
-  <sample time='114:10 min' depth='0.0 m' />
-  <sample time='114:20 min' depth='0.0 m' />
-  <sample time='114:30 min' depth='0.0 m' />
-  <sample time='114:40 min' depth='0.0 m' />
-  </divecomputer>
-</dive>
 <dive number='1' otu='97' cns='34%' date='2014-04-01' time='10:00:00' duration='77:54 min'>
   <notes>CCR dive</notes>
   <cylinder size='2.0 l' workpressure='232.0 bar' description='Oxy2' o2='100.0%' start='190.0 bar' end='130.0 bar' use='oxygen' />
@@ -5763,6 +5024,745 @@
   <sample time='82:46 min' depth='0.224 m' />
   <sample time='82:48 min' depth='0.245 m' temp='9.7 C' />
   <sample time='82:50 min' depth='0.235 m' ndl='0:00 min' stoptime='0:00 min' cns='0%' po2='0.0 bar' />
+  </divecomputer>
+</dive>
+<dive number='3' date='2014-10-01' time='10:02:00' duration='48:00 min'>
+  <buddy>Tomaz</buddy>
+  <suit>none</suit>
+  <divecomputer model='csv' last-manual-time='48:00 min'>
+  <depth max='13.3 m' mean='11.5 m' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='1:29 min' depth='13.3 m' />
+  <sample time='39:02 min' depth='13.3 m' />
+  <sample time='40:02 min' depth='4.389 m' />
+  <sample time='47:31 min' depth='4.389 m' />
+  <sample time='48:00 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='4' otu='13' cns='5%' date='2014-10-01' time='14:19:00' duration='34:00 min'>
+  <buddy>Don</buddy>
+  <suit>dry, Whites Fusion</suit>
+  <divecomputer model='csv' last-manual-time='34:00 min'>
+  <depth max='24.9 m' mean='20.1 m' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='2:46 min' depth='24.9 m' />
+  <sample time='25:35 min' depth='24.9 m' />
+  <sample time='27:26 min' depth='8.217 m' />
+  <sample time='33:05 min' depth='8.217 m' />
+  <sample time='34:00 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='417' otu='138' cns='54%' divesiteid='deadbeef' date='2015-05-23' time='13:23:00' duration='100:00 min'>
+  <notes>{\rtf1\ansi\ansicpg1252\deff0\deflang1035{\fonttbl{\f0\fnil\fcharset0 Microsoft Sans Serif;}}
+\viewkind4\uc1\pard\f0\fs17\par
+}</notes>
+  <cylinder o2='50.0%' he='6.0%' />
+  <cylinder o2='16.0%' he='55.0%' />
+  <cylinder o2='25.0%' he='26.0%' />
+  <cylinder o2='16.0%' he='55.0%' />
+  <cylinder o2='25.0%' he='26.0%' />
+  <cylinder o2='50.0%' he='6.0%' />
+  <cylinder o2='100.0%' />
+  <divetemperature air='11.0 C' water='5.0 C'/>
+  <divecomputer model='OSTC'>
+  <depth max='81.5 m' mean='22.379 m' />
+  <temperature water='5.1 C' />
+  <event time='0:00 min' type='25' value='393266' name='gaschange' cylinder='0' o2='50.0%' he='6.0%' />
+  <event time='10:30 min' type='25' value='3604496' name='gaschange' cylinder='1' o2='16.0%' he='55.0%' />
+  <event time='15:50 min' type='25' value='1703961' name='gaschange' cylinder='2' o2='25.0%' he='26.0%' />
+  <event time='19:20 min' type='25' value='3604496' name='gaschange' cylinder='1' o2='16.0%' he='55.0%' />
+  <event time='40:10 min' type='25' value='1703961' name='gaschange' cylinder='2' o2='25.0%' he='26.0%' />
+  <event time='49:20 min' type='25' value='393266' name='gaschange' cylinder='0' o2='50.0%' he='6.0%' />
+  <event time='72:00 min' type='11' value='100' name='gaschange' cylinder='6' o2='100.0%' />
+  <sample time='0:00 min' depth='2.68 m' temp='11.1 C' ndl='240:00 min' />
+  <sample time='0:10 min' depth='3.46 m' />
+  <sample time='0:20 min' depth='4.17 m' />
+  <sample time='0:30 min' depth='3.74 m' />
+  <sample time='0:40 min' depth='3.44 m' />
+  <sample time='0:50 min' depth='3.9 m' />
+  <sample time='1:00 min' depth='4.57 m' />
+  <sample time='1:10 min' depth='4.84 m' />
+  <sample time='1:20 min' depth='5.78 m' />
+  <sample time='1:30 min' depth='6.5 m' />
+  <sample time='1:40 min' depth='7.19 m' />
+  <sample time='1:50 min' depth='7.66 m' temp='10.2 C' />
+  <sample time='2:00 min' depth='7.73 m' />
+  <sample time='2:10 min' depth='7.9 m' />
+  <sample time='2:20 min' depth='7.8 m' />
+  <sample time='2:30 min' depth='7.68 m' />
+  <sample time='2:40 min' depth='7.31 m' />
+  <sample time='2:50 min' depth='7.35 m' temp='9.6 C' />
+  <sample time='3:00 min' depth='7.59 m' />
+  <sample time='3:10 min' depth='7.84 m' />
+  <sample time='3:20 min' depth='8.08 m' />
+  <sample time='3:30 min' depth='8.24 m' />
+  <sample time='3:40 min' depth='8.44 m' />
+  <sample time='3:50 min' depth='8.51 m' temp='9.2 C' cns='1%' />
+  <sample time='4:00 min' depth='8.71 m' />
+  <sample time='4:10 min' depth='9.23 m' />
+  <sample time='4:20 min' depth='9.57 m' />
+  <sample time='4:30 min' depth='9.95 m' />
+  <sample time='4:40 min' depth='9.96 m' />
+  <sample time='4:50 min' depth='9.92 m' temp='8.9 C' />
+  <sample time='5:00 min' depth='10.0 m' />
+  <sample time='5:10 min' depth='10.35 m' />
+  <sample time='5:20 min' depth='10.43 m' />
+  <sample time='5:30 min' depth='10.57 m' />
+  <sample time='5:40 min' depth='10.76 m' />
+  <sample time='5:50 min' depth='11.45 m' temp='8.6 C' cns='2%' />
+  <sample time='6:00 min' depth='11.7 m' />
+  <sample time='6:10 min' depth='11.84 m' />
+  <sample time='6:20 min' depth='11.95 m' />
+  <sample time='6:30 min' depth='12.47 m' />
+  <sample time='6:40 min' depth='12.66 m' />
+  <sample time='6:50 min' depth='13.01 m' temp='8.2 C' />
+  <sample time='7:00 min' depth='13.09 m' />
+  <sample time='7:10 min' depth='13.52 m' />
+  <sample time='7:20 min' depth='14.08 m' />
+  <sample time='7:30 min' depth='14.32 m' />
+  <sample time='7:40 min' depth='15.0 m' />
+  <sample time='7:50 min' depth='15.15 m' temp='7.7 C' />
+  <sample time='8:00 min' depth='15.7 m' />
+  <sample time='8:10 min' depth='15.47 m' />
+  <sample time='8:20 min' depth='16.18 m' />
+  <sample time='8:30 min' depth='16.61 m' />
+  <sample time='8:40 min' depth='17.09 m' />
+  <sample time='8:50 min' depth='17.75 m' temp='7.0 C' />
+  <sample time='9:00 min' depth='18.21 m' />
+  <sample time='9:10 min' depth='18.65 m' />
+  <sample time='9:20 min' depth='19.03 m' />
+  <sample time='9:30 min' depth='19.31 m' />
+  <sample time='9:40 min' depth='19.88 m' />
+  <sample time='9:50 min' depth='19.84 m' temp='6.6 C' cns='4%' />
+  <sample time='10:00 min' depth='20.19 m' />
+  <sample time='10:10 min' depth='20.63 m' />
+  <sample time='10:20 min' depth='21.17 m' />
+  <sample time='10:30 min' depth='21.48 m' />
+  <sample time='10:40 min' depth='21.66 m' />
+  <sample time='10:50 min' depth='21.87 m' temp='6.3 C' ndl='10:00 min' />
+  <sample time='11:00 min' depth='22.01 m' />
+  <sample time='11:10 min' depth='22.06 m' />
+  <sample time='11:20 min' depth='21.9 m' />
+  <sample time='11:30 min' depth='22.16 m' />
+  <sample time='11:40 min' depth='22.26 m' />
+  <sample time='11:50 min' depth='22.75 m' temp='5.9 C' ndl='9:00 min' />
+  <sample time='12:00 min' depth='22.41 m' />
+  <sample time='12:10 min' depth='22.4 m' />
+  <sample time='12:20 min' depth='22.41 m' />
+  <sample time='12:30 min' depth='22.2 m' />
+  <sample time='12:40 min' depth='22.4 m' />
+  <sample time='12:50 min' depth='22.7 m' temp='5.7 C' ndl='8:00 min' />
+  <sample time='13:00 min' depth='22.93 m' />
+  <sample time='13:10 min' depth='22.56 m' />
+  <sample time='13:20 min' depth='22.69 m' />
+  <sample time='13:30 min' depth='23.0 m' />
+  <sample time='13:40 min' depth='23.7 m' />
+  <sample time='13:50 min' depth='23.51 m' temp='5.6 C' ndl='6:00 min' cns='5%' />
+  <sample time='14:00 min' depth='23.1 m' />
+  <sample time='14:10 min' depth='23.33 m' />
+  <sample time='14:20 min' depth='22.58 m' />
+  <sample time='14:30 min' depth='22.04 m' />
+  <sample time='14:40 min' depth='22.36 m' />
+  <sample time='14:50 min' depth='22.21 m' temp='5.5 C' />
+  <sample time='15:00 min' depth='21.95 m' />
+  <sample time='15:10 min' depth='21.3 m' />
+  <sample time='15:20 min' depth='21.26 m' />
+  <sample time='15:30 min' depth='21.14 m' />
+  <sample time='15:40 min' depth='21.21 m' />
+  <sample time='15:50 min' depth='21.66 m' temp='5.4 C' ndl='18:00 min' />
+  <sample time='16:00 min' depth='22.33 m' />
+  <sample time='16:10 min' depth='22.39 m' />
+  <sample time='16:20 min' depth='22.62 m' />
+  <sample time='16:30 min' depth='22.96 m' />
+  <sample time='16:40 min' depth='23.97 m' />
+  <sample time='16:50 min' depth='24.88 m' temp='5.3 C' ndl='11:00 min' />
+  <sample time='17:00 min' depth='25.78 m' />
+  <sample time='17:10 min' depth='26.66 m' />
+  <sample time='17:20 min' depth='27.43 m' />
+  <sample time='17:30 min' depth='27.81 m' />
+  <sample time='17:40 min' depth='28.32 m' />
+  <sample time='17:50 min' depth='29.01 m' temp='5.2 C' ndl='6:00 min' />
+  <sample time='18:00 min' depth='29.63 m' />
+  <sample time='18:10 min' depth='30.61 m' />
+  <sample time='18:20 min' depth='31.92 m' />
+  <sample time='18:30 min' depth='33.94 m' />
+  <sample time='18:40 min' depth='36.17 m' />
+  <sample time='18:50 min' depth='37.79 m' ndl='3:00 min' />
+  <sample time='19:00 min' depth='38.85 m' />
+  <sample time='19:10 min' depth='39.56 m' />
+  <sample time='19:20 min' depth='40.67 m' />
+  <sample time='19:30 min' depth='41.84 m' />
+  <sample time='19:40 min' depth='42.95 m' />
+  <sample time='19:50 min' depth='44.55 m' ndl='0:00 min' in_deco='1' stoptime='1:00 min' stopdepth='3.0 m' cns='6%' />
+  <sample time='20:00 min' depth='46.24 m' />
+  <sample time='20:10 min' depth='47.53 m' />
+  <sample time='20:20 min' depth='49.53 m' />
+  <sample time='20:30 min' depth='50.56 m' />
+  <sample time='20:40 min' depth='52.49 m' />
+  <sample time='20:50 min' depth='53.64 m' stopdepth='15.0 m' />
+  <sample time='21:00 min' depth='54.95 m' />
+  <sample time='21:10 min' depth='57.28 m' />
+  <sample time='21:20 min' depth='58.94 m' />
+  <sample time='21:30 min' depth='61.03 m' />
+  <sample time='21:40 min' depth='62.84 m' />
+  <sample time='21:50 min' depth='64.2 m' temp='5.3 C' stopdepth='21.0 m' cns='7%' />
+  <sample time='22:00 min' depth='66.32 m' />
+  <sample time='22:10 min' depth='68.55 m' />
+  <sample time='22:20 min' depth='70.44 m' />
+  <sample time='22:30 min' depth='71.79 m' />
+  <sample time='22:40 min' depth='73.4 m' />
+  <sample time='22:50 min' depth='75.13 m' stopdepth='24.0 m' />
+  <sample time='23:00 min' depth='76.46 m' />
+  <sample time='23:10 min' depth='78.25 m' />
+  <sample time='23:20 min' depth='79.35 m' />
+  <sample time='23:30 min' depth='79.4 m' />
+  <sample time='23:40 min' depth='79.48 m' />
+  <sample time='23:50 min' depth='79.57 m' stopdepth='27.0 m' cns='8%' />
+  <sample time='24:00 min' depth='78.89 m' />
+  <sample time='24:10 min' depth='78.34 m' />
+  <sample time='24:20 min' depth='78.09 m' />
+  <sample time='24:30 min' depth='78.2 m' />
+  <sample time='24:40 min' depth='78.39 m' />
+  <sample time='24:50 min' depth='78.66 m' temp='5.2 C' stopdepth='30.0 m' />
+  <sample time='25:00 min' depth='78.75 m' />
+  <sample time='25:10 min' depth='78.92 m' />
+  <sample time='25:20 min' depth='78.73 m' />
+  <sample time='25:30 min' depth='78.29 m' />
+  <sample time='25:40 min' depth='78.04 m' />
+  <sample time='25:50 min' depth='78.15 m' cns='9%' />
+  <sample time='26:00 min' depth='78.49 m' />
+  <sample time='26:10 min' depth='78.46 m' />
+  <sample time='26:20 min' depth='78.21 m' />
+  <sample time='26:30 min' depth='78.15 m' />
+  <sample time='26:40 min' depth='78.27 m' />
+  <sample time='26:50 min' depth='78.07 m' stopdepth='33.0 m' />
+  <sample time='27:00 min' depth='77.94 m' />
+  <sample time='27:10 min' depth='78.03 m' />
+  <sample time='27:20 min' depth='78.24 m' />
+  <sample time='27:30 min' depth='78.26 m' />
+  <sample time='27:40 min' depth='78.34 m' />
+  <sample time='27:50 min' depth='78.28 m' cns='10%' />
+  <sample time='28:00 min' depth='78.34 m' />
+  <sample time='28:10 min' depth='78.44 m' />
+  <sample time='28:20 min' depth='78.35 m' />
+  <sample time='28:30 min' depth='78.45 m' />
+  <sample time='28:40 min' depth='78.18 m' />
+  <sample time='28:50 min' depth='77.78 m' temp='5.1 C' stopdepth='36.0 m' />
+  <sample time='29:00 min' depth='77.78 m' />
+  <sample time='29:10 min' depth='76.76 m' />
+  <sample time='29:20 min' depth='75.75 m' />
+  <sample time='29:30 min' depth='74.95 m' />
+  <sample time='29:40 min' depth='74.33 m' />
+  <sample time='29:50 min' depth='74.1 m' temp='5.2 C' cns='12%' />
+  <sample time='30:00 min' depth='73.76 m' />
+  <sample time='30:10 min' depth='73.1 m' />
+  <sample time='30:20 min' depth='71.91 m' />
+  <sample time='30:30 min' depth='70.79 m' />
+  <sample time='30:40 min' depth='69.68 m' />
+  <sample time='30:50 min' depth='69.23 m' temp='5.3 C' />
+  <sample time='31:00 min' depth='68.51 m' />
+  <sample time='31:10 min' depth='68.6 m' />
+  <sample time='31:20 min' depth='68.43 m' />
+  <sample time='31:30 min' depth='67.49 m' />
+  <sample time='31:40 min' depth='66.86 m' />
+  <sample time='31:50 min' depth='65.99 m' temp='5.4 C' cns='13%' />
+  <sample time='32:00 min' depth='65.48 m' />
+  <sample time='32:10 min' depth='65.02 m' />
+  <sample time='32:20 min' depth='64.73 m' />
+  <sample time='32:30 min' depth='64.54 m' />
+  <sample time='32:40 min' depth='63.49 m' />
+  <sample time='32:50 min' depth='62.18 m' />
+  <sample time='33:00 min' depth='61.19 m' />
+  <sample time='33:10 min' depth='60.9 m' />
+  <sample time='33:20 min' depth='60.05 m' />
+  <sample time='33:30 min' depth='58.42 m' />
+  <sample time='33:40 min' depth='58.14 m' />
+  <sample time='33:50 min' depth='56.7 m' temp='5.5 C' cns='14%' />
+  <sample time='34:00 min' depth='56.22 m' />
+  <sample time='34:10 min' depth='55.46 m' />
+  <sample time='34:20 min' depth='55.09 m' />
+  <sample time='34:30 min' depth='54.36 m' />
+  <sample time='34:40 min' depth='53.51 m' />
+  <sample time='34:50 min' depth='52.79 m' />
+  <sample time='35:00 min' depth='51.86 m' />
+  <sample time='35:10 min' depth='51.22 m' />
+  <sample time='35:20 min' depth='50.37 m' />
+  <sample time='35:30 min' depth='49.57 m' />
+  <sample time='35:40 min' depth='48.71 m' />
+  <sample time='35:50 min' depth='47.76 m' temp='5.6 C' />
+  <sample time='36:00 min' depth='47.4 m' />
+  <sample time='36:10 min' depth='47.14 m' />
+  <sample time='36:20 min' depth='46.89 m' />
+  <sample time='36:30 min' depth='46.17 m' />
+  <sample time='36:40 min' depth='45.25 m' />
+  <sample time='36:50 min' depth='44.97 m' />
+  <sample time='37:00 min' depth='44.06 m' />
+  <sample time='37:10 min' depth='43.26 m' />
+  <sample time='37:20 min' depth='42.15 m' />
+  <sample time='37:30 min' depth='41.4 m' />
+  <sample time='37:40 min' depth='40.29 m' />
+  <sample time='37:50 min' depth='39.63 m' cns='15%' />
+  <sample time='38:00 min' depth='39.01 m' />
+  <sample time='38:10 min' depth='38.03 m' />
+  <sample time='38:20 min' depth='36.79 m' />
+  <sample time='38:30 min' depth='36.08 m' />
+  <sample time='38:40 min' depth='35.56 m' />
+  <sample time='38:50 min' depth='34.84 m' stopdepth='33.0 m' />
+  <sample time='39:00 min' depth='33.65 m' />
+  <sample time='39:10 min' depth='32.74 m' />
+  <sample time='39:20 min' depth='31.82 m' />
+  <sample time='39:30 min' depth='31.77 m' />
+  <sample time='39:40 min' depth='31.52 m' />
+  <sample time='39:50 min' depth='31.04 m' stoptime='2:00 min' stopdepth='30.0 m' />
+  <sample time='40:00 min' depth='30.74 m' />
+  <sample time='40:10 min' depth='30.54 m' />
+  <sample time='40:20 min' depth='30.41 m' />
+  <sample time='40:30 min' depth='30.5 m' />
+  <sample time='40:40 min' depth='29.69 m' />
+  <sample time='40:50 min' depth='29.01 m' stoptime='1:00 min' />
+  <sample time='41:00 min' depth='28.62 m' />
+  <sample time='41:10 min' depth='28.33 m' />
+  <sample time='41:20 min' depth='27.86 m' />
+  <sample time='41:30 min' depth='27.68 m' />
+  <sample time='41:40 min' depth='27.38 m' />
+  <sample time='41:50 min' depth='26.92 m' temp='5.7 C' stopdepth='27.0 m' cns='16%' />
+  <sample time='42:00 min' depth='26.64 m' />
+  <sample time='42:10 min' depth='26.45 m' />
+  <sample time='42:20 min' depth='26.05 m' />
+  <sample time='42:30 min' depth='25.83 m' />
+  <sample time='42:40 min' depth='24.63 m' />
+  <sample time='42:50 min' depth='24.53 m' stopdepth='24.0 m' />
+  <sample time='43:00 min' depth='24.17 m' />
+  <sample time='43:10 min' depth='23.85 m' />
+  <sample time='43:20 min' depth='23.85 m' />
+  <sample time='43:30 min' depth='23.7 m' />
+  <sample time='43:40 min' depth='23.72 m' />
+  <sample time='43:50 min' depth='23.56 m' stoptime='2:00 min' stopdepth='21.0 m' />
+  <sample time='44:00 min' depth='23.41 m' />
+  <sample time='44:10 min' depth='23.14 m' />
+  <sample time='44:20 min' depth='23.04 m' />
+  <sample time='44:30 min' depth='22.78 m' />
+  <sample time='44:40 min' depth='22.37 m' />
+  <sample time='44:50 min' depth='22.51 m' temp='5.8 C' stoptime='1:00 min' />
+  <sample time='45:00 min' depth='22.71 m' />
+  <sample time='45:10 min' depth='22.43 m' />
+  <sample time='45:20 min' depth='22.59 m' />
+  <sample time='45:30 min' depth='22.66 m' />
+  <sample time='45:40 min' depth='22.69 m' />
+  <sample time='45:50 min' depth='22.52 m' cns='17%' />
+  <sample time='46:00 min' depth='22.43 m' />
+  <sample time='46:10 min' depth='22.68 m' />
+  <sample time='46:20 min' depth='22.5 m' />
+  <sample time='46:30 min' depth='22.13 m' />
+  <sample time='46:40 min' depth='22.17 m' />
+  <sample time='46:50 min' depth='21.97 m' stoptime='2:00 min' stopdepth='18.0 m' />
+  <sample time='47:00 min' depth='21.84 m' />
+  <sample time='47:10 min' depth='21.85 m' />
+  <sample time='47:20 min' depth='21.67 m' />
+  <sample time='47:30 min' depth='21.49 m' />
+  <sample time='47:40 min' depth='21.48 m' />
+  <sample time='47:50 min' depth='21.46 m' stoptime='1:00 min' />
+  <sample time='48:00 min' depth='21.19 m' />
+  <sample time='48:10 min' depth='20.98 m' />
+  <sample time='48:20 min' depth='20.88 m' />
+  <sample time='48:30 min' depth='20.76 m' />
+  <sample time='48:40 min' depth='20.81 m' />
+  <sample time='48:50 min' depth='20.74 m' />
+  <sample time='49:00 min' depth='20.5 m' />
+  <sample time='49:10 min' depth='20.48 m' />
+  <sample time='49:20 min' depth='20.42 m' />
+  <sample time='49:30 min' depth='20.25 m' />
+  <sample time='49:40 min' depth='20.55 m' />
+  <sample time='49:50 min' depth='20.82 m' stoptime='3:00 min' stopdepth='15.0 m' cns='18%' />
+  <sample time='50:00 min' depth='20.76 m' />
+  <sample time='50:10 min' depth='20.66 m' />
+  <sample time='50:20 min' depth='20.64 m' />
+  <sample time='50:30 min' depth='20.22 m' />
+  <sample time='50:40 min' depth='20.56 m' />
+  <sample time='50:50 min' depth='20.5 m' stoptime='2:00 min' />
+  <sample time='51:00 min' depth='20.27 m' />
+  <sample time='51:10 min' depth='20.12 m' />
+  <sample time='51:20 min' depth='20.2 m' />
+  <sample time='51:30 min' depth='20.27 m' />
+  <sample time='51:40 min' depth='20.22 m' />
+  <sample time='51:50 min' depth='20.64 m' temp='5.7 C' stoptime='1:00 min' cns='19%' />
+  <sample time='52:00 min' depth='20.75 m' />
+  <sample time='52:10 min' depth='20.5 m' />
+  <sample time='52:20 min' depth='20.31 m' />
+  <sample time='52:30 min' depth='20.08 m' />
+  <sample time='52:40 min' depth='19.85 m' />
+  <sample time='52:50 min' depth='19.54 m' stoptime='5:00 min' stopdepth='12.0 m' />
+  <sample time='53:00 min' depth='18.96 m' />
+  <sample time='53:10 min' depth='18.89 m' />
+  <sample time='53:20 min' depth='18.66 m' />
+  <sample time='53:30 min' depth='17.98 m' />
+  <sample time='53:40 min' depth='17.9 m' />
+  <sample time='53:50 min' depth='17.35 m' temp='5.8 C' stoptime='4:00 min' cns='21%' />
+  <sample time='54:00 min' depth='17.29 m' />
+  <sample time='54:10 min' depth='16.96 m' />
+  <sample time='54:20 min' depth='15.98 m' />
+  <sample time='54:30 min' depth='15.97 m' />
+  <sample time='54:40 min' depth='15.57 m' />
+  <sample time='54:50 min' depth='15.9 m' stoptime='3:00 min' />
+  <sample time='55:00 min' depth='16.09 m' />
+  <sample time='55:10 min' depth='15.59 m' />
+  <sample time='55:20 min' depth='15.54 m' />
+  <sample time='55:30 min' depth='14.99 m' />
+  <sample time='55:40 min' depth='14.76 m' />
+  <sample time='55:50 min' depth='14.54 m' temp='5.9 C' stoptime='2:00 min' cns='22%' />
+  <sample time='56:00 min' depth='13.85 m' />
+  <sample time='56:10 min' depth='13.54 m' />
+  <sample time='56:20 min' depth='13.36 m' />
+  <sample time='56:30 min' depth='13.5 m' />
+  <sample time='56:40 min' depth='13.52 m' />
+  <sample time='56:50 min' depth='13.17 m' temp='6.0 C' stoptime='1:00 min' />
+  <sample time='57:00 min' depth='12.59 m' />
+  <sample time='57:10 min' depth='12.59 m' />
+  <sample time='57:20 min' depth='12.25 m' />
+  <sample time='57:30 min' depth='12.35 m' />
+  <sample time='57:40 min' depth='12.58 m' />
+  <sample time='57:50 min' depth='12.91 m' temp='6.2 C' stoptime='8:00 min' stopdepth='9.0 m' cns='23%' />
+  <sample time='58:00 min' depth='12.96 m' />
+  <sample time='58:10 min' depth='12.64 m' />
+  <sample time='58:20 min' depth='12.76 m' />
+  <sample time='58:30 min' depth='12.73 m' />
+  <sample time='58:40 min' depth='12.59 m' />
+  <sample time='58:50 min' depth='12.2 m' temp='6.4 C' stoptime='7:00 min' />
+  <sample time='59:00 min' depth='12.05 m' />
+  <sample time='59:10 min' depth='11.82 m' />
+  <sample time='59:20 min' depth='11.48 m' />
+  <sample time='59:30 min' depth='11.65 m' />
+  <sample time='59:40 min' depth='11.42 m' />
+  <sample time='59:50 min' depth='11.57 m' temp='6.6 C' stoptime='6:00 min' cns='24%' />
+  <sample time='60:00 min' depth='11.47 m' />
+  <sample time='60:10 min' depth='11.14 m' />
+  <sample time='60:20 min' depth='10.78 m' />
+  <sample time='60:30 min' depth='10.56 m' />
+  <sample time='60:40 min' depth='10.3 m' />
+  <sample time='60:50 min' depth='10.33 m' temp='6.7 C' stoptime='5:00 min' />
+  <sample time='61:00 min' depth='10.45 m' />
+  <sample time='61:10 min' depth='10.19 m' />
+  <sample time='61:20 min' depth='9.95 m' />
+  <sample time='61:30 min' depth='9.8 m' />
+  <sample time='61:40 min' depth='9.75 m' />
+  <sample time='61:50 min' depth='9.49 m' temp='6.9 C' stoptime='4:00 min' />
+  <sample time='62:00 min' depth='9.61 m' />
+  <sample time='62:10 min' depth='9.44 m' />
+  <sample time='62:20 min' depth='9.3 m' />
+  <sample time='62:30 min' depth='9.12 m' />
+  <sample time='62:40 min' depth='9.34 m' />
+  <sample time='62:50 min' depth='9.46 m' temp='7.0 C' stoptime='3:00 min' />
+  <sample time='63:00 min' depth='9.63 m' />
+  <sample time='63:10 min' depth='9.6 m' />
+  <sample time='63:20 min' depth='9.55 m' />
+  <sample time='63:30 min' depth='9.51 m' />
+  <sample time='63:40 min' depth='9.45 m' />
+  <sample time='63:50 min' depth='9.42 m' temp='7.1 C' stoptime='2:00 min' cns='25%' />
+  <sample time='64:00 min' depth='9.46 m' />
+  <sample time='64:10 min' depth='9.51 m' />
+  <sample time='64:20 min' depth='9.52 m' />
+  <sample time='64:30 min' depth='9.75 m' />
+  <sample time='64:40 min' depth='9.62 m' />
+  <sample time='64:50 min' depth='9.84 m' stoptime='1:00 min' />
+  <sample time='65:00 min' depth='9.64 m' />
+  <sample time='65:10 min' depth='9.48 m' />
+  <sample time='65:20 min' depth='9.48 m' />
+  <sample time='65:30 min' depth='9.37 m' />
+  <sample time='65:40 min' depth='8.93 m' />
+  <sample time='65:50 min' depth='8.88 m' stoptime='9:00 min' stopdepth='6.0 m' cns='26%' />
+  <sample time='66:00 min' depth='8.69 m' />
+  <sample time='66:10 min' depth='8.74 m' />
+  <sample time='66:20 min' depth='8.65 m' />
+  <sample time='66:30 min' depth='8.33 m' />
+  <sample time='66:40 min' depth='7.98 m' />
+  <sample time='66:50 min' depth='7.87 m' temp='7.2 C' stoptime='8:00 min' />
+  <sample time='67:00 min' depth='7.63 m' />
+  <sample time='67:10 min' depth='7.88 m' />
+  <sample time='67:20 min' depth='7.78 m' />
+  <sample time='67:30 min' depth='7.39 m' />
+  <sample time='67:40 min' depth='7.3 m' />
+  <sample time='67:50 min' depth='7.33 m' temp='7.3 C' stoptime='7:00 min' />
+  <sample time='68:00 min' depth='7.16 m' />
+  <sample time='68:10 min' depth='7.18 m' />
+  <sample time='68:20 min' depth='7.37 m' />
+  <sample time='68:30 min' depth='7.22 m' />
+  <sample time='68:40 min' depth='7.54 m' />
+  <sample time='68:50 min' depth='7.23 m' temp='7.4 C' />
+  <sample time='69:00 min' depth='7.24 m' />
+  <sample time='69:10 min' depth='7.26 m' />
+  <sample time='69:20 min' depth='7.06 m' />
+  <sample time='69:30 min' depth='7.3 m' />
+  <sample time='69:40 min' depth='6.95 m' />
+  <sample time='69:50 min' depth='7.2 m' temp='7.5 C' stoptime='6:00 min' cns='27%' />
+  <sample time='70:00 min' depth='6.79 m' />
+  <sample time='70:10 min' depth='6.54 m' />
+  <sample time='70:20 min' depth='6.77 m' />
+  <sample time='70:30 min' depth='6.34 m' />
+  <sample time='70:40 min' depth='6.39 m' />
+  <sample time='70:50 min' depth='6.26 m' temp='7.6 C' stoptime='5:00 min' />
+  <sample time='71:00 min' depth='6.28 m' />
+  <sample time='71:10 min' depth='6.27 m' />
+  <sample time='71:20 min' depth='6.29 m' />
+  <sample time='71:30 min' depth='5.92 m' />
+  <sample time='71:40 min' depth='5.7 m' />
+  <sample time='71:50 min' depth='5.84 m' temp='7.8 C' />
+  <sample time='72:00 min' depth='5.89 m' />
+  <sample time='72:10 min' depth='6.07 m' />
+  <sample time='72:20 min' depth='5.76 m' />
+  <sample time='72:30 min' depth='5.77 m' />
+  <sample time='72:40 min' depth='5.83 m' />
+  <sample time='72:50 min' depth='5.87 m' temp='7.9 C' stoptime='4:00 min' />
+  <sample time='73:00 min' depth='5.88 m' />
+  <sample time='73:10 min' depth='5.84 m' />
+  <sample time='73:20 min' depth='5.73 m' />
+  <sample time='73:30 min' depth='5.8 m' />
+  <sample time='73:40 min' depth='5.68 m' />
+  <sample time='73:50 min' depth='6.02 m' stoptime='3:00 min' cns='30%' />
+  <sample time='74:00 min' depth='5.84 m' />
+  <sample time='74:10 min' depth='5.84 m' />
+  <sample time='74:20 min' depth='6.13 m' />
+  <sample time='74:30 min' depth='5.99 m' />
+  <sample time='74:40 min' depth='5.99 m' />
+  <sample time='74:50 min' depth='5.94 m' temp='8.0 C' stoptime='2:00 min' />
+  <sample time='75:00 min' depth='5.95 m' />
+  <sample time='75:10 min' depth='6.11 m' />
+  <sample time='75:20 min' depth='6.16 m' />
+  <sample time='75:30 min' depth='6.12 m' />
+  <sample time='75:40 min' depth='6.21 m' />
+  <sample time='75:50 min' depth='6.4 m' temp='8.1 C' stoptime='1:00 min' cns='33%' />
+  <sample time='76:00 min' depth='5.83 m' />
+  <sample time='76:10 min' depth='5.74 m' />
+  <sample time='76:20 min' depth='6.0 m' />
+  <sample time='76:30 min' depth='5.96 m' />
+  <sample time='76:40 min' depth='6.17 m' />
+  <sample time='76:50 min' depth='5.99 m' temp='8.2 C' stoptime='16:00 min' stopdepth='3.0 m' />
+  <sample time='77:00 min' depth='6.0 m' />
+  <sample time='77:10 min' depth='6.17 m' />
+  <sample time='77:20 min' depth='5.92 m' />
+  <sample time='77:30 min' depth='5.77 m' />
+  <sample time='77:40 min' depth='5.75 m' />
+  <sample time='77:50 min' depth='5.52 m' stoptime='15:00 min' cns='36%' />
+  <sample time='78:00 min' depth='5.19 m' />
+  <sample time='78:10 min' depth='5.23 m' />
+  <sample time='78:20 min' depth='5.14 m' />
+  <sample time='78:30 min' depth='4.86 m' />
+  <sample time='78:40 min' depth='4.98 m' />
+  <sample time='78:50 min' depth='4.9 m' stoptime='14:00 min' />
+  <sample time='79:00 min' depth='4.68 m' />
+  <sample time='79:10 min' depth='4.59 m' />
+  <sample time='79:20 min' depth='4.51 m' />
+  <sample time='79:30 min' depth='4.61 m' />
+  <sample time='79:40 min' depth='4.73 m' />
+  <sample time='79:50 min' depth='4.63 m' temp='8.3 C' stoptime='13:00 min' cns='37%' />
+  <sample time='80:00 min' depth='4.68 m' />
+  <sample time='80:10 min' depth='4.63 m' />
+  <sample time='80:20 min' depth='4.49 m' />
+  <sample time='80:30 min' depth='4.44 m' />
+  <sample time='80:40 min' depth='4.43 m' />
+  <sample time='80:50 min' depth='4.53 m' temp='8.5 C' stoptime='12:00 min' />
+  <sample time='81:00 min' depth='4.69 m' />
+  <sample time='81:10 min' depth='4.55 m' />
+  <sample time='81:20 min' depth='4.6 m' />
+  <sample time='81:30 min' depth='4.48 m' />
+  <sample time='81:40 min' depth='4.52 m' />
+  <sample time='81:50 min' depth='4.35 m' stoptime='11:00 min' cns='39%' />
+  <sample time='82:00 min' depth='4.39 m' />
+  <sample time='82:10 min' depth='4.15 m' />
+  <sample time='82:20 min' depth='4.12 m' />
+  <sample time='82:30 min' depth='4.03 m' />
+  <sample time='82:40 min' depth='3.72 m' />
+  <sample time='82:50 min' depth='3.58 m' temp='8.6 C' stoptime='10:00 min' />
+  <sample time='83:00 min' depth='3.7 m' />
+  <sample time='83:10 min' depth='3.8 m' />
+  <sample time='83:20 min' depth='3.42 m' />
+  <sample time='83:30 min' depth='3.31 m' />
+  <sample time='83:40 min' depth='3.44 m' />
+  <sample time='83:50 min' depth='3.79 m' temp='8.7 C' stoptime='9:00 min' cns='40%' />
+  <sample time='84:00 min' depth='3.89 m' />
+  <sample time='84:10 min' depth='3.82 m' />
+  <sample time='84:20 min' depth='3.62 m' />
+  <sample time='84:30 min' depth='3.7 m' />
+  <sample time='84:40 min' depth='3.48 m' />
+  <sample time='84:50 min' depth='3.51 m' temp='8.8 C' stoptime='8:00 min' />
+  <sample time='85:00 min' depth='3.68 m' />
+  <sample time='85:10 min' depth='3.52 m' />
+  <sample time='85:20 min' depth='3.98 m' />
+  <sample time='85:30 min' depth='3.83 m' />
+  <sample time='85:40 min' depth='3.42 m' />
+  <sample time='85:50 min' depth='3.33 m' stoptime='7:00 min' cns='41%' />
+  <sample time='86:00 min' depth='3.49 m' />
+  <sample time='86:10 min' depth='3.36 m' />
+  <sample time='86:20 min' depth='3.54 m' />
+  <sample time='86:30 min' depth='3.58 m' />
+  <sample time='86:40 min' depth='3.42 m' />
+  <sample time='86:50 min' depth='3.94 m' temp='8.9 C' stoptime='6:00 min' />
+  <sample time='87:00 min' depth='4.09 m' />
+  <sample time='87:10 min' depth='4.14 m' />
+  <sample time='87:20 min' depth='4.01 m' />
+  <sample time='87:30 min' depth='4.06 m' />
+  <sample time='87:40 min' depth='4.28 m' />
+  <sample time='87:50 min' depth='4.27 m' stoptime='5:00 min' cns='42%' />
+  <sample time='88:00 min' depth='4.05 m' />
+  <sample time='88:10 min' depth='4.22 m' />
+  <sample time='88:20 min' depth='4.39 m' />
+  <sample time='88:30 min' depth='4.13 m' />
+  <sample time='88:40 min' depth='4.31 m' />
+  <sample time='88:50 min' depth='4.41 m' stoptime='4:00 min' />
+  <sample time='89:00 min' depth='4.22 m' />
+  <sample time='89:10 min' depth='3.98 m' />
+  <sample time='89:20 min' depth='4.06 m' />
+  <sample time='89:30 min' depth='4.32 m' />
+  <sample time='89:40 min' depth='4.55 m' />
+  <sample time='89:50 min' depth='4.67 m' stoptime='3:00 min' cns='44%' />
+  <sample time='90:00 min' depth='4.68 m' />
+  <sample time='90:10 min' depth='4.83 m' />
+  <sample time='90:20 min' depth='4.84 m' />
+  <sample time='90:30 min' depth='5.05 m' />
+  <sample time='90:40 min' depth='5.52 m' />
+  <sample time='90:50 min' depth='5.33 m' stoptime='2:00 min' />
+  <sample time='91:00 min' depth='5.09 m' />
+  <sample time='91:10 min' depth='4.81 m' />
+  <sample time='91:20 min' depth='4.69 m' />
+  <sample time='91:30 min' depth='4.52 m' />
+  <sample time='91:40 min' depth='4.48 m' />
+  <sample time='91:50 min' depth='4.55 m' stoptime='1:00 min' cns='45%' />
+  <sample time='92:00 min' depth='4.66 m' />
+  <sample time='92:10 min' depth='4.66 m' />
+  <sample time='92:20 min' depth='4.72 m' />
+  <sample time='92:30 min' depth='4.68 m' />
+  <sample time='92:40 min' depth='4.76 m' />
+  <sample time='92:50 min' depth='4.84 m' temp='9.0 C' ndl='240:00 min' in_deco='0' stoptime='0:00 min' stopdepth='0.0 m' />
+  <sample time='93:00 min' depth='4.87 m' />
+  <sample time='93:10 min' depth='4.99 m' />
+  <sample time='93:20 min' depth='5.08 m' />
+  <sample time='93:30 min' depth='4.91 m' />
+  <sample time='93:40 min' depth='5.04 m' />
+  <sample time='93:50 min' depth='4.97 m' cns='47%' />
+  <sample time='94:00 min' depth='5.16 m' />
+  <sample time='94:10 min' depth='4.91 m' />
+  <sample time='94:20 min' depth='4.92 m' />
+  <sample time='94:30 min' depth='4.81 m' />
+  <sample time='94:40 min' depth='4.68 m' />
+  <sample time='94:50 min' depth='5.18 m' />
+  <sample time='95:00 min' depth='5.21 m' />
+  <sample time='95:10 min' depth='4.65 m' />
+  <sample time='95:20 min' depth='4.14 m' />
+  <sample time='95:30 min' depth='3.99 m' />
+  <sample time='95:40 min' depth='3.8 m' />
+  <sample time='95:50 min' depth='3.5 m' temp='9.1 C' cns='48%' />
+  <sample time='96:00 min' depth='3.37 m' />
+  <sample time='96:10 min' depth='3.39 m' />
+  <sample time='96:20 min' depth='2.94 m' />
+  <sample time='96:30 min' depth='2.82 m' />
+  <sample time='96:40 min' depth='2.8 m' />
+  <sample time='96:50 min' depth='2.71 m' />
+  <sample time='97:00 min' depth='2.13 m' />
+  <sample time='97:10 min' depth='1.8 m' />
+  <sample time='97:20 min' depth='1.99 m' />
+  <sample time='97:30 min' depth='1.88 m' />
+  <sample time='97:40 min' depth='1.18 m' />
+  <sample time='97:50 min' depth='1.47 m' temp='9.2 C' cns='49%' />
+  <sample time='98:00 min' depth='1.12 m' />
+  <sample time='98:10 min' depth='1.17 m' />
+  <sample time='98:20 min' depth='1.04 m' />
+  <sample time='98:30 min' depth='0.85 m' />
+  <sample time='98:40 min' depth='0.48 m' />
+  <sample time='98:50 min' depth='0.0 m' temp='9.4 C' />
+  <sample time='99:00 min' depth='0.0 m' />
+  <sample time='99:10 min' depth='0.03 m' />
+  <sample time='99:20 min' depth='0.0 m' />
+  <sample time='99:30 min' depth='0.0 m' />
+  <sample time='99:40 min' depth='0.0 m' />
+  <sample time='99:50 min' depth='0.0 m' temp='10.0 C' cns='50%' />
+  <sample time='100:00 min' depth='0.0 m' />
+  <sample time='100:10 min' depth='0.0 m' />
+  <sample time='100:20 min' depth='0.0 m' />
+  <sample time='100:30 min' depth='0.0 m' />
+  <sample time='100:40 min' depth='0.0 m' />
+  <sample time='100:50 min' depth='0.0 m' temp='10.2 C' />
+  <sample time='101:00 min' depth='0.0 m' />
+  <sample time='101:10 min' depth='0.0 m' />
+  <sample time='101:20 min' depth='0.0 m' />
+  <sample time='101:30 min' depth='0.0 m' />
+  <sample time='101:40 min' depth='0.0 m' />
+  <sample time='101:50 min' depth='0.0 m' temp='10.4 C' />
+  <sample time='102:00 min' depth='0.0 m' />
+  <sample time='102:10 min' depth='0.06 m' />
+  <sample time='102:20 min' depth='0.01 m' />
+  <sample time='102:30 min' depth='0.02 m' />
+  <sample time='102:40 min' depth='0.0 m' />
+  <sample time='102:50 min' depth='0.1 m' temp='10.6 C' />
+  <sample time='103:00 min' depth='0.17 m' />
+  <sample time='103:10 min' depth='0.02 m' />
+  <sample time='103:20 min' depth='0.09 m' />
+  <sample time='103:30 min' depth='0.02 m' />
+  <sample time='103:40 min' depth='0.4 m' />
+  <sample time='103:50 min' depth='0.22 m' temp='10.8 C' cns='51%' />
+  <sample time='104:00 min' depth='0.02 m' />
+  <sample time='104:10 min' depth='0.01 m' />
+  <sample time='104:20 min' depth='0.02 m' />
+  <sample time='104:30 min' depth='0.0 m' />
+  <sample time='104:40 min' depth='0.27 m' />
+  <sample time='104:50 min' depth='0.27 m' />
+  <sample time='105:00 min' depth='0.09 m' />
+  <sample time='105:10 min' depth='0.01 m' />
+  <sample time='105:20 min' depth='1.13 m' />
+  <sample time='105:30 min' depth='1.18 m' />
+  <sample time='105:40 min' depth='0.85 m' />
+  <sample time='105:50 min' depth='0.24 m' cns='52%' />
+  <sample time='106:00 min' depth='1.02 m' />
+  <sample time='106:10 min' depth='0.99 m' />
+  <sample time='106:20 min' depth='0.85 m' />
+  <sample time='106:30 min' depth='0.0 m' />
+  <sample time='106:40 min' depth='0.0 m' />
+  <sample time='106:50 min' depth='0.01 m' />
+  <sample time='107:00 min' depth='0.0 m' />
+  <sample time='107:10 min' depth='0.0 m' />
+  <sample time='107:20 min' depth='0.0 m' />
+  <sample time='107:30 min' depth='0.0 m' />
+  <sample time='107:40 min' depth='0.0 m' />
+  <sample time='107:50 min' depth='0.0 m' />
+  <sample time='108:00 min' depth='0.0 m' />
+  <sample time='108:10 min' depth='0.0 m' />
+  <sample time='108:20 min' depth='0.0 m' />
+  <sample time='108:30 min' depth='0.0 m' />
+  <sample time='108:40 min' depth='0.0 m' />
+  <sample time='108:50 min' depth='0.0 m' />
+  <sample time='109:00 min' depth='0.0 m' />
+  <sample time='109:10 min' depth='0.0 m' />
+  <sample time='109:20 min' depth='0.0 m' />
+  <sample time='109:30 min' depth='0.0 m' />
+  <sample time='109:40 min' depth='0.0 m' />
+  <sample time='109:50 min' depth='0.0 m' cns='53%' />
+  <sample time='110:00 min' depth='0.0 m' />
+  <sample time='110:10 min' depth='0.0 m' />
+  <sample time='110:20 min' depth='0.0 m' />
+  <sample time='110:30 min' depth='0.0 m' />
+  <sample time='110:40 min' depth='0.0 m' />
+  <sample time='110:50 min' depth='0.0 m' temp='10.9 C' />
+  <sample time='111:00 min' depth='0.0 m' />
+  <sample time='111:10 min' depth='0.0 m' />
+  <sample time='111:20 min' depth='0.0 m' />
+  <sample time='111:30 min' depth='0.0 m' />
+  <sample time='111:40 min' depth='0.0 m' />
+  <sample time='111:50 min' depth='0.0 m' temp='11.0 C' cns='54%' />
+  <sample time='112:00 min' depth='0.0 m' />
+  <sample time='112:10 min' depth='0.0 m' />
+  <sample time='112:20 min' depth='0.0 m' />
+  <sample time='112:30 min' depth='0.0 m' />
+  <sample time='112:40 min' depth='0.0 m' />
+  <sample time='112:50 min' depth='0.0 m' temp='11.1 C' />
+  <sample time='113:00 min' depth='0.0 m' />
+  <sample time='113:10 min' depth='0.0 m' />
+  <sample time='113:20 min' depth='0.0 m' />
+  <sample time='113:30 min' depth='0.0 m' />
+  <sample time='113:40 min' depth='0.0 m' />
+  <sample time='113:50 min' depth='0.0 m' />
+  <sample time='114:00 min' depth='0.0 m' />
+  <sample time='114:10 min' depth='0.0 m' />
+  <sample time='114:20 min' depth='0.0 m' />
+  <sample time='114:30 min' depth='0.0 m' />
+  <sample time='114:40 min' depth='0.0 m' />
   </divecomputer>
 </dive>
 </dives>

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -130,6 +130,8 @@ void TestParse::testParse()
 	QCOMPARE(parseV3(), 0);
 	fprintf(stderr, "number of dives %d \n", divelog.dives->nr);
 
+	sort_dive_table(divelog.dives);
+
 	QCOMPARE(save_dives("./testout.ssrf"), 0);
 	FILE_COMPARE("./testout.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
@@ -140,6 +142,8 @@ void TestParse::testParseDM4()
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &_sqlite3_handle), 0);
 	QCOMPARE(parse_dm4_buffer(_sqlite3_handle, 0, 0, 0, &divelog), 0);
 
+	sort_dive_table(divelog.dives);
+
 	QCOMPARE(save_dives("./testdm4out.ssrf"), 0);
 	FILE_COMPARE("./testdm4out.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.xml");
@@ -149,6 +153,8 @@ void TestParse::testParseDM5()
 {
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM5.db", &_sqlite3_handle), 0);
 	QCOMPARE(parse_dm5_buffer(_sqlite3_handle, 0, 0, 0, &divelog), 0);
+
+	sort_dive_table(divelog.dives);
 
 	QCOMPARE(save_dives("./testdm5out.ssrf"), 0);
 	FILE_COMPARE("./testdm5out.ssrf",
@@ -192,6 +198,8 @@ void TestParse::testParseHUDC()
 		dive->dc.when = 1255152761;
 	}
 
+	sort_dive_table(divelog.dives);
+
 	QCOMPARE(save_dives("./testhudcout.ssrf"), 0);
 	FILE_COMPARE("./testhudcout.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearHUDC.xml");
@@ -230,6 +238,8 @@ void TestParse::testParseNewFormat()
 	fprintf(stderr, "number of dives %d \n", divelog.dives->nr);
 	QCOMPARE(save_dives("./testsbnewout.ssrf"), 0);
 
+	sort_dive_table(divelog.dives);
+
 	// Currently the CSV parse fails
 	FILE_COMPARE("./testsbnewout.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/TestDiveSeabearNewFormat.xml");
@@ -245,6 +255,8 @@ void TestParse::testParseDLD()
 
 	fprintf(stderr, "number of dives from DLD: %d \n", divelog.dives->nr);
 
+	sort_dive_table(divelog.dives);
+
 	// Compare output
 	QCOMPARE(save_dives("./testdldout.ssrf"), 0);
 	FILE_COMPARE("./testdldout.ssrf",
@@ -258,6 +270,9 @@ void TestParse::testParseMerge()
 	 */
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/ostc.xml", &divelog), 0);
 	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/vyper.xml", &divelog), 0);
+
+	sort_dive_table(divelog.dives);
+
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
 	FILE_COMPARE("./testmerge.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
@@ -323,10 +338,9 @@ void TestParse::exportCSVDiveDetails()
 		dive->sac = saved_sac;
 	}
 
-
+	sort_dive_table(divelog.dives);
 
 	export_dives_xslt("testcsvexportmanual2.csv", 0, 0, "xml2manualcsv.xslt", false);
-
 	FILE_COMPARE("testcsvexportmanual2.csv",
 		     "testcsvexportmanual.csv");
 
@@ -361,8 +375,9 @@ void TestParse::exportSubsurfaceCSV()
 		dive->sac = saved_sac;
 	}
 
-	export_dives_xslt("testcsvexportmanual2-cyl.csv", 0, 0, "xml2manualcsv.xslt", false);
+	sort_dive_table(divelog.dives);
 
+	export_dives_xslt("testcsvexportmanual2-cyl.csv", 0, 0, "xml2manualcsv.xslt", false);
 	FILE_COMPARE("testcsvexportmanual2-cyl.csv",
 		     "testcsvexportmanual-cyl.csv");
 
@@ -399,8 +414,9 @@ void TestParse::exportCSVDiveProfile()
 	clear_dive_file_data();
 
 	parseCSVprofile(1, "testcsvexportprofileimperial.csv");
-	export_dives_xslt("testcsvexportprofile2.csv", 0, 0, "xml2csv.xslt", false);
+	sort_dive_table(divelog.dives);
 
+	export_dives_xslt("testcsvexportprofile2.csv", 0, 0, "xml2csv.xslt", false);
 	FILE_COMPARE("testcsvexportprofile2.csv",
 		     "testcsvexportprofile.csv");
 
@@ -416,8 +432,9 @@ void TestParse::exportUDDF()
 	clear_dive_file_data();
 
 	parse_file("testuddfexport.uddf", &divelog);
-	export_dives_xslt("testuddfexport2.uddf", 0, 1, "uddf-export.xslt", false);
+	sort_dive_table(divelog.dives);
 
+	export_dives_xslt("testuddfexport2.uddf", 0, 1, "uddf-export.xslt", false);
 	FILE_COMPARE("testuddfexport.uddf",
 		     "testuddfexport2.uddf");
 
@@ -462,6 +479,8 @@ void TestParse::parseDL7()
 				&params, "DL7", &divelog),
 		 0);
 	QCOMPARE(divelog.dives->nr, 3);
+
+	sort_dive_table(divelog.dives);
 
 	QCOMPARE(save_dives("./testdl7out.ssrf"), 0);
 	FILE_COMPARE("./testdl7out.ssrf",

--- a/tests/testprofile.cpp
+++ b/tests/testprofile.cpp
@@ -34,6 +34,7 @@ void TestProfile::testProfileExport()
 {
 	prefs.planner_deco_mode = BUEHLMANN;
 	parse_file(SUBSURFACE_TEST_DATA "/dives/abitofeverything.ssrf", &divelog);
+	sort_dive_table(divelog.dives);
 	save_profiledata("exportprofile.csv", false);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/exportprofilereference.csv");
 	QCOMPARE(org.open(QFile::ReadOnly), true);
@@ -50,6 +51,7 @@ void TestProfile::testProfileExportVPMB()
 {
 	prefs.planner_deco_mode = VPMB;
 	parse_file(SUBSURFACE_TEST_DATA "/dives/abitofeverything.ssrf", &divelog);
+	sort_dive_table(divelog.dives);
 	save_profiledata("exportprofileVPMB.csv", false);
 	QFile org(SUBSURFACE_TEST_DATA "/dives/exportprofilereferenceVPMB.csv");
 	QCOMPARE(org.open(QFile::ReadOnly), true);


### PR DESCRIPTION
The dive list will be changed to an always-sorted list where one can use binary search.

However, this makes some tests fail, because they only use parse_dive(), which doesn't do any sorting.

To fix this future problem, sort the tables before performing the tests. This provides a more realistic setup, as in the actual application, the dive list will always be sorted on import.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is a preparatory commit for porting the divelist to C++. I plan to keep the list always sorted, however some tests work on unsorted lists (which is an ill-defined case btw, since the core expects dives to be in order).

@atdotde: please check the profile export.

PS: Please wait with merge until I can rebase my C++ branch on this and see if it does what I expect.