### PR TITLE
Bugfix: Fix Incorrect Volumes Displayed for Tank Types.

### DIFF
--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1319,8 +1319,7 @@ EditCylinder::EditCylinder(int index, cylinder_t cylIn, EditCylinderType typeIn,
 void EditCylinder::redo()
 {
 	for (size_t i = 0; i < dives.size(); ++i) {
-		set_tank_info_size(&tank_info_table, cyl[i].type.description, cyl[i].type.size);
-		set_tank_info_workingpressure(&tank_info_table, cyl[i].type.description, cyl[i].type.workingpressure);
+		set_tank_info_data(&tank_info_table, cyl[i].type.description, cyl[i].type.size, cyl[i].type.workingpressure);
 		std::swap(*get_cylinder(dives[i], indexes[i]), cyl[i]);
 		update_cylinder_related_info(dives[i]);
 		emit diveListNotifier.cylinderEdited(dives[i], indexes[i]);

--- a/core/equipment.h
+++ b/core/equipment.h
@@ -126,9 +126,9 @@ extern void reset_tank_info_table(struct tank_info_table *table);
 extern void clear_tank_info_table(struct tank_info_table *table);
 extern void add_tank_info_metric(struct tank_info_table *table, const char *name, int ml, int bar);
 extern void add_tank_info_imperial(struct tank_info_table *table, const char *name, int cuft, int psi);
-extern void set_tank_info_size(struct tank_info_table *table, const char *name, volume_t size);
-extern void set_tank_info_workingpressure(struct tank_info_table *table, const char *name, pressure_t working_pressure);
-extern struct tank_info *get_tank_info(struct tank_info_table *table, const char *name);
+extern void extract_tank_info(const struct tank_info *info, volume_t *size, pressure_t *working_pressure);
+extern bool get_tank_info_data(struct tank_info_table *table, const char *name, volume_t *size, pressure_t *pressure);
+extern void set_tank_info_data(struct tank_info_table *table, const char *name, volume_t size, pressure_t working_pressure);
 
 struct ws_info_t {
 	const char *name;

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -218,18 +218,13 @@ void TankInfoDelegate::setModelData(QWidget *, QAbstractItemModel *model, const 
 		mymodel->setData(IDX(CylindersModel::TYPE), cylinderName, CylindersModel::TEMP_ROLE);
 		return;
 	}
-	int tankSize = 0;
-	int tankPressure = 0;
-	tank_info *info = get_tank_info(&tank_info_table, qPrintable(cylinderName));
-	if (info) {
-		// OMG, the units here are a mess.
-		tankSize = info->ml != 0 ? info->ml : lrint(cuft_to_l(info->cuft) * 1000.0);
-		tankPressure = info->bar != 0 ? info->bar * 1000 : psi_to_mbar(info->psi);
-	}
 
+	volume_t tankSize = {0};
+	pressure_t tankPressure = {0};
+	get_tank_info_data(&tank_info_table, qPrintable(cylinderName), &tankSize, &tankPressure);
 	mymodel->setData(IDX(CylindersModel::TYPE), cylinderName, CylindersModel::TEMP_ROLE);
-	mymodel->setData(IDX(CylindersModel::WORKINGPRESS), tankPressure, CylindersModel::TEMP_ROLE);
-	mymodel->setData(IDX(CylindersModel::SIZE), tankSize, CylindersModel::TEMP_ROLE);
+	mymodel->setData(IDX(CylindersModel::WORKINGPRESS), tankPressure.mbar, CylindersModel::TEMP_ROLE);
+	mymodel->setData(IDX(CylindersModel::SIZE), tankSize.mliter, CylindersModel::TEMP_ROLE);
 }
 
 static QAbstractItemModel *createTankInfoModel(QWidget *parent)

--- a/qt-models/tankinfomodel.cpp
+++ b/qt-models/tankinfomodel.cpp
@@ -13,17 +13,15 @@ QVariant TankInfoModel::data(const QModelIndex &index, int role) const
 		return defaultModelFont();
 	if (role == Qt::DisplayRole || role == Qt::EditRole) {
 		const struct tank_info &info = tank_info_table.infos[index.row()];
-		int ml = info.ml;
-		double bar = (info.psi) ? psi_to_bar(info.psi) : info.bar;
-
-		if (info.cuft && info.psi)
-			ml = lrint(cuft_to_l(info.cuft) * 1000 / bar_to_atm(bar));
+		volume_t size = {0};
+		pressure_t pressure = {0};
+		extract_tank_info(&info, &size, &pressure);
 
 		switch (index.column()) {
 		case BAR:
-			return bar * 1000;
+			return pressure.mbar;
 		case ML:
-			return ml;
+			return size.mliter;
 		case DESCRIPTION:
 			return info.name;
 		}


### PR DESCRIPTION


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Fix an issue introduced in #4148.
Essentially the refactoring missed the fact that in the imperial system tank size is tracked as the free gas volume, but in the metric system (which is the one used in most of Subsurface's calculations) tank size is tracked as water capacity.
So when updating a tank template tracking imperial measurements, the given (metric) volume in l has to be multiplied by the working pressure, and vice versa.
This also combines all the logic dealing with `tank_info` data in one place, hopefully making it less likely that this will be broken by inconsistencies in the future.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4239.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://github.com/subsurface/subsurface/assets/4742747/989e9d79-6ae0-4e11-8b09-92082aef7307)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger 