### PR TITLE
FIX: Bug in "negate" filter constraint attribute when loaded from Git

### DIFF
--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -968,7 +968,7 @@ static void format_one_filter_constraint(int preset_id, int constraint_id, struc
 		show_utf8(b, " rangemode=", mode, "");
 	}
 	if (constraint->negate)
-		put_format(b, " negate");
+		put_format(b, " negate=\"1\"");
 	std::string data = filter_constraint_data_to_string(constraint);
 	show_utf8(b, " data=", data.c_str(), "\n");
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
To filter presets using constraints with "negate" attribute, when loaded from Git (i.e cloud storage), throws a error. This is because "negate" attribute was saved without a value. Filter preset parser expects key/value pair. This fix add a default value "1" to "negate" attribute. This is the way used in SSRF, for example

### Changes made:
When save on Git, added a default value "1" to "negate" attribute

### Related issues:

### Additional information:
Error after load cloud storage:

![image](https://github.com/user-attachments/assets/e8929ebf-361a-47a4-a023-d423ea3def28)

### Release note:

### Documentation change:

### Mentions:
