### PR TITLE
fix copy/paste of dive-site

### DIFF
--- a/commands/command.cpp
+++ b/commands/command.cpp
@@ -267,9 +267,9 @@ int editDiveGuide(const QStringList &newList, bool currentDiveOnly)
 	return execute_edit(new EditDiveGuide(newList, currentDiveOnly));
 }
 
-void pasteDives(const dive *d, dive_components what)
+void pasteDives(const dive_paste_data &data)
 {
-	execute(new PasteDives(d, what));
+	execute(new PasteDives(data));
 }
 
 void replanDive(dive *d)

--- a/commands/command.h
+++ b/commands/command.h
@@ -13,6 +13,7 @@
 struct divecomputer;
 struct divelog;
 struct dive_components;
+struct dive_paste_data;
 struct dive_site;
 struct dive_trip;
 struct event;
@@ -95,7 +96,7 @@ int editDiveSiteNew(const QString &newName, bool currentDiveOnly);
 int editTags(const QStringList &newList, bool currentDiveOnly);
 int editBuddies(const QStringList &newList, bool currentDiveOnly);
 int editDiveGuide(const QStringList &newList, bool currentDiveOnly);
-void pasteDives(const dive *d, dive_components what);
+void pasteDives(const dive_paste_data &data);
 enum class EditProfileType {
 	ADD,
 	REMOVE,

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -287,34 +287,35 @@ public:
 
 // Fields we have to remember to undo paste
 struct PasteState {
-	dive *d;
-	dive_site *divesite;
-	std::string notes;
-	std::string diveguide;
-	std::string buddy;
-	std::string suit;
-	int rating;
-	int wavesize;
-	int visibility;
-	int current;
-	int surge;
-	int chill;
-	tag_list tags;
-	cylinder_table cylinders;
-	weightsystem_table weightsystems;
-	int number;
-	timestamp_t when;
+	dive &d;
+	std::optional<dive_site *> divesite;
+	std::optional<std::string> notes;
+	std::optional<std::string> diveguide;
+	std::optional<std::string> buddy;
+	std::optional<std::string> suit;
+	std::optional<int> rating;
+	std::optional<int> wavesize;
+	std::optional<int> visibility;
+	std::optional<int> current;
+	std::optional<int> surge;
+	std::optional<int> chill;
+	std::optional<tag_list> tags;
+	std::optional<cylinder_table> cylinders;
+	std::optional<weightsystem_table> weightsystems;
+	std::optional<int> number;
+	std::optional<timestamp_t> when;
 
-	PasteState(dive *d, const dive *data, dive_components what); // Read data from dive data for dive d
+	PasteState(dive &d, const dive_paste_data &data, std::vector<dive_site *> &changed_dive_sites);
 	~PasteState();
-	void swap(dive_components what); // Exchange values here and in dive
+	void swap(); // Exchange values here and in dive
 };
 
 class PasteDives : public Base {
-	dive_components what;
+	dive_paste_data data;
 	std::vector<PasteState> dives;
+	std::vector<dive_site *> dive_sites_changed;
 public:
-	PasteDives(const dive *d, dive_components what);
+	PasteDives(const dive_paste_data &data);
 private:
 	void undo() override;
 	void redo() override;

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -203,40 +203,6 @@ void copy_dive(const struct dive *s, struct dive *d)
 	d->invalidate_cache();
 }
 
-#define CONDITIONAL_COPY_STRING(_component) \
-	if (what._component)                \
-		d->_component = s->_component
-
-// copy elements, depending on bits in what that are set
-void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_components what, bool clear)
-{
-	if (clear)
-		d->clear();
-	CONDITIONAL_COPY_STRING(notes);
-	CONDITIONAL_COPY_STRING(diveguide);
-	CONDITIONAL_COPY_STRING(buddy);
-	CONDITIONAL_COPY_STRING(suit);
-	if (what.rating)
-		d->rating = s->rating;
-	if (what.visibility)
-		d->visibility = s->visibility;
-	if (what.divesite) {
-		unregister_dive_from_dive_site(d);
-		s->dive_site->add_dive(d);
-	}
-	if (what.tags)
-		d->tags = s->tags;
-	if (what.cylinders)
-		copy_cylinder_types(s, d);
-	if (what.weights)
-		d->weightsystems = s->weightsystems;
-	if (what.number)
-		d->number = s->number;
-	if (what.when)
-		d->when = s->when;
-}
-#undef CONDITIONAL_COPY_STRING
-
 /* copies all events from the given dive computer before a given time
    this is used when editing a dive in the planner to preserve the events
    of the old dive */

