### PR TITLE
Fix crash on MacOS during download from new BLE computer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+bluetooth: fix crash on MacOS when doing first download from a new BLE device
 statistics: show proper dates in January
 desktop: add country to the fields indexed for full text search
 import: update libdivecomputer version, add support for the Scubapro G3 / Luna and Shearwater Tern

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -365,7 +365,7 @@ void DownloadFromDCWidget::on_product_currentTextChanged(const QString &)
 
 void DownloadFromDCWidget::on_device_currentTextChanged(const QString &device)
 {
-#if defined(Q_OS_MACOS)
+#if defined(BT_SUPPORT) && defined(Q_OS_MACOS)
 	if (isBluetoothAddress(device)) {
 		// ensure we have a discovery running
 		if (btd == nullptr)
@@ -429,6 +429,16 @@ void DownloadFromDCWidget::on_downloadCancelRetryButton_clicked()
 			address = extractBluetoothNameAddress(ui.device->currentText(), name);
 			data->setDevName(address);
 			data->setDevBluetoothName(name);
+		}
+		if (btd) {
+			// btd should only be active for mac os.
+			// Need to ensure that any scan is shut down BEFORE starting the download
+			// because internally (as of 5.15.13) the QT discovery agent uses a QTimer
+			// that can only be shut off from the same thread it was started from.
+			QString devAddr = data->devName().startsWith("LE:")
+							 ? data->devName().right(data->devName().size()-3)
+							 : data->devName();
+			getBtDeviceInfo(devAddr);
 		}
 	} else
 		// this breaks an "else if" across lines... not happy...


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Ensure that any bluetooth scan started (by changing the device name) in the download-from-dive-computer dialog (desktop version) is stopped before the download process is started up.
Because the QT bluetooth discovery agent uses a QTimer internally, it must be stopped from the same thread as it was started from. Otherwise the download process (using a different thread), calls getBtDeviceInfo and attempts to shut down any running scan - it will dispose of the QTimer but is not able to kill or deregister the timer. So when the timer goes off it results in a memory violation.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
1. In DownloadFromDCWidget::on_downloadCancelRetryButton_clicked(), added a call to getBtDeviceInfo() if BTDiscovery instance has been created. This ensures that a) the device was discovered and b) any outstanding scan is stopped (from the same thread that started it).
2. Added BT_SUPPORT conditional compile to assignment of btd member in DownloadFromDCWidget, since the btd member is only present if BT_SUPPORT is defined.
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4259 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Only happens on MacOS.
QT5.15.2 does not use the QTimer internally, 5.15.13 does (not sure what version they added it).
From the code, looks like any BLE device would be affected - classical bluetooth devices may be affected (depends how fast the scan discovers it).
The device name needs to be empty or a non bluetooth address when to import dialog first appears - so that the BTDiscovery instance is first created when the remote device selection dialog returns (and download button is pressed while internal QTimer is still active).

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
have added the following to the change log:
`bluetooth: fix crash on MacOS when doing first download from a new BLE device`

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
none

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
