### PR TITLE
desktop: reinstate WSInfoModel constructor

### DIFF
--- a/qt-models/weightsysteminfomodel.cpp
+++ b/qt-models/weightsysteminfomodel.cpp
@@ -31,3 +31,8 @@ int WSInfoModel::rowCount(const QModelIndex&) const
 {
 	return static_cast<int>(ws_info_table.size());
 }
+
+WSInfoModel::WSInfoModel(QObject *parent) : CleanerTableModel(parent)
+{
+	setHeaderDataStrings(QStringList() << tr("Description") << tr("kg"));
+}

--- a/qt-models/weightsysteminfomodel.h
+++ b/qt-models/weightsysteminfomodel.h
@@ -12,7 +12,7 @@ public:
 		DESCRIPTION,
 		GR
 	};
-	using CleanerTableModel::CleanerTableModel;
+	WSInfoModel(QObject *parent);
 
 	QVariant data(const QModelIndex &index, int role) const override;
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;


### PR DESCRIPTION
In 1af00703b367b060a0be450c3577e99dd30d86a4 the constructor of WSInfoModel was removed, not realizing that it contains a crucial call to setHeaderDataStrings().

Fixes #4294

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fixes #4294, for details see commit description.