### PR TITLE
Fix Suunto FIT file import dive duration mis-calculation

### DIFF
--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -272,6 +272,10 @@ void fixup_dc_duration(struct divecomputer &dc)
 		int time = sample.time.seconds;
 		int depth = sample.depth.mm;
 
+		/* Do we *have* a depth? */
+		if (depth < 0)
+			continue;
+
 		/* We ignore segments at the surface */
 		if (depth > SURFACE_THRESHOLD || lastdepth > SURFACE_THRESHOLD) {
 			duration += time - lasttime;


### PR DESCRIPTION
The Suunto FIT files end up creating a sample every second, but a lot of those samples with no depth information, marked as "depth.mm" being negative.

That doesn't end up being a problem for subsurface, _except_ that it really confuses our "dc_fixup_duration()" logic, and the dive duration ends up being completely nonsensical (generally roughly by a factor of five: every tenth sample has a depth, and we only count samples that "begin or end under water" as being relevant for the dive duration, so two out of the ten samples will count towards the dive time).

Saving the dive will then not save these invalid depths, so saving and reloading the dive ends up fixing the dive duration calculation.

The fix is trivial - we just ignore samples with negative depth in dc_fixup_duration().

The FIT file parser should probably be taught to not even bother sending empty samples to subsurface, but that's a separate cleanup.  This fixes the actual bad behavior.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