--- a/core/dive.h
+++ b/core/dive.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -146,24 +147,25 @@ struct dive_or_trip {
 extern void cylinder_renumber(struct dive &dive, int mapping[]);
 extern int same_gasmix_cylinder(const cylinder_t &cyl, int cylid, const struct dive *dive, bool check_unused);
 
-/* when selectively copying dive information, which parts should be copied? */
-struct dive_components {
-	unsigned int divesite : 1;
-	unsigned int notes : 1;
-	unsigned int diveguide : 1;
-	unsigned int buddy : 1;
-	unsigned int suit : 1;
-	unsigned int rating : 1;
-	unsigned int visibility : 1;
-	unsigned int wavesize : 1;
-	unsigned int current : 1;
-	unsigned int surge : 1;
-	unsigned int chill : 1;
-	unsigned int tags : 1;
-	unsigned int cylinders : 1;
-	unsigned int weights : 1;
-	unsigned int number : 1;
-	unsigned int when : 1;
+/* Data stored when copying a dive */
+struct dive_paste_data {
+	std::optional<uint32_t> divesite; // We save the uuid not a pointer, because the
+					  // user might copy and then delete the dive site.
+	std::optional<std::string> notes;
+	std::optional<std::string> diveguide;
+	std::optional<std::string> buddy;
+	std::optional<std::string> suit;
+	std::optional<int> rating;
+	std::optional<int> visibility;
+	std::optional<int> wavesize;
+	std::optional<int> current;
+	std::optional<int> surge;
+	std::optional<int> chill;
+	std::optional<tag_list> tags;
+	std::optional<cylinder_table> cylinders;
+	std::optional<weightsystem_table> weights;
+	std::optional<int> number;
+	std::optional<timestamp_t> when;
 };
 
 extern std::unique_ptr<dive> clone_make_first_dc(const struct dive &d, int dc_number);
@@ -179,7 +181,6 @@ struct membuffer;
 extern void save_one_dive_to_mb(struct membuffer *b, const struct dive &dive, bool anonymize);
 
 extern void copy_dive(const struct dive *s, struct dive *d);
-extern void selective_copy_dive(const struct dive *s, struct dive *d, struct dive_components what, bool clear);
 
 extern int legacy_format_o2pressures(const struct dive *dive, const struct divecomputer *dc);
 

--- a/core/range.h
+++ b/core/range.h
@@ -181,11 +181,21 @@ bool range_contains(const Range &v, const Element &item)
 
 // Insert into an already sorted range
 template<typename Range, typename Element, typename Comp>
-void range_insert_sorted(Range &v, Element &item, Comp &comp)
+void range_insert_sorted(Range &v, Element &item, Comp comp)
 {
 	auto it = std::lower_bound(std::begin(v), std::end(v), item,
 				   [&comp](auto &a, auto &b) { return comp(a, b) < 0; });
 	v.insert(it, std::move(item));
+}
+
+// Insert into an already sorted range, but don't add an item twice
+template<typename Range, typename Element, typename Comp>
+void range_insert_sorted_unique(Range &v, Element &item, Comp comp)
+{
+	auto it = std::lower_bound(std::begin(v), std::end(v), item,
+				   [&comp](auto &a, auto &b) { return comp(a, b) < 0; });
+	if (it == std::end(v) || comp(item, *it) != 0)
+		v.insert(it, std::move(item));
 }
 
 template<typename Range, typename Element>

--- a/desktop-widgets/CMakeLists.txt
+++ b/desktop-widgets/CMakeLists.txt
@@ -68,6 +68,8 @@ set(SUBSURFACE_INTERFACE
 	about.h
 	configuredivecomputerdialog.cpp
 	configuredivecomputerdialog.h
+	divecomponentselection.cpp
+	divecomponentselection.h
 	divelistview.cpp
 	divelistview.h
 	divelogexportdialog.cpp

--- a/desktop-widgets/divecomponentselection.cpp
+++ b/desktop-widgets/divecomponentselection.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "divecomponentselection.h"
+#include "core/dive.h"
+#include "core/divesite.h"
+#include "core/format.h"
+#include "core/qthelper.h" // for get_dive_date_string()
+#include "core/selection.h"
+#include "core/string-format.h"
+
+#include <QClipboard>
+#include <QShortcut>
+
+template <typename T>
+static void assign_paste_data(QCheckBox &checkbox, const T &src, std::optional<T> &dest)
+{
+	if (checkbox.isChecked())
+		dest = src;
+	else
+		dest = {};
+}
+
+template <typename T>
+static void set_checked(QCheckBox &checkbox, const std::optional<T> &v)
+{
+	checkbox.setChecked(v.has_value());
+}
+
+DiveComponentSelection::DiveComponentSelection(dive_paste_data &data, QWidget *parent) :
+	QDialog(parent), data(data)
+{
+	ui.setupUi(this);
+	set_checked(*ui.divesite, data.divesite);
+	set_checked(*ui.diveguide, data.diveguide);
+	set_checked(*ui.buddy, data.buddy);
+	set_checked(*ui.rating, data.rating);
+	set_checked(*ui.visibility, data.visibility);
+	set_checked(*ui.notes, data.notes);
+	set_checked(*ui.suit, data.suit);
+	set_checked(*ui.tags, data.tags);
+	set_checked(*ui.cylinders, data.cylinders);
+	set_checked(*ui.weights, data.weights);
+	set_checked(*ui.number, data.number);
+	set_checked(*ui.when, data.when);
+	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, &DiveComponentSelection::buttonClicked);
+	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_W), this);
+	connect(close, &QShortcut::activated, this, &DiveComponentSelection::close);
+	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
+	connect(quit, &QShortcut::activated, parent, &QWidget::close);
+}
+
+void DiveComponentSelection::buttonClicked(QAbstractButton *button)
+{
+	if (current_dive && ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
+		// Divesite is special, as we store the uuid not the pointer, since the
+		// user may delete the divesite after copying.
+		assign_paste_data(*ui.divesite, current_dive->dive_site ? current_dive->dive_site->uuid : uint32_t(), data.divesite);
+		assign_paste_data(*ui.diveguide, current_dive->diveguide, data.diveguide);
+		assign_paste_data(*ui.buddy, current_dive->buddy, data.buddy);
+		assign_paste_data(*ui.rating, current_dive->rating, data.rating);
+		assign_paste_data(*ui.visibility, current_dive->visibility, data.visibility);
+		assign_paste_data(*ui.notes, current_dive->notes, data.notes);
+		assign_paste_data(*ui.suit, current_dive->suit, data.suit);
+		assign_paste_data(*ui.tags, current_dive->tags, data.tags);
+		assign_paste_data(*ui.cylinders, current_dive->cylinders, data.cylinders);
+		assign_paste_data(*ui.weights, current_dive->weightsystems, data.weights);
+		assign_paste_data(*ui.number, current_dive->number, data.number);
+		assign_paste_data(*ui.when, current_dive->when, data.when);
+
+		std::string text;
+		if (data.divesite && current_dive->dive_site)
+			text += tr("Dive site: ").toStdString() + current_dive->dive_site->name + '\n';
+		if (data.diveguide)
+			text += tr("Dive guide: ").toStdString() + current_dive->diveguide + '\n';
+		if (data.buddy)
+			text += tr("Buddy: ").toStdString() + current_dive->buddy + '\n';
+		if (data.rating)
+			text += tr("Rating: ").toStdString() + std::string(current_dive->rating, '*') + '\n';
+		if (data.visibility)
+			text += tr("Visibility: ").toStdString() + std::string(current_dive->visibility, '*') + '\n';
+		if (data.wavesize)
+			text += tr("Wave size: ").toStdString() + std::string(current_dive->wavesize, '*') + '\n';
+		if (data.current)
+			text += tr("Current: ").toStdString() + std::string(current_dive->current, '*') + '\n';
+		if (data.surge)
+			text += tr("Surge: ").toStdString() + std::string(current_dive->surge, '*') + '\n';
+		if (data.chill)
+			text += tr("Chill: ").toStdString() + std::string(current_dive->chill, '*') + '\n';
+		if (data.notes)
+			text += tr("Notes:\n").toStdString() + current_dive->notes + '\n';
+		if (data.suit)
+			text += tr("Suit: ").toStdString() + current_dive->suit + '\n';
+		if (data.tags)
+			text += tr("Tags: ").toStdString() + taglist_get_tagstring(current_dive->tags) + '\n';
+		if (data.cylinders)
+			text += tr("Cylinders:\n").toStdString() + formatGas(current_dive).toStdString();
+		if (data.weights)
+			text += tr("Weights:\n").toStdString() + formatWeightList(current_dive).toStdString();
+		if (data.number)
+			text += tr("Dive number: ").toStdString() + casprintf_loc("%d", current_dive->number) + '\n';
+		if (data.when)
+			text += tr("Date / time: ").toStdString() + get_dive_date_string(current_dive->when).toStdString() + '\n';
+		QApplication::clipboard()->setText(QString::fromStdString(text));
+	}
+}

