### PR TITLE
Profile: Fix the Initial Gasmix.

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -103,7 +103,6 @@ struct dive {
 	bool likely_same(const struct dive &b) const;
 	bool is_cylinder_used(int idx) const;
 	bool is_cylinder_prot(int idx) const;
-	int explicit_first_cylinder(const struct divecomputer *dc) const;
 	int get_cylinder_index(const struct event &ev) const;
 	bool has_gaschange_event(const struct divecomputer *dc, int idx) const;
 	struct gasmix get_gasmix_from_event(const struct event &ev) const;

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -431,7 +431,7 @@ static void add_dive_to_deco(struct deco_state *ds, const struct dive &dive, boo
 
 		for (j = t0; j < t1; j++) {
 			int depth = interpolate(psample.depth.mm, sample.depth.mm, j - t0, t1 - t0);
-			auto gasmix = loop.next(j);
+			auto gasmix = loop.at(j).first;
 			add_segment(ds, dive.depth_to_bar(depth), gasmix, 1, sample.setpoint.mbar,
 				    loop_d.next(j), dive.sac,
 				    in_planner);

--- a/core/event.h
+++ b/core/event.h
@@ -68,12 +68,26 @@ public:
 class gasmix_loop {
 	const struct dive &dive;
 	const struct divecomputer &dc;
-	struct gasmix last;
+	bool first_run;
 	event_loop loop;
-	const struct event *ev;
+	const struct event *next_event;
+	int last_cylinder_index;
+	int last_time;
 public:
 	gasmix_loop(const struct dive &dive, const struct divecomputer &dc);
-	gasmix next(int time);
+	// Return the next cylinder index / gasmix from the list of gas switches
+	// and the time in seconds when this gas switch happened
+	// (including the potentially imaginary first gas switch to cylinder 0 / air)
+	std::pair<int, int> next_cylinder_index(); // -1 -> end
+	std::pair<gasmix, int> next(); // gasmix_invalid -> end
+
+	// Return the cylinder index / gasmix at a given time during the dive
+	// and the time in seconds when this switch to this gas happened
+	// (including the potentially imaginary first gas switch to cylinder 0 / air)
+	std::pair<int, int> cylinder_index_at(int time); // -1 -> end
+	std::pair<gasmix, int> at(int time); // gasmix_invalid -> end
+
+	bool has_next() const;
 };
 
 /* Get divemodes at increasing timestamps. */

--- a/core/gas.cpp
+++ b/core/gas.cpp
@@ -187,7 +187,9 @@ const char *gastype_name(enum gastype type)
 
 std::string gasmix::name() const
 {
-	if (gasmix_is_air(*this))
+	if (get_he(*this) < 0 || get_o2(*this) < 0)
+		return translate("gettextFromC", "invalid gas");
+	else if (gasmix_is_air(*this))
 		return translate("gettextFromC", "air");
 	else if (get_he(*this) == 0 && get_o2(*this) < 1000)
 		return format_string_std(translate("gettextFromC", "EAN%d"), (get_o2(*this) + 5) / 10);

--- a/profile-widget/divepercentageitem.cpp
+++ b/profile-widget/divepercentageitem.cpp
@@ -115,7 +115,7 @@ void DivePercentageItem::replot(const dive *d, const struct divecomputer *dc, co
 				continue;
 
 			double value = item.percentages[tissue];
-			struct gasmix gasmix = loop.next(sec);
+			struct gasmix gasmix = loop.at(sec).first;
 			int inert = get_n2(gasmix) + get_he(gasmix);
 			color = colorScale(value, inert);
 			if (nextX >= width)


### PR DESCRIPTION
Fix the initial gasmix that is shown in the tank bar of the profile.

Also add a meaningful gas name for gases with negative values for percentages.

@bstoeger: This is a side effect of the `event_loop` functionality introduced as part of #4198. In the case of an `event_loop("gasmix")` this does not take into account the edge case where there is no gaschange event at the very beginning of the dive, and the first gasmix is implicitly used as the starting gasmix. This happens for planned and manually added dives, but also for some dive computers. We are using the
same kind of loop in a number of other places in `core/profile.cpp`, `core/dive.cpp`, `core/gaspressures.cpp`, and `profile-widget/tankitem.cpp`, and I am wondering if we should be converting these to use `gasmix_loop` instead to avoid being bit by this special case?

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
