### PR TITLE
correct re-plan menu label in documentation

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -4347,7 +4347,7 @@ The volumes of gases required for bailout can be found at the bottom of the *Div
 Normally, when a dive plan has been saved, it is accessible from the *Dive List*, like any
 other dive log. Within the *Dive List* there is no way to change a saved dive plan.
 To change a dive plan, select it on the *Dive List*. Then, in the main menu,
-select _Log ->  Re-plan dive_. This will open the selected dive plan within the dive planner,
+select _Log ->  Edit dive in planner_. This will open the selected dive plan within the dive planner,
 allowing changes to be made and saved as usual.
 
 In addition, there is the option "Save new". This keeps the original


### PR DESCRIPTION


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The (presumably) older label "Re-plan dive" in the Log menu was replaced with "Edit dive in planner", but the documentation section "Modifying an existing dive plan" was not updated.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) replace "Re-plan dive" with "Edit dive in planner"

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
None found _(should I create one?)_

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
_see above_

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
