### PR TITLE
Fix undo of dive merging with respect to changed location in dive site

### DIFF
--- a/commands/command_base.h
+++ b/commands/command_base.h
@@ -149,6 +149,12 @@ QVector<T> stdToQt(const std::vector<T> &v)
 #endif
 }
 
+template<typename T>
+std::vector<T> qtToStd(const QVector<T> &v)
+{
+	return std::vector<T>(v.begin(), v.end());
+}
+
 // We put everything in a namespace, so that we can shorten names without polluting the global namespace
 namespace Command {
 

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -922,7 +922,7 @@ MergeDives::MergeDives(const QVector <dive *> &dives)
 		return;
 	}
 
-	auto [d, trip, site] = divelog.dives.merge_dives(*dives[0], *dives[1], dives[1]->when - dives[0]->when, false);
+	auto [d, trip] = divelog.dives.merge_dives(*dives[0], *dives[1], dives[1]->when - dives[0]->when, false);
 
 	// Currently, the core code selects the dive -> this is not what we want, as
 	// we manually manage the selection post-command.
@@ -932,11 +932,10 @@ MergeDives::MergeDives(const QVector <dive *> &dives)
 	// Set the preferred dive trip, so that for subsequent merges the better trip can be selected
 	d->divetrip = trip;
 	for (int i = 2; i < dives.count(); ++i) {
-		auto [d2, trip, site] = divelog.dives.merge_dives(*d, *dives[i], dives[i]->when - d->when, false);
+		auto [d2, trip] = divelog.dives.merge_dives(*d, *dives[i], dives[i]->when - d->when, false);
 		d = std::move(d2);
 		// Set the preferred dive trip and site, so that for subsequent merges the better trip and site can be selected
 		d->divetrip = trip;
-		d->dive_site = site;
 	}
 
 	// The merged dive gets the number of the first dive with a non-zero number

--- a/commands/command_divelist.h
+++ b/commands/command_divelist.h
@@ -267,6 +267,7 @@ private:
 	void undoit() override;
 	void redoit() override;
 	bool workToBeDone() override;
+	void swapDivesite(); // Common code for undo and redo.
 
 	// For redo
 	// Add one and remove a batch of dives
@@ -284,6 +285,8 @@ private:
 
 	// For undo and redo
 	QVector<QPair<dive *, int>> divesToRenumber;
+	dive_site		*site;
+	location_t		location;
 };
 
 } // namespace Command

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -198,7 +198,7 @@ void dive::clear()
  * any impact on the source */
 void copy_dive(const struct dive *s, struct dive *d)
 {
-	/* simply copy things over, but then the dive cache. */
+	/* simply copy things over, but then clear the dive cache. */
 	*d = *s;
 	d->invalidate_cache();
 }

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -1175,14 +1175,13 @@ merge_result dive_table::merge_dives(const struct dive &a_in, const struct dive 
 	res.trip = get_preferred_trip(a, b);
 
 	/* we take the first dive site, unless it's empty */
-	res.site = a->dive_site && !a->dive_site->is_empty() ? a->dive_site : b->dive_site;
-	if (res.site && !res.site->has_gps_location() && b->dive_site && b->dive_site->has_gps_location()) {
+	res.dive->dive_site = a->dive_site && !a->dive_site->is_empty() ? a->dive_site : b->dive_site;
+	if (res.dive->dive_site && !res.dive->dive_site->has_gps_location() && b->dive_site && b->dive_site->has_gps_location()) {
 		/* we picked the first dive site and that didn't have GPS data, but the new dive has
 		 * GPS data (that could be a download from a GPS enabled dive computer).
 		 * Keep the dive site, but add the GPS data */
-		res.site->location = b->dive_site->location;
+		res.dive->dive_site->location = b->dive_site->location;
 	}
-	res.dive->dive_site = res.site;
 	fixup_dive(*res.dive);
 
 	return res;
@@ -1206,8 +1205,7 @@ struct std::unique_ptr<dive> dive_table::try_to_merge(const struct dive &a, cons
 	if (!a.likely_same(b))
 		return {};
 
-	auto [res, trip, site] = merge_dives(a, b, 0, prefer_downloaded);
-	res->dive_site = site; /* Caller has to call site->add_dive()! */
+	auto [res, trip] = merge_dives(a, b, 0, prefer_downloaded);
 	return std::move(res);
 }
 

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -18,7 +18,6 @@ int comp_dives_ptr(const struct dive *a, const struct dive *b);
 struct merge_result {
 	std::unique_ptr<struct dive> dive;
 	dive_trip *trip;
-	dive_site *site;
 };
 
 struct dive_table : public sorted_owning_table<dive, &comp_dives> {

--- a/core/divelist.h
+++ b/core/divelist.h
@@ -6,6 +6,7 @@
 #include "divesitetable.h"
 #include "units.h"
 #include <memory>
+#include <optional>
 
 struct dive;
 struct divelog;
@@ -17,7 +18,7 @@ int comp_dives_ptr(const struct dive *a, const struct dive *b);
 
 struct merge_result {
 	std::unique_ptr<struct dive> dive;
-	dive_trip *trip;
+	std::optional<location_t> set_location; // change location of dive site
 };
 
 struct dive_table : public sorted_owning_table<dive, &comp_dives> {
@@ -40,13 +41,14 @@ struct dive_table : public sorted_owning_table<dive, &comp_dives> {
 	std::array<std::unique_ptr<dive>, 2> split_divecomputer(const struct dive &src, int num) const;
 	std::array<std::unique_ptr<dive>, 2> split_dive(const struct dive &dive) const;
 	std::array<std::unique_ptr<dive>, 2> split_dive_at_time(const struct dive &dive, duration_t time) const;
-	merge_result merge_dives(const struct dive &a_in, const struct dive &b_in, int offset, bool prefer_downloaded) const;
+	merge_result merge_dives(const std::vector<dive *> &dives) const;
 	std::unique_ptr<dive> try_to_merge(const struct dive &a, const struct dive &b, bool prefer_downloaded) const;
 	bool has_dive(unsigned int deviceid, unsigned int diveid) const;
 	std::unique_ptr<dive> clone_delete_divecomputer(const struct dive &d, int dc_number);
 private:
 	int calculate_cns(struct dive &dive) const; // Note: writes into dive->cns
 	std::array<std::unique_ptr<dive>, 2> split_dive_at(const struct dive &dive, int a, int b) const;
+	std::unique_ptr<dive> merge_two_dives(const struct dive &a_in, const struct dive &b_in, int offset, bool prefer_downloaded) const;
 };
 
 void clear_dive_file_data();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

When dive-merging changed the location of a dive site, that was done outside of the undo system.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Not sure if necessary.