### PR TITLE
cleanup: remove unused function create_and_hookup_trip_from_dive()

### DIFF
--- a/core/trip.c
+++ b/core/trip.c
@@ -153,17 +153,6 @@ dive_trip_t *create_trip_from_dive(struct dive *dive)
 	return trip;
 }
 
-dive_trip_t *create_and_hookup_trip_from_dive(struct dive *dive, struct trip_table *trip_table_arg)
-{
-	dive_trip_t *dive_trip;
-
-	dive_trip = create_trip_from_dive(dive);
-
-	add_dive_to_trip(dive, dive_trip);
-	insert_trip(dive_trip, trip_table_arg);
-	return dive_trip;
-}
-
 /* random threshold: three days without diving -> new trip
  * this works very well for people who usually dive as part of a trip and don't
  * regularly dive at a local facility; this is why trips are an optional feature */

--- a/core/trip.h
+++ b/core/trip.h
@@ -43,7 +43,6 @@ extern void sort_trip_table(struct trip_table *table);
 
 extern dive_trip_t *alloc_trip(void);
 extern dive_trip_t *create_trip_from_dive(struct dive *dive);
-extern dive_trip_t *create_and_hookup_trip_from_dive(struct dive *dive, struct trip_table *trip_table_arg);
 extern dive_trip_t *get_dives_to_autogroup(struct dive_table *table, int start, int *from, int *to, bool *allocated);
 extern dive_trip_t *get_trip_for_new_dive(struct dive *new_dive, bool *allocated);
 extern dive_trip_t *get_trip_by_uniq_id(int tripId);


### PR DESCRIPTION
It seems that the last user was removed 5 years ago: ff9506b21?

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Another dead-code removal. This function hasn't been in use for a looong time...