### PR TITLE
cleanup: remove unused function get_dive_id_closest_to()

### DIFF
--- a/core/divelist.c
+++ b/core/divelist.c
@@ -1277,32 +1277,6 @@ void report_datafile_version(int version)
 		min_datafile_version = version;
 }
 
-int get_dive_id_closest_to(timestamp_t when)
-{
-	int i;
-	int nr = divelog.dives->nr;
-
-	// deal with pathological cases
-	if (nr == 0)
-		return 0;
-	else if (nr == 1)
-		return divelog.dives->dives[0]->id;
-
-	for (i = 0; i < nr && divelog.dives->dives[i]->when <= when; i++)
-		; // nothing
-
-	// again, capture the two edge cases first
-	if (i == nr)
-		return divelog.dives->dives[i - 1]->id;
-	else if (i == 0)
-		return divelog.dives->dives[0]->id;
-
-	if (when - divelog.dives->dives[i - 1]->when < divelog.dives->dives[i]->when - when)
-		return divelog.dives->dives[i - 1]->id;
-	else
-		return divelog.dives->dives[i]->id;
-}
-
 void clear_dive_file_data()
 {
 	fulltext_unregister_all();

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -57,7 +57,6 @@ extern int comp_dives(const struct dive *a, const struct dive *b);
 int get_min_datafile_version();
 void reset_min_datafile_version();
 void report_datafile_version(int version);
-int get_dive_id_closest_to(timestamp_t when);
 void clear_dive_file_data();
 void clear_dive_table(struct dive_table *table);
 void move_dive_table(struct dive_table *src, struct dive_table *dst);


### PR DESCRIPTION
The last caller was removed in e700920e8ef.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Trivial code cleanup: remove unused function.