### PR TITLE
core: add missing #include <tuple>

### DIFF
--- a/core/event.cpp
+++ b/core/event.cpp
@@ -4,6 +4,8 @@
 #include "eventtype.h"
 #include "subsurface-string.h"
 
+#include <tuple>
+
 event::event() : type(SAMPLE_EVENT_NONE), flags(0), value(0),
 	divemode(OC), hidden(false)
 {


### PR DESCRIPTION
Fixes gcc complaining about

```
/build/subsurface-beta-202408190452/core/event.cpp: In member function 'bool event::operator==(const event&) const': /build/subsurface-beta-202408190452/core/event.cpp:64:21: error: 'tie' is not a member of 'std'
   64 |         return std::tie(time.seconds, type, flags, value, name) ==
      |                     ^~~
/build/subsurface-beta-202408190452/core/event.cpp:6:1: note: 'std::tie' is defined in header '<tuple>'; did you forget to '#include <tuple>'?
    5 | #include "subsurface-string.h"
  +++ |+#include <tuple>
    6 |
/build/subsurface-beta-202408190452/core/event.cpp:65:21: error: 'tie' is not a member of 'std'
   65 |                std::tie(b.time.seconds, b.type, b.flags, b.value, b.name);
      |                     ^~~
/build/subsurface-beta-202408190452/core/event.cpp:65:21: note: 'std::tie' is defined in header '<tuple>'; did you forget to '#include <tuple>'?
```

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Add an include that gcc (on Debian bookworm) is complaining is missing

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
