### PR TITLE
[TRIVIAL] planner: remove unnecessary strdup()

### DIFF
--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -145,7 +145,6 @@ void add_plan_to_notes(struct diveplan *diveplan, struct dive *dive, bool show_d
 
 		// TODO: avoid copy
 		dive->notes = buf;
-		dive->notes = strdup(buf.c_str());
 
 		return;
 	}


### PR DESCRIPTION
This leaks memory and was (probably unintentionally) introduced in 2d8e343221e3f0c89d459a29f603a92f9893ab70.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove what seems to be a rebase artifact.