### PR TITLE
Filter: Fix Loading of Negated Conditions from git.

### DIFF
--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -357,22 +357,26 @@ static char *parse_keyvalue_entry(void (*fn)(void *, const char *, const std::st
 		line++;
 	}
 
-	if (c == '=')
+	if (c != 0)
 		*line++ = 0;
 
-	char *start_val = line;
-	while ((c = *line) != 0) {
-		if (isspace(c))
-			break;
-		line++;
+	std::string val;
+	if (c == '=') {
+		const char *start_val = line;
+		while ((c = *line) != 0) {
+			if (isspace(c))
+				break;
+			line++;
+		}
+
+		/* Did we get a string? Take it from the list of strings */
+		val = start_val[0] == '"' ? pop_cstring(state, key)
+					  : std::string(start_val, line - start_val);
+
+		if (c)
+			line++;
+
 	}
-
-	/* Did we get a string? Take it from the list of strings */
-	std::string val = start_val[0] == '"' ? pop_cstring(state, key)
-					      : std::string(start_val, line - start_val);
-
-	if (c)
-		line++;
 
 	fn(fndata, key, val);
 	return line;


### PR DESCRIPTION



<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix loading of the negation of filter conditions. Unlike other conditions that are persisted as `<key>="<value>"`, this is persisted to git as `negate`.
This fix remediates this for all cases where the condition has already been saved to the cloud storage.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4246.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Saving to XML takes a different approach and indicates negated conditions with `negate="1"`, making it identical to all other attributes. The question is if this approach should be implemented in addition to the above fix, in order to unify the storage format.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
