### PR TITLE
Fix sample times in dive merging

### DIFF
--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -1182,6 +1182,7 @@ merge_result dive_table::merge_dives(const struct dive &a_in, const struct dive 
 		 * Keep the dive site, but add the GPS data */
 		res.site->location = b->dive_site->location;
 	}
+	res.dive->dive_site = res.site;
 	fixup_dive(*res.dive);
 
 	return res;


### PR DESCRIPTION
Commit c27314d60 ("core: replace add_sample() by append_sample()") broke the dive computer interleaving when merging two dives: the sample merging (done by "merge_samples()") no longer took the offset between the two merged dives into account, and instead just blindly copied the samples from the second dive computer with no time offset.

The end result was a completely broken profile.

This adds back the sample offset.  It also takes the offset not from the difference in time of the two dives, but the difference in time of the dive computers.  That way we're not mixing up different times from different sources that aren't necessarily in sync (the time *difference* is hopefully the same, but still..).

The dive merging still messes up the dive location. That's some other bug.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
