### PR TITLE
Reduce attack vector in artifact-links.yml

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -10,10 +10,15 @@ jobs:
     name: Add artifact links to PR and issues
     runs-on: ubuntu-22.04
 
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: read
+
     steps:
     - name: Add artifact links to PR and issues
       if: github.event.workflow_run.event == 'pull_request'
-      uses: tonyhallett/artifacts-url-comments@v1.1.0
+      uses: tonyhallett/artifacts-url-comments@0965ff1a7ae03c5c1644d3c30f956effea4e05ef # v1.1.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
`artifact-links.yml` uses a third-party GitHub Action. This pull request reduces the attack vector introduced by it. This should probably be done in a similar way for all other third-party GitHub Actions being used.

### Changes made:

- Pin action to git hash, https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash
- Restrict permissions for the GITHUB_TOKEN, https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

### Mentions:
Thanks @TheAssassin