### PR TITLE
snap: use a local `/etc/gitconfig`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,10 @@ confinement: strict
 base: core22
 adopt-info: subsurface
 
+layout:
+  /etc/gitconfig:
+    bind-file: $SNAP_DATA/gitconfig
+
 apps:
   subsurface:
     environment:


### PR DESCRIPTION
Fixes: #3465

### Describe the pull request:
- [x] Bug fix

### Pull request long description:
Use a local version of `/etc/gitconfig` in the snap, to avoid `libgit2` barfing at the system one.

### Changes made:
Lay a local `$SNAP_DATA/gitconfig` at `/etc/gitconfig`.

### Related issues:
#3465