--- a/desktop-widgets/divecomponentselection.h
+++ b/desktop-widgets/divecomponentselection.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef DIVECOMPONENTSELECTION_H
+#define DIVECOMPONENTSELECTION_H
+
+#include "ui_divecomponentselection.h"
+
+struct dive_paste_data;
+
+class DiveComponentSelection : public QDialog {
+	Q_OBJECT
+public:
+	explicit DiveComponentSelection(dive_paste_data &data, QWidget *parent = nullptr);
+private
+slots:
+	void buttonClicked(QAbstractButton *button);
+
+private:
+	Ui::DiveComponentSelectionDialog ui;
+	dive_paste_data &data;
+};
+
+#endif

--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -38,6 +38,7 @@
 #include "core/settings/qPrefDisplay.h"
 
 #include "desktop-widgets/about.h"
+#include "desktop-widgets/divecomponentselection.h"
 #include "desktop-widgets/divelistview.h"
 #include "desktop-widgets/divelogexportdialog.h"
 #include "desktop-widgets/divelogimportdialog.h"
@@ -207,7 +208,6 @@ MainWindow::MainWindow() :
 #ifdef NO_USERMANUAL
 	ui.menuHelp->removeAction(ui.actionUserManual);
 #endif
-	memset(&what, 0, sizeof(what));
 
 	updateManager = new UpdateManager(this);
 	undoAction = Command::undoAction(this);
@@ -1424,13 +1424,13 @@ void MainWindow::on_copy_triggered()
 {
 	// open dialog to select what gets copied
 	// copy the displayed dive
-	DiveComponentSelection dialog(this, &copyPasteDive, &what);
+	DiveComponentSelection dialog(paste_data, this);
 	dialog.exec();
 }
 
 void MainWindow::on_paste_triggered()
 {
-	Command::pasteDives(&copyPasteDive, what);
+	Command::pasteDives(paste_data);
 }
 
 void MainWindow::on_actionFilterTags_triggered()

--- a/desktop-widgets/mainwindow.h
+++ b/desktop-widgets/mainwindow.h
@@ -203,8 +203,7 @@ private:
 	bool plannerStateClean();
 	void setupSocialNetworkMenu();
 	QDialog *findMovedImagesDialog;
-	struct dive copyPasteDive;
-	struct dive_components what;
+	dive_paste_data paste_data;
 	QStringList recentFiles;
 	QAction *actionsRecent[NUM_RECENT_FILES];
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -9,7 +9,6 @@
 #include <QAction>
 #include <QDesktopServices>
 #include <QToolTip>
-#include <QClipboard>
 #include <QCompleter>
 
 #include "core/file.h"
@@ -275,93 +274,6 @@ URLDialog::URLDialog(QWidget *parent) : QDialog(parent)
 QString URLDialog::url() const
 {
 	return ui.urlField->toPlainText();
-}
-
-#define COMPONENT_FROM_UI(_component) what->_component = ui._component->isChecked()
-#define UI_FROM_COMPONENT(_component) ui._component->setChecked(what->_component)
-
-DiveComponentSelection::DiveComponentSelection(QWidget *parent, struct dive *target, struct dive_components *_what) : targetDive(target)
-{
-	ui.setupUi(this);
-	what = _what;
-	UI_FROM_COMPONENT(divesite);
-	UI_FROM_COMPONENT(diveguide);
-	UI_FROM_COMPONENT(buddy);
-	UI_FROM_COMPONENT(rating);
-	UI_FROM_COMPONENT(visibility);
-	UI_FROM_COMPONENT(notes);
-	UI_FROM_COMPONENT(suit);
-	UI_FROM_COMPONENT(tags);
-	UI_FROM_COMPONENT(cylinders);
-	UI_FROM_COMPONENT(weights);
-	UI_FROM_COMPONENT(number);
-	UI_FROM_COMPONENT(when);
-	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, &DiveComponentSelection::buttonClicked);
-	QShortcut *close = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_W), this);
-	connect(close, &QShortcut::activated, this, &DiveComponentSelection::close);
-	QShortcut *quit = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q), this);
-	connect(quit, &QShortcut::activated, parent, &QWidget::close);
-}
-
-void DiveComponentSelection::buttonClicked(QAbstractButton *button)
-{
-	if (current_dive && ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole) {
-		COMPONENT_FROM_UI(divesite);
-		COMPONENT_FROM_UI(diveguide);
-		COMPONENT_FROM_UI(buddy);
-		COMPONENT_FROM_UI(rating);
-		COMPONENT_FROM_UI(visibility);
-		COMPONENT_FROM_UI(notes);
-		COMPONENT_FROM_UI(suit);
-		COMPONENT_FROM_UI(tags);
-		COMPONENT_FROM_UI(cylinders);
-		COMPONENT_FROM_UI(weights);
-		COMPONENT_FROM_UI(number);
-		COMPONENT_FROM_UI(when);
-		selective_copy_dive(current_dive, targetDive, *what, true);
-		QClipboard *clipboard = QApplication::clipboard();
-		QTextStream text;
-		QString cliptext;
-		text.setString(&cliptext);
-		if (what->divesite && current_dive->dive_site)
-			text << tr("Dive site: ") << QString::fromStdString(current_dive->dive_site->name) << "\n";
-		if (what->diveguide)
-			text << tr("Dive guide: ") << QString::fromStdString(current_dive->diveguide) << "\n";
-		if (what->buddy)
-			text << tr("Buddy: ") << QString::fromStdString(current_dive->buddy) << "\n";
-		if (what->rating)
-			text << tr("Rating: ") + QString("*").repeated(current_dive->rating) << "\n";
-		if (what->visibility)
-			text << tr("Visibility: ") + QString("*").repeated(current_dive->visibility) << "\n";
-		if (what->notes)
-			text << tr("Notes:\n") << QString::fromStdString(current_dive->notes) << "\n";
-		if (what->suit)
-			text << tr("Suit: ") << QString::fromStdString(current_dive->suit) << "\n";
-		if (what-> tags) {
-			text << tr("Tags: ");
-			for (const divetag *tag: current_dive->tags)
-				text << tag->name.c_str() << " ";
-			text << "\n";
-		}
-		if (what->cylinders) {
-			text << tr("Cylinders:\n");
-			for (auto [idx, cyl]: enumerated_range(current_dive->cylinders)) {
-				if (current_dive->is_cylinder_used(idx))
-					text << QString::fromStdString(cyl.type.description) << " "
-					     << QString::fromStdString(cyl.gasmix.name()) << "\n";
-			}
-		}
-		if (what->weights) {
-			text << tr("Weights:\n");
-			for (auto &ws: current_dive->weightsystems)
-				text << QString::fromStdString(ws.description) << ws.weight.grams / 1000 << "kg\n";
-		}
-		if (what->number)
-			text << tr("Dive number: ") << current_dive->number << "\n";
-		if (what->when)
-			text << tr("Date / time: ") << get_dive_date_string(current_dive->when) << "\n";
-		clipboard->setText(cliptext);
-	}
 }
 
 AddFilterPresetDialog::AddFilterPresetDialog(const QString &defaultName, QWidget *parent)

--- a/desktop-widgets/simplewidgets.h
+++ b/desktop-widgets/simplewidgets.h
@@ -7,7 +7,6 @@ class QAbstractButton;
 class QNetworkReply;
 class FilterModelBase;
 struct dive;
-struct dive_components;
 
 #include "core/units.h"
 #include <QWidget>
@@ -20,7 +19,6 @@ struct dive_components;
 #include "ui_shifttimes.h"
 #include "ui_shiftimagetimes.h"
 #include "ui_urldialog.h"
-#include "ui_divecomponentselection.h"
 #include "ui_listfilter.h"
 #include "ui_addfilterpreset.h"
 
@@ -100,20 +98,6 @@ public:
 	QString url() const;
 private:
 	Ui::URLDialog ui;
-};
-
-class DiveComponentSelection : public QDialog {
-	Q_OBJECT
-public:
-	explicit DiveComponentSelection(QWidget *parent, struct dive *target, struct dive_components *_what);
-private
-slots:
-	void buttonClicked(QAbstractButton *button);
-
-private:
-	Ui::DiveComponentSelectionDialog ui;
-	struct dive *targetDive;
-	struct dive_components *what;
 };
 
 class AddFilterPresetDialog : public QDialog {

--- a/mobile-widgets/qml/CopySettings.qml
+++ b/mobile-widgets/qml/CopySettings.qml
@@ -38,11 +38,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleDiveSite(false)
+				checked: manager.pasteDiveSite
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleDiveSite(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Notes")
@@ -50,11 +47,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleNotes(false)
+				checked: manager.pasteNotes
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleNotes(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Dive guide")
@@ -62,11 +56,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleDiveGuide(false)
+				checked: manager.pasteDiveGuide
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleDiveGuide(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Buddy")
@@ -74,11 +65,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleBuddy(false)
+				checked: manager.pasteBuddy
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleBuddy(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Suit")
@@ -86,11 +74,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleSuit(false)
+				checked: manager.pasteSuit
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleSuit(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Rating")
@@ -98,11 +83,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleRating(false)
+				checked: manager.pasteRating
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleRating(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Visibility")
@@ -110,11 +92,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleVisibility(false)
+				checked: manager.pasteVisibility
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleVisibility(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Tags")
@@ -122,11 +101,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleTags(false)
+				checked: manager.pasteTags
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleTags(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Cylinders")
@@ -134,11 +110,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleCylinders(false)
+				checked: manager.pasteCylinders
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleCylinders(true)
-				}
 			}
 			Controls.Label {
 				text: qsTr("Weights")
@@ -146,11 +119,8 @@ Kirigami.ScrollablePage {
 				Layout.preferredWidth: gridWidth * 0.75
 			}
 			SsrfSwitch {
-				checked: manager.toggleWeights(false)
+				checked: manager.pasteWeights
 				Layout.preferredWidth: gridWidth * 0.25
-				onClicked: {
-					manager.toggleWeights(true)
-				}
 			}
 		}
 

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -43,6 +43,17 @@ class QMLManager : public QObject {
 	Q_PROPERTY(QString progressMessage MEMBER m_progressMessage WRITE setProgressMessage NOTIFY progressMessageChanged)
 	Q_PROPERTY(bool btEnabled MEMBER m_btEnabled WRITE setBtEnabled NOTIFY btEnabledChanged)
 
+	Q_PROPERTY(bool pasteDiveSite MEMBER m_pasteDiveSite)
+	Q_PROPERTY(bool pasteNotes MEMBER m_pasteNotes)
+	Q_PROPERTY(bool pasteDiveGuide MEMBER m_pasteDiveGuide)
+	Q_PROPERTY(bool pasteBuddy MEMBER m_pasteBuddy)
+	Q_PROPERTY(bool pasteSuit MEMBER m_pasteSuit)
+	Q_PROPERTY(bool pasteRating MEMBER m_pasteRating)
+	Q_PROPERTY(bool pasteVisibility MEMBER m_pasteVisibility)
+	Q_PROPERTY(bool pasteTags MEMBER m_pasteTags)
+	Q_PROPERTY(bool pasteCylinders MEMBER m_pasteCylinders)
+	Q_PROPERTY(bool pasteWeights MEMBER m_pasteWeights)
+
 	Q_PROPERTY(QString DC_vendor READ DC_vendor WRITE DC_setVendor)
 	Q_PROPERTY(QString DC_product READ DC_product WRITE DC_setProduct)
 	Q_PROPERTY(QString DC_devName READ DC_devName WRITE DC_setDevName)
@@ -187,16 +198,6 @@ public slots:
 	void toggleDiveInvalid(int id);
 	void copyDiveData(int id);
 	void pasteDiveData(int id);
-	bool toggleDiveSite(bool toggle);
-	bool toggleNotes(bool toggle);
-	bool toggleDiveGuide(bool toggle);
-	bool toggleBuddy(bool toggle);
-	bool toggleSuit(bool toggle);
-	bool toggleRating(bool toggle);
-	bool toggleVisibility(bool toggle);
-	bool toggleTags(bool toggle);
-	bool toggleCylinders(bool toggle);
-	bool toggleWeights(bool toggle);
 	void undo();
 	void redo();
 	int addDive();
@@ -250,11 +251,21 @@ private:
 	void updateAllGlobalLists();
 	void updateHaveLocalChanges(bool status);
 
+	bool m_pasteDiveSite;
+	bool m_pasteNotes;
+	bool m_pasteDiveGuide;
+	bool m_pasteBuddy;
+	bool m_pasteSuit;
+	bool m_pasteRating;
+	bool m_pasteVisibility;
+	bool m_pasteTags;
+	bool m_pasteCylinders;
+	bool m_pasteWeights;
+
 	location_t getGps(QString &gps);
 	QString m_pluggedInDeviceName;
 	bool m_showNonDiveComputers;
-	struct dive *m_copyPasteDive = NULL;
-	struct dive_components what;
+	struct dive_paste_data paste_data;
 	QAction *undoAction;
 
 	bool verifyCredentials(QString email, QString password, QString pin);


### PR DESCRIPTION
The copy/pasting of dive-sites was fundamentally broken in at least two ways:

1) The dive-site pointer in struct dive was simply overwritten, which
   breaks internal consistency. Also, no dive-site changed signals where
   sent.

2) The copied dive-site was stored as a pointer in a struct dive. Thus,
   the user could copy a dive, then delete the dive-site and paste.
   This would lead to a dangling pointer and ultimately crash the
   application.

Fix this by storing the UUID of the dive-site, not a pointer. To do that, don't store a copy of the dive, but collect all the data in a `dive_paste_data` structure.
If the dive site has been deleted on paste, do nothing. Send the appropriate signals on pasting.

The mobile version had an additional bug: It kept a pointer to the dive to be copied, which might become stale by undo.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The copy & paste of dive-site data was horribly buggy. See commit message: Not only would it not properly unregister/register the dives from the dive site, it was also keeping potentially stale pointers (either to dive sites or to dives). A crash is not completely easy to pull of but can be done.

Try to fix this by implementing value semantics instead of using references (pointers). The end result is not particularly nice, but hopefully better than outright wrong.

I didn't test the mobile version, because I neither found the settings screen where one can configure copy/paste, nor the actual buttons to copy/paste. Weird.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Properly unregister/register dives on paste.
2) Use value semantics: store UUID of dive site, not pointer.
3) Copy dive data, don't keep a pointer to the copied dive on mobile.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Done.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Not needed.