### PR TITLE
Playing around: make unit types smarter

### DIFF
--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -204,7 +204,7 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 				put_format(&buf, "\\def\\%scyl%cmixO2{%.1f\\%%}\n", ssrf, 'a' + i, get_o2(cyl.gasmix)/10.0);
 				put_format(&buf, "\\def\\%scyl%cmixHe{%.1f\\%%}\n", ssrf, 'a' + i, get_he(cyl.gasmix)/10.0);
 				put_format(&buf, "\\def\\%scyl%cmixN2{%.1f\\%%}\n", ssrf, 'a' + i, (100.0 - (get_o2(cyl.gasmix)/10.0) - (get_he(cyl.gasmix)/10.0)));
-				delta_p.mbar += cyl.start.mbar - cyl.end.mbar;
+				delta_p += cyl.start - cyl.end;
 				put_format(&buf, "\\def\\%scyl%cstartpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.start.mbar, &unit)/1.0, ssrf);
 				put_format(&buf, "\\def\\%scyl%cendpress{%.1f\\%spressureunit}\n", ssrf, 'a' + i, get_pressure_units(cyl.end.mbar, &unit)/1.0, ssrf);
 				qty_cyl += 1;

--- a/commands/command_divelist.cpp
+++ b/commands/command_divelist.cpp
@@ -390,8 +390,8 @@ void DiveListBase::redo()
 AddDive::AddDive(std::unique_ptr<dive> d, bool autogroup, bool newNumber)
 {
 	setText(Command::Base::tr("add dive"));
-	d->maxdepth.mm = 0;
-	d->dcs[0].maxdepth.mm = 0;
+	d->maxdepth = 0_m;
+	d->dcs[0].maxdepth = 0_m;
 	divelog.dives.fixup_dive(*d);
 
 	// this only matters if undoit were called before redoit

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1260,8 +1260,8 @@ EditCylinder::EditCylinder(int index, cylinder_t cylIn, EditCylinderType typeIn,
 			cyl[i].cylinder_use = cylIn.cylinder_use;
 			break;
 		case EditCylinderType::PRESSURE:
-			cyl[i].start.mbar = cylIn.start.mbar;
-			cyl[i].end.mbar = cylIn.end.mbar;
+			cyl[i].start = cylIn.start;
+			cyl[i].end = cylIn.end;
 			break;
 		case EditCylinderType::GASMIX:
 			cyl[i].gasmix = cylIn.gasmix;

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -790,10 +790,6 @@ void PasteDives::redo()
 // ***** ReplanDive *****
 ReplanDive::ReplanDive(dive *source) : d(current_dive),
 	when(0),
-	maxdepth({0}),
-	meandepth({0}),
-	surface_pressure({0}),
-	duration({0}),
 	salinity(0)
 {
 	if (!d)
@@ -870,11 +866,7 @@ QString editProfileTypeToString(EditProfileType type, int count)
 }
 
 EditProfile::EditProfile(const dive *source, int dcNr, EditProfileType type, int count) : d(current_dive),
-	dcNr(dcNr),
-	maxdepth({0}),
-	meandepth({0}),
-	dcmaxdepth({0}),
-	duration({0})
+	dcNr(dcNr)
 {
 	const struct divecomputer *sdc = source->get_dc(dcNr);
 	if (!sdc)

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -306,7 +306,7 @@ void EditDuration::set(struct dive *d, int value) const
 {
 	d->dcs[0].duration.seconds = value;
 	d->duration = d->dcs[0].duration;
-	d->dcs[0].meandepth.mm = 0;
+	d->dcs[0].meandepth = 0_m;
 	d->dcs[0].samples.clear();
 	fake_dc(&d->dcs[0]);
 }
@@ -326,7 +326,7 @@ void EditDepth::set(struct dive *d, int value) const
 {
 	d->dcs[0].maxdepth.mm = value;
 	d->maxdepth = d->dcs[0].maxdepth;
-	d->dcs[0].meandepth.mm = 0;
+	d->dcs[0].meandepth = 0_m;
 	d->dcs[0].samples.clear();
 	fake_dc(&d->dcs[0]);
 }
@@ -673,10 +673,10 @@ PasteState::PasteState(dive &d, const dive_paste_data &data, std::vector<dive_si
 		}
 		for (size_t i = data.cylinders->size(); i < cylinders->size(); ++i) {
 			cylinder_t &cyl = (*cylinders)[i];
-			cyl.start.mbar = 0;
-			cyl.end.mbar = 0;
-			cyl.sample_start.mbar = 0;
-			cyl.sample_end.mbar = 0;
+			cyl.start = 0_bar;
+			cyl.end = 0_bar;
+			cyl.sample_start = 0_bar;
+			cyl.sample_end = 0_bar;
 			cyl.manually_added = true;
 		}
 	}
@@ -796,7 +796,7 @@ ReplanDive::ReplanDive(dive *source) : d(current_dive),
 		return;
 
 	// Fix source. Things might be inconsistent after modifying the profile.
-	source->maxdepth.mm = source->dcs[0].maxdepth.mm = 0;
+	source->maxdepth = source->dcs[0].maxdepth = 0_m;
 	divelog.dives.fixup_dive(*source);
 
 	when = source->when;

--- a/core/cochran.cpp
+++ b/core/cochran.cpp
@@ -677,7 +677,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 			cylinder_t cyl = default_cylinder(dive.get());
 			cyl.gasmix.o2.permille = (log[CMD_O2_PERCENT] / 256
 				+ log[CMD_O2_PERCENT + 1]) * 10;
-			cyl.gasmix.he.permille = 0;
+			cyl.gasmix.he = 0_percent;
 			dive->cylinders.add(0, std::move(cyl));
 		} else {
 			dc->model = "Commander";
@@ -686,7 +686,7 @@ static void cochran_parse_dive(const unsigned char *decode, unsigned mod,
 				cylinder_t cyl = default_cylinder(dive.get());
 				cyl.gasmix.o2.permille = (log[CMD_O2_PERCENT + g * 2] / 256
 					+ log[CMD_O2_PERCENT + g * 2 + 1]) * 10;
-				cyl.gasmix.he.permille = 0;
+				cyl.gasmix.he = 0_percent;
 				dive->cylinders.add(g, std::move(cyl));
 			}
 		}

--- a/core/datatrak.cpp
+++ b/core/datatrak.cpp
@@ -618,7 +618,7 @@ static void wlog_compl_parser(std::string &wl_mem, struct dive *dt_dive, int dco
 	 */
 	tmp = (int) two_bytes_to_int(runner[pos_weight + 1], runner[pos_weight]);
 	if (tmp != 0x7fff) {
-		weightsystem_t ws = { {tmp * 10}, translate("gettextFromC", "unknown"), false };
+		weightsystem_t ws = { {.grams = tmp * 10}, translate("gettextFromC", "unknown"), false };
 		dt_dive->weightsystems.push_back(std::move(ws));
 	}
 

--- a/core/datatrak.cpp
+++ b/core/datatrak.cpp
@@ -239,19 +239,19 @@ static char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive, struct 
 	read_bytes(1);
 	switch (tmp_1byte) {
 		case 1:
-			dt_dive->dcs[0].surface_pressure.mbar = 1013;
+			dt_dive->dcs[0].surface_pressure = 1_atm;
 			break;
 		case 2:
-			dt_dive->dcs[0].surface_pressure.mbar = 932;
+			dt_dive->dcs[0].surface_pressure = 932_mbar;
 			break;
 		case 3:
-			dt_dive->dcs[0].surface_pressure.mbar = 828;
+			dt_dive->dcs[0].surface_pressure = 828_mbar;
 			break;
 		case 4:
-			dt_dive->dcs[0].surface_pressure.mbar = 735;
+			dt_dive->dcs[0].surface_pressure = 735_mbar;
 			break;
 		default:
-			dt_dive->dcs[0].surface_pressure.mbar = 1013;
+			dt_dive->dcs[0].surface_pressure = 1_atm;
 	}
 
 	/*
@@ -336,9 +336,9 @@ static char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive, struct 
 		cylinder_t cyl;
 		cyl.type.size.mliter = tmp_2bytes * 10;
 		cyl.type.description = cyl_type_by_size(tmp_2bytes * 10);
-		cyl.start.mbar = 200000;
-		cyl.gasmix.he.permille = 0;
-		cyl.gasmix.o2.permille = 210;
+		cyl.start = 200_bar;
+		cyl.gasmix.he = 0_percent;
+		cyl.gasmix.o2 = 21_percent;
 		cyl.manually_added = true;
 		dt_dive->cylinders.push_back(std::move(cyl));
 	}
@@ -365,7 +365,7 @@ static char *dt_dive_parser(unsigned char *runner, struct dive *dt_dive, struct 
 	if (tmp_2bytes != 0x7fff)
 		dt_dive->watertemp.mkelvin = dt_dive->dcs[0].watertemp.mkelvin = C_to_mkelvin((double)(tmp_2bytes / 100));
 	else
-		dt_dive->watertemp.mkelvin = 0;
+		dt_dive->watertemp = 0_K;
 
 	/*
 	 * Air used in bar*100.

--- a/core/deco.cpp
+++ b/core/deco.cpp
@@ -495,8 +495,8 @@ void clear_vpmb_state(struct deco_state *ds)
 		ds->max_he_crushing_pressure[ci] = 0.0;
 	}
 	ds->max_ambient_pressure = 0;
-	ds->first_ceiling_pressure.mbar = 0;
-	ds->max_bottom_ceiling_pressure.mbar = 0;
+	ds->first_ceiling_pressure = 0_bar;
+	ds->max_bottom_ceiling_pressure = 0_bar;
 }
 
 void clear_deco(struct deco_state *ds, double surface_pressure, bool in_planner)

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2368,8 +2368,7 @@ bool dive::cache_is_valid() const
 
 pressure_t dive::get_surface_pressure() const
 {
-	return surface_pressure.mbar > 0 ? surface_pressure
-					 : pressure_t { .mbar = SURFACE_PRESSURE };
+	return surface_pressure.mbar > 0 ? surface_pressure : 1_atm;
 }
 
 /* This returns the conversion factor that you need to multiply
@@ -2387,17 +2386,14 @@ static double salinity_to_specific_weight(int salinity)
  * and add that to the surface pressure (or to 1013 if that's unknown) */
 static double calculate_depth_to_mbarf(int depth, pressure_t surface_pressure, int salinity)
 {
-	double specific_weight;
-	int mbar = surface_pressure.mbar;
-
-	if (!mbar)
-		mbar = SURFACE_PRESSURE;
+	if (!surface_pressure.mbar)
+		surface_pressure = 1_atm;
 	if (!salinity)
 		salinity = SEAWATER_SALINITY;
 	if (salinity < 500)
 		salinity += FRESHWATER_SALINITY;
-	specific_weight = salinity_to_specific_weight(salinity);
-	return mbar + depth * specific_weight;
+	double specific_weight = salinity_to_specific_weight(salinity);
+	return surface_pressure.mbar + depth * specific_weight;
 }
 
 int dive::depth_to_mbar(int depth) const
@@ -2452,7 +2448,7 @@ int dive::mbar_to_depth(int mbar) const
 		: dcs[0].surface_pressure;
 
 	if (!surface_pressure.mbar)
-		surface_pressure.mbar = SURFACE_PRESSURE;
+		surface_pressure = 1_atm;
 
 	return rel_mbar_to_depth(mbar - surface_pressure.mbar);
 }

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2248,7 +2248,7 @@ duration_t dive::totaltime() const
 				time = dc_time;
 		}
 	}
-	return { time };
+	return { .seconds = time };
 }
 
 timestamp_t dive::endtime() const
@@ -2367,7 +2367,7 @@ bool dive::cache_is_valid() const
 pressure_t dive::get_surface_pressure() const
 {
 	return surface_pressure.mbar > 0 ? surface_pressure
-					 : pressure_t { SURFACE_PRESSURE };
+					 : pressure_t { .mbar = SURFACE_PRESSURE };
 }
 
 /* This returns the conversion factor that you need to multiply
@@ -2459,13 +2459,13 @@ int dive::mbar_to_depth(int mbar) const
 depth_t dive::gas_mod(struct gasmix mix, pressure_t po2_limit, int roundto) const
 {
 	double depth = (double) mbar_to_depth(po2_limit.mbar * 1000 / get_o2(mix));
-	return depth_t { (int)lrint(depth / roundto) * roundto };
+	return depth_t { .mm = (int)lrint(depth / roundto) * roundto };
 }
 
 /* Maximum narcotic depth rounded to multiples of roundto mm */
 depth_t dive::gas_mnd(struct gasmix mix, depth_t end, int roundto) const
 {
-	pressure_t ppo2n2 { depth_to_mbar(end.mm) };
+	pressure_t ppo2n2 { .mbar = depth_to_mbar(end.mm) };
 
 	int maxambient = prefs.o2narcotic ?
 					(int)lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0))
@@ -2475,7 +2475,7 @@ depth_t dive::gas_mnd(struct gasmix mix, depth_t end, int roundto) const
 					:
 						// Actually: Infinity
 						1000000;
-	return depth_t { (int)lrint(((double)mbar_to_depth(maxambient)) / roundto) * roundto };
+	return depth_t { .mm = (int)lrint(((double)mbar_to_depth(maxambient)) / roundto) * roundto };
 }
 
 std::string dive::get_country() const
@@ -2677,7 +2677,7 @@ temperature_t dive::dc_watertemp() const
 	}
 	if (!nr)
 		return temperature_t();
-	return temperature_t{ static_cast<uint32_t>((sum + nr / 2) / nr) };
+	return temperature_t{ .mkelvin = static_cast<uint32_t>((sum + nr / 2) / nr) };
 }
 
 /*
@@ -2695,7 +2695,7 @@ temperature_t dive::dc_airtemp() const
 	}
 	if (!nr)
 		return temperature_t();
-	return temperature_t{ static_cast<uint32_t>((sum + nr / 2) / nr) };
+	return temperature_t{ .mkelvin = static_cast<uint32_t>((sum + nr / 2) / nr) };
 }
 
 /*
@@ -2782,5 +2782,5 @@ weight_t dive::total_weight() const
 	// TODO: implement addition for units.h types
 	return std::accumulate(weightsystems.begin(), weightsystems.end(), weight_t(),
 			       [] (weight_t w, const weightsystem_t &ws)
-			       { return weight_t{ w.grams + ws.weight.grams }; });
+			       { return weight_t{ .grams = w.grams + ws.weight.grams }; });
 }

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -554,7 +554,7 @@ static void match_standard_cylinder(cylinder_type_t &type)
 	default:
 		return;
 	}
-	type.description = format_string_std(fmt, (int)lrint(cuft));
+	type.description = format_string_std(fmt, int_cast<int>(cuft));
 }
 
 /*
@@ -2439,7 +2439,7 @@ int dive::rel_mbar_to_depth(int mbar) const
 
 	/* whole mbar gives us cm precision */
 	double specific_weight = salinity_to_specific_weight(salinity);
-	return (int)lrint(mbar / specific_weight);
+	return int_cast<int>(mbar / specific_weight);
 }
 
 int dive::mbar_to_depth(int mbar) const
@@ -2459,7 +2459,7 @@ int dive::mbar_to_depth(int mbar) const
 depth_t dive::gas_mod(struct gasmix mix, pressure_t po2_limit, int roundto) const
 {
 	double depth = (double) mbar_to_depth(po2_limit.mbar * 1000 / get_o2(mix));
-	return depth_t { .mm = (int)lrint(depth / roundto) * roundto };
+	return depth_t { .mm = int_cast<int>(depth / roundto) * roundto };
 }
 
 /* Maximum narcotic depth rounded to multiples of roundto mm */
@@ -2468,14 +2468,14 @@ depth_t dive::gas_mnd(struct gasmix mix, depth_t end, int roundto) const
 	pressure_t ppo2n2 { .mbar = depth_to_mbar(end.mm) };
 
 	int maxambient = prefs.o2narcotic ?
-					(int)lrint(ppo2n2.mbar / (1 - get_he(mix) / 1000.0))
+					int_cast<int>(ppo2n2.mbar / (1 - get_he(mix) / 1000.0))
 			      :
 					get_n2(mix) > 0 ?
-						(int)lrint(ppo2n2.mbar * N2_IN_AIR / get_n2(mix))
+						int_cast<int>(ppo2n2.mbar * N2_IN_AIR / get_n2(mix))
 					:
 						// Actually: Infinity
 						1000000;
-	return depth_t { .mm = (int)lrint(((double)mbar_to_depth(maxambient)) / roundto) * roundto };
+	return depth_t { .mm = int_cast<int>(((double)mbar_to_depth(maxambient)) / roundto) * roundto };
 }
 
 std::string dive::get_country() const

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -118,9 +118,9 @@ static void fill_samples_no_avg(std::vector<sample> &s, int max_d, int max_t, do
 		s[2].time.seconds = max_t - lrint(max_d / slope) - 180;
 		s[2].depth.mm = max_d;
 		s[3].time.seconds = max_t - lrint(5000 / slope) - 180;
-		s[3].depth.mm = 5000;
+		s[3].depth = 5_m;
 		s[4].time.seconds = max_t - lrint(5000 / slope);
-		s[4].depth.mm = 5000;
+		s[4].depth = 5_m;
 	}
 }
 

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -151,10 +151,9 @@ static int calculate_otu(const struct dive &dive)
 	double otu = 0.0;
 	const struct divecomputer *dc = &dive.dcs[0];
 	for (auto [psample, sample]: pairwise_range(dc->samples)) {
-		int t;
 		int po2i, po2f;
 		double pm;
-		t = sample.time.seconds - psample.time.seconds;
+		int t = (sample.time - psample.time).seconds;
 		// if there is sensor data use sensor[0]
 		if ((dc->divemode == CCR || dc->divemode == PSCR) && sample.o2sensor[0].mbar) {
 			po2i = psample.o2sensor[0].mbar;
@@ -215,7 +214,7 @@ static double calculate_cns_dive(const struct dive &dive)
 	double rate;
 	/* Calculate the CNS for each sample in this dive and sum them */
 	for (auto [psample, sample]: pairwise_range(dc->samples)) {
-		int t = sample.time.seconds - psample.time.seconds;
+		int t = (sample.time - psample.time).seconds;
 		int po2 = get_sample_o2(dive, dc, sample, psample);
 		/* Don't increase CNS when po2 below 500 matm */
 		if (po2 <= 500)

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -51,18 +51,18 @@ void dive_table::force_fixup_dive(struct dive &d) const
 	duration_t old_duration = d.duration;
 	std::vector<start_end_pressure> old_pressures(d.cylinders.size());
 
-	d.maxdepth.mm = 0;
-	dc->maxdepth.mm = 0;
-	d.watertemp.mkelvin = 0;
-	dc->watertemp.mkelvin = 0;
-	d.duration.seconds = 0;
-	d.maxtemp.mkelvin = 0;
-	d.mintemp.mkelvin = 0;
+	d.maxdepth = 0_m;
+	dc->maxdepth = 0_m;
+	d.watertemp = 0_K;
+	dc->watertemp = 0_K;
+	d.duration = 0_sec;
+	d.maxtemp = 0_K;
+	d.mintemp = 0_K;
 	for (auto [i, cyl]: enumerated_range(d.cylinders)) {
 		old_pressures[i].start = cyl.start;
 		old_pressures[i].end = cyl.end;
-		cyl.start.mbar = 0;
-		cyl.end.mbar = 0;
+		cyl.start = 0_bar;
+		cyl.end = 0_bar;
 	}
 
 	fixup_dive(d);
@@ -95,7 +95,7 @@ std::unique_ptr<dive> dive_table::default_dive()
 {
 	auto d = std::make_unique<dive>();
 	d->when = time(nullptr) + gettimezoneoffset() + 3600;
-	d->dcs[0].duration.seconds = 40 * 60;
+	d->dcs[0].duration = 40_min;
 	d->dcs[0].maxdepth.mm = M_OR_FT(15, 45);
 	d->dcs[0].meandepth.mm = M_OR_FT(13, 39); // this creates a resonable looking safety stop
 	make_manually_added_dive_dc(&d->dcs[0]);

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -110,7 +110,7 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 			out << "\"MAX_TEMP\":\"" << (s.max_temp.mkelvin == 0 ? 0 : get_temperature_string(s.max_temp)) << "\",";
 			out << "},";
 			total_stats.selection_size += s.selection_size;
-			total_stats.total_time.seconds += s.total_time.seconds;
+			total_stats.total_time += s.total_time;
 		}
 		exportHTMLstatisticsTotal(out, &total_stats);
 	}

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -80,7 +80,7 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 
 	stats_summary stats = calculate_stats_summary(hes.selectedOnly);
 	total_stats.selection_size = 0;
-	total_stats.total_time.seconds = 0;
+	total_stats.total_time = 0_sec;
 
 	out << "divestat=[";
 	if (hes.yearlyStatistics) {

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -317,8 +317,8 @@ void reset_cylinders(struct dive *dive, bool track_gas)
 			cyl.depth = dive->gas_mod(cyl.gasmix, decopo2, M_OR_FT(3,10));
 		if (track_gas)
 			cyl.start.mbar = cyl.end.mbar = cyl.type.workingpressure.mbar;
-		cyl.gas_used.mliter = 0;
-		cyl.deco_gas_used.mliter = 0;
+		cyl.gas_used = 0_l;
+		cyl.deco_gas_used = 0_l;
 	}
 }
 
@@ -404,8 +404,8 @@ void add_default_cylinder(struct dive *d)
 	} else {
 		// roughly an AL80
 		cyl.type.description = translate("gettextFromC", "unknown");
-		cyl.type.size.mliter = 11100;
-		cyl.type.workingpressure.mbar = 207000;
+		cyl.type.size = 11100_ml;
+		cyl.type.workingpressure = 207_bar;
 	}
 	d->cylinders.add(0, std::move(cyl));
 	reset_cylinders(d, false);

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -182,7 +182,7 @@ volume_t cylinder_t::gas_volume(pressure_t p) const
 {
 	double bar = p.mbar / 1000.0;
 	double z_factor = gas_compressibility_factor(gasmix, bar);
-	return volume_t { .mliter = static_cast<int>(lrint(type.size.mliter * bar_to_atm(bar) / z_factor)) };
+	return volume_t { .mliter = int_cast<int>(type.size.mliter * bar_to_atm(bar) / z_factor) };
 }
 
 int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table &cylinders)
@@ -348,7 +348,7 @@ void copy_cylinder_types(const struct dive *s, struct dive *d)
 void fill_default_cylinder(const struct dive *dive, cylinder_t *cyl)
 {
 	const std::string &cyl_name = prefs.default_cylinder;
-	pressure_t pO2 = {.mbar = static_cast<int>(lrint(prefs.modpO2 * 1000.0))};
+	pressure_t pO2 = {.mbar = int_cast<int>(prefs.modpO2 * 1000.0)};
 
 	if (cyl_name.empty())
 		return;

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -112,9 +112,9 @@ void set_tank_info_data(std::vector<tank_info> &table, const std::string &name, 
 std::pair<volume_t, pressure_t> extract_tank_info(const struct tank_info &info)
 {
 	pressure_t working_pressure {
-		static_cast<int32_t>(info.bar != 0 ? info.bar * 1000 : psi_to_mbar(info.psi))
+		.mbar = static_cast<int32_t>(info.bar != 0 ? info.bar * 1000 : psi_to_mbar(info.psi))
 	};
-	volume_t size { 0 };
+	volume_t size;
 	if (info.ml != 0)
 		size.mliter = info.ml;
 	else if (working_pressure.mbar != 0)
@@ -128,7 +128,7 @@ std::pair<volume_t, pressure_t> get_tank_info_data(const std::vector<tank_info> 
 	auto it = std::find_if(table.begin(), table.end(), [&name](const tank_info &info)
 			       { return info.name == name; });
 	return it != table.end() ? extract_tank_info(*it)
-				 : std::make_pair(volume_t{0}, pressure_t{0});
+				 : std::make_pair(volume_t(), pressure_t());
 }
 
 void add_cylinder_description(const cylinder_type_t &type)
@@ -182,7 +182,7 @@ volume_t cylinder_t::gas_volume(pressure_t p) const
 {
 	double bar = p.mbar / 1000.0;
 	double z_factor = gas_compressibility_factor(gasmix, bar);
-	return volume_t { static_cast<int>(lrint(type.size.mliter * bar_to_atm(bar) / z_factor)) };
+	return volume_t { .mliter = static_cast<int>(lrint(type.size.mliter * bar_to_atm(bar) / z_factor)) };
 }
 
 int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table &cylinders)

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -283,7 +283,7 @@ static int display_to_base_unit(double f, enum filter_constraint_type type)
 	switch (desc->units) {
 	case FILTER_CONSTRAINT_NO_UNIT:
 	default:
-		return (int)lrint(f);
+		return int_cast<int>(f);
 	case FILTER_CONSTRAINT_LENGTH_UNIT:
 		return prefs.units.length == units::METERS ? lrint(f * 1000.0) : feet_to_mm(f);
 	case FILTER_CONSTRAINT_DURATION_UNIT:

--- a/core/gas.cpp
+++ b/core/gas.cpp
@@ -54,7 +54,7 @@ void sanitize_gasmix(struct gasmix &mix)
 			return;
 		/* 20.8% to 21% O2 is just air */
 		if (gasmix_is_air(mix)) {
-			mix.o2.permille = 0;
+			mix.o2 = 0_percent;
 			return;
 		}
 	}

--- a/core/gas.h
+++ b/core/gas.h
@@ -16,8 +16,8 @@ struct gasmix {
 	fraction_t he;
 	std::string name() const;
 };
-static const struct gasmix gasmix_invalid = { { -1 }, { -1 } };
-static const struct gasmix gasmix_air = { { 0 }, { 0 } };
+static const struct gasmix gasmix_invalid = { { .permille = -1 }, { .permille = -1 } };
+static const struct gasmix gasmix_air = { { .permille = 0 }, { .permille = 0 } };
 
 enum gastype {
 	GASTYPE_AIR,

--- a/core/gas.h
+++ b/core/gas.h
@@ -17,7 +17,7 @@ struct gasmix {
 	std::string name() const;
 };
 static const struct gasmix gasmix_invalid = { { .permille = -1 }, { .permille = -1 } };
-static const struct gasmix gasmix_air = { { .permille = 0 }, { .permille = 0 } };
+static const struct gasmix gasmix_air = { 0_percent, 0_percent };
 
 enum gastype {
 	GASTYPE_AIR,

--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -217,7 +217,7 @@ Thumbnailer::Thumbnail Thumbnailer::getVideoThumbnailFromStream(QDataStream &str
 	// is not repeated ad-nauseum for broken images.
 	if (numPics == 0 && prefs.extract_video_thumbnails) {
 		QMetaObject::invokeMethod(VideoFrameExtractor::instance(), "extract", Qt::AutoConnection,
-					  Q_ARG(QString, filename), Q_ARG(QString, filename), Q_ARG(duration_t, duration_t{(int32_t)duration}));
+					  Q_ARG(QString, filename), Q_ARG(QString, filename), Q_ARG(duration_t, duration_t{ .seconds = (int32_t)duration}));
 	}
 
 	// Currently, we support only one picture
@@ -231,7 +231,7 @@ Thumbnailer::Thumbnail Thumbnailer::getVideoThumbnailFromStream(QDataStream &str
 		res = videoImage; // No picture -> show dummy-icon
 	else
 		markVideoThumbnail(res); // We got an image -> place our video marker on top of it
-	return { res, MEDIATYPE_VIDEO, { (int32_t)duration } };
+	return { res, MEDIATYPE_VIDEO, { .seconds = (int32_t)duration } };
 }
 
 // Fetch a thumbnail from cache.

--- a/core/import-csv.cpp
+++ b/core/import-csv.cpp
@@ -519,10 +519,10 @@ int parse_txt_file(const char *filename, const char *csv, struct divelog *log)
 		{
 			cylinder_t cyl;
 			cyl.cylinder_use = OXYGEN;
-			cyl.type.size.mliter = 3000;
-			cyl.type.workingpressure.mbar = 200000;
+			cyl.type.size = 3_l;
+			cyl.type.workingpressure = 200_bar;
 			cyl.type.description = "3l Mk6";
-			cyl.gasmix.o2.permille = 1000;
+			cyl.gasmix.o2 = 100_percent;
 			cyl.manually_added = true;
 			cyl.bestmix_o2 = 0;
 			cyl.bestmix_he = 0;
@@ -532,8 +532,8 @@ int parse_txt_file(const char *filename, const char *csv, struct divelog *log)
 		{
 			cylinder_t cyl;
 			cyl.cylinder_use = DILUENT;
-			cyl.type.size.mliter = 3000;
-			cyl.type.workingpressure.mbar = 200000;
+			cyl.type.size = 3_l;
+			cyl.type.workingpressure = 200_bar;
 			cyl.type.description = "3l Mk6";
 			value = parse_mkvi_value(memtxt.data(), "Helium percentage");
 			he = atoi(value.c_str());

--- a/core/import-divinglog.cpp
+++ b/core/import-divinglog.cpp
@@ -171,7 +171,7 @@ static int divinglog_profile(void *param, int, char **data, char **)
 			 */
 			int val = atoi_n(ptr4, 3);
 			if (state->cur_sample->in_deco) {
-				state->cur_sample->ndl.seconds = 0;
+				state->cur_sample->ndl = 0_sec;
 				if (val)
 					state->cur_sample->tts.seconds = val * 60;
 			} else {

--- a/core/import-divinglog.cpp
+++ b/core/import-divinglog.cpp
@@ -309,7 +309,7 @@ static int divinglog_dive(void *param, int, char **data, char **)
 		state->cur_dive->watertemp.mkelvin = C_to_mkelvin(atol(data[9]));
 
 	if (data[10]) {
-		weightsystem_t ws = { { atoi(data[10]) * 1000 }, translate("gettextFromC", "unknown"), false };
+		weightsystem_t ws = { { .grams = atoi(data[10]) * 1000 }, translate("gettextFromC", "unknown"), false };
 		state->cur_dive->weightsystems.push_back(std::move(ws));
 	}
 

--- a/core/import-suunto.cpp
+++ b/core/import-suunto.cpp
@@ -316,7 +316,7 @@ static int dm5_cylinders(void *param, int, char **data, char **)
 		 * value is 0 (and using metric units). So we just use
 		 * the same 12 liters when size is not available */
 		if (permissive_strtod(data[6], NULL) == 0.0 && cyl->start.mbar)
-			cyl->type.size.mliter = 12000;
+			cyl->type.size = 12_l;
 		else
 			cyl->type.size.mliter = lrint((permissive_strtod(data[6], NULL)) * 1000);
 	}

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -160,7 +160,7 @@ static dc_status_t parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_
 		}
 	}
 	bool no_volume = true;
-	struct gasmix bottom_gas = { {1000}, {0} }; /* Default to pure O2, or air if there are no mixes defined */
+	struct gasmix bottom_gas = { { .permille = 1000}, {} }; /* Default to pure O2, or air if there are no mixes defined */
 	if (ngases == 0) {
 		bottom_gas = gasmix_air;
 	}

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -160,7 +160,7 @@ static dc_status_t parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_
 		}
 	}
 	bool no_volume = true;
-	struct gasmix bottom_gas = { { .permille = 1000}, {} }; /* Default to pure O2, or air if there are no mixes defined */
+	struct gasmix bottom_gas = { 100_percent, 0_percent }; /* Default to pure O2, or air if there are no mixes defined */
 	if (ngases == 0) {
 		bottom_gas = gasmix_air;
 	}
@@ -291,7 +291,7 @@ static dc_status_t parse_gasmixes(device_data_t *devdata, struct dive *dive, dc_
 					cyl.end.mbar = lrint(tank.endpressure * 1000);
 				} else if (devdata->vendor == "Uwatec") {
 					cyl.start.mbar = lrint(tank.beginpressure * 1000 + 30000);
-					cyl.end.mbar = 30000;
+					cyl.end = 30_bar;
 				}
 			}
 		}
@@ -850,7 +850,7 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 	/* Various libdivecomputer interface fixups */
 	if (dive->dcs[0].airtemp.mkelvin == 0 && first_temp_is_air && !dive->dcs[0].samples.empty()) {
 		dive->dcs[0].airtemp = dive->dcs[0].samples[0].temperature;
-		dive->dcs[0].samples[0].temperature.mkelvin = 0;
+		dive->dcs[0].samples[0].temperature = 0_K;
 	}
 
 	/* special case for bug in Tecdiving DiveComputer.eu

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -93,17 +93,17 @@ static weight_t get_weight(const char *line)
 
 static pressure_t get_airpressure(const char *line)
 {
-	return pressure_t { .mbar = static_cast<int32_t>(lrint(ascii_strtod(line, NULL))) };
+	return pressure_t { .mbar = int_cast<int32_t>(ascii_strtod(line, NULL)) };
 }
 
 static pressure_t get_pressure(const char *line)
 {
-	return pressure_t { .mbar = static_cast<int32_t>(lrint(1000 * ascii_strtod(line, NULL))) };
+	return pressure_t { .mbar = int_cast<int32_t>(1000 * ascii_strtod(line, NULL)) };
 }
 
 static o2pressure_t get_o2pressure(const char *line)
 {
-	return o2pressure_t { .mbar = static_cast<uint16_t>(lrint(1000 * ascii_strtod(line, NULL))) };
+	return o2pressure_t { .mbar = int_cast<uint16_t>(1000 * ascii_strtod(line, NULL)) };
 }
 
 static int get_salinity(const char *line)

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -667,8 +667,8 @@ static struct sample *new_sample(struct git_parser_state *state)
 	size_t num_samples = state->active_dc->samples.size();
 	if (num_samples >= 2) {
 		*sample = state->active_dc->samples[num_samples - 2];
-		sample->pressure[0].mbar = 0;
-		sample->pressure[1].mbar = 0;
+		sample->pressure[0] = 0_bar;
+		sample->pressure[1] = 0_bar;
 	} else {
 		sample->sensor[0] = sanitize_sensor_id(state->active_dive.get(), !state->o2pressure_sensor);
 		sample->sensor[1] = sanitize_sensor_id(state->active_dive.get(), state->o2pressure_sensor);

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -93,16 +93,17 @@ static weight_t get_weight(const char *line)
 
 static pressure_t get_airpressure(const char *line)
 {
-	pressure_t p;
-	p.mbar = lrint(ascii_strtod(line, NULL));
-	return p;
+	return pressure_t { .mbar = static_cast<int32_t>(lrint(ascii_strtod(line, NULL))) };
 }
 
 static pressure_t get_pressure(const char *line)
 {
-	pressure_t p;
-	p.mbar = lrint(1000 * ascii_strtod(line, NULL));
-	return p;
+	return pressure_t { .mbar = static_cast<int32_t>(lrint(1000 * ascii_strtod(line, NULL))) };
+}
+
+static o2pressure_t get_o2pressure(const char *line)
+{
+	return o2pressure_t { .mbar = static_cast<uint16_t>(lrint(1000 * ascii_strtod(line, NULL))) };
 }
 
 static int get_salinity(const char *line)
@@ -557,43 +558,35 @@ static void parse_sample_keyvalue(void *_sample, const char *key, const std::str
 	}
 
 	if (!strcmp(key, "po2")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->setpoint.mbar = p.mbar;
+		sample->setpoint = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor1")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[0].mbar = p.mbar;
+		sample->o2sensor[0] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor2")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[1].mbar = p.mbar;
+		sample->o2sensor[1] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor3")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[2].mbar = p.mbar;
+		sample->o2sensor[2] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor4")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[3].mbar = p.mbar;
+		sample->o2sensor[3] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor5")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[4].mbar = p.mbar;
+		sample->o2sensor[4] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "sensor6")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->o2sensor[5].mbar = p.mbar;
+		sample->o2sensor[5] = get_o2pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "o2pressure")) {
-		pressure_t p = get_pressure(value.c_str());
-		sample->pressure[1].mbar = p.mbar;
+		sample->pressure[1] = get_pressure(value.c_str());
 		return;
 	}
 	if (!strcmp(key, "heartbeat")) {

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -531,7 +531,7 @@ static bool parseASF(QFile &f, metadata *metadata)
 mediatype_t get_metadata(const char *filename_in, metadata *data)
 {
 	data->timestamp = 0;
-	data->duration.seconds = 0;
+	data->duration = 0_sec;
 	data->location.lat.udeg = 0;
 	data->location.lon.udeg = 0;
 

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -328,7 +328,7 @@ static void temperature(const char *buffer, temperature_t *temperature, struct p
 	/* temperatures outside -40C .. +70C should be ignored */
 	if (temperature->mkelvin < ZERO_C_IN_MKELVIN - 40000 ||
 	    temperature->mkelvin > ZERO_C_IN_MKELVIN + 70000)
-		temperature->mkelvin = 0;
+		*temperature = 0_K;
 }
 
 static void sampletime(const char *buffer, duration_t *time)
@@ -351,7 +351,7 @@ static void sampletime(const char *buffer, duration_t *time)
 		time->seconds = (hr * 60 + min) * 60 + sec;
 		break;
 	default:
-		time->seconds = 0;
+		*time = 0_sec;
 		report_info("Strange sample time reading %s", buffer);
 	}
 }
@@ -715,7 +715,7 @@ static void parse_libdc_deco(const char *buffer, struct sample *s)
 		s->in_deco = false;
 		// The time wasn't stoptime, it was ndl
 		s->ndl = s->stoptime;
-		s->stoptime.seconds = 0;
+		s->stoptime = 0_sec;
 	}
 }
 

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -678,7 +678,7 @@ static void eventtime(const char *buffer, duration_t *duration, struct parser_st
 {
 	sampletime(buffer, duration);
 	if (state->cur_sample)
-		duration->seconds += state->cur_sample->time.seconds;
+		*duration += state->cur_sample->time;
 }
 
 static void try_to_match_autogroup(const char *name, char *buf, struct parser_state *state)

--- a/core/parse.cpp
+++ b/core/parse.cpp
@@ -267,8 +267,7 @@ void dive_end(struct parser_state *state)
 	}
 	state->cur_dive.reset();
 	state->cur_dc = NULL;
-	state->cur_location.lat.udeg = 0;
-	state->cur_location.lon.udeg = 0;
+	state->cur_location = location_t();
 }
 
 void trip_start(struct parser_state *state)
@@ -350,8 +349,8 @@ void sample_start(struct parser_state *state)
 
 	if (dc->samples.size() > 1) {
 		*sample = dc->samples[dc->samples.size() - 2];
-		sample->pressure[0].mbar = 0;
-		sample->pressure[1].mbar = 0;
+		sample->pressure[0] = 0_bar;
+		sample->pressure[1] = 0_bar;
 	} else {
 		sample->sensor[0] = sanitize_sensor_id(state->cur_dive.get(), !state->o2pressure_sensor);
 		sample->sensor[1] = sanitize_sensor_id(state->cur_dive.get(), state->o2pressure_sensor);

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -201,7 +201,7 @@ static void create_dive_from_plan(struct diveplan &diveplan, struct dive *dive, 
 	cylinder_t *cyl;
 	int oldpo2 = 0;
 	int lasttime = 0, last_manual_point = 0;
-	depth_t lastdepth = {.mm = 0};
+	depth_t lastdepth;
 	int lastcylid;
 	enum divemode_t type = dc->divemode;
 
@@ -305,7 +305,7 @@ divedatapoint::divedatapoint(int time_incr, int depth, int cylinderid, int po2, 
 	time(time_incr),
 	depth{ .mm = depth },
 	cylinderid(cylinderid),
-	minimum_gas{ .mbar = 0 },
+	minimum_gas = 0_bar;
 	setpoint(po2),
 	entered(entered),
 	divemode(OC)
@@ -654,7 +654,7 @@ std::vector<decostop> plan(struct deco_state *ds, struct diveplan &diveplan, str
 	}
 
 	clear_deco(ds, dive->surface_pressure.mbar / 1000.0, true);
-	ds->max_bottom_ceiling_pressure.mbar = ds->first_ceiling_pressure.mbar = 0;
+	ds->max_bottom_ceiling_pressure = ds->first_ceiling_pressure = 0_bar;
 	create_dive_from_plan(diveplan, dive, dc, is_planner);
 
 	// Do we want deco stop array in metres or feet?

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -185,12 +185,12 @@ static void update_cylinder_pressure(struct dive *d, int old_depth, int new_dept
 		return;
 	mean_depth.mm = (old_depth + new_depth) / 2;
 	gas_used.mliter = lrint(d->depth_to_atm(mean_depth.mm) * sac / 60 * duration * factor / 1000);
-	cyl->gas_used.mliter += gas_used.mliter;
+	cyl->gas_used += gas_used;
 	if (in_deco)
-		cyl->deco_gas_used.mliter += gas_used.mliter;
+		cyl->deco_gas_used += gas_used;
 	if (cyl->type.size.mliter) {
 		delta_p.mbar = lrint(gas_used.mliter * 1000.0 / cyl->type.size.mliter * gas_compressibility_factor(cyl->gasmix, cyl->end.mbar / 1000.0));
-		cyl->end.mbar -= delta_p.mbar;
+		cyl->end -= delta_p;
 	}
 }
 

--- a/core/planner.h
+++ b/core/planner.h
@@ -39,7 +39,7 @@ struct diveplan {
 	diveplan &operator=(diveplan &&) = default;
 
 	timestamp_t when = 0;
-	int surface_pressure = 0; /* mbar */
+	pressure_t surface_pressure;
 	int bottomsac = 0;	/* ml/min */
 	int decosac = 0;	  /* ml/min */
 	int salinity = 0;

--- a/core/pref.cpp
+++ b/core/pref.cpp
@@ -41,7 +41,7 @@ preferences::preferences() :
 	ascratestops(9000 / 60),
 	ascrate50(9000 / 60),
 	ascrate75(9000 / 60),
-	bestmixend({ .mm = 30'000 }),
+	bestmixend(30_m),
 	bottompo2(1400),
 	bottomsac(20000),
 	decopo2(1600),

--- a/core/pref.cpp
+++ b/core/pref.cpp
@@ -41,7 +41,7 @@ preferences::preferences() :
 	ascratestops(9000 / 60),
 	ascrate50(9000 / 60),
 	ascrate75(9000 / 60),
-	bestmixend({ 30000 }),
+	bestmixend({ .mm = 30'000 }),
 	bottompo2(1400),
 	bottomsac(20000),
 	decopo2(1600),

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1504,8 +1504,8 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 					const cylinder_t *cyl = d->get_cylinder(cylinder_index);
 
 					// TODO: Implement addition/subtraction on units.h types
-					volumes_used[cylinder_index] += cyl->gas_volume((pressure_t){ last_pressures[cylinder_index] }).mliter -
-									cyl->gas_volume((pressure_t){ next_pressure }).mliter;
+					volumes_used[cylinder_index] += cyl->gas_volume((pressure_t){ .mbar = last_pressures[cylinder_index] }).mliter -
+									cyl->gas_volume((pressure_t){ .mbar = next_pressure }).mliter;
 				}
 
 				// check if the gas in this cylinder is being used

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -111,7 +111,7 @@ static int get_local_sac(struct plot_info &pi, int idx1, int idx2, struct dive *
 	struct plot_data &entry1 = pi.entry[idx1];
 	struct plot_data &entry2 = pi.entry[idx2];
 	int duration = entry2.sec - entry1.sec;
-	int depth, airuse;
+	int depth;
 	pressure_t a, b;
 	double atm;
 
@@ -128,11 +128,10 @@ static int get_local_sac(struct plot_info &pi, int idx1, int idx2, struct dive *
 
 	cyl = dive->get_cylinder(index);
 
-	// TODO: Implement addition/subtraction on units.h types
-	airuse = cyl->gas_volume(a).mliter - cyl->gas_volume(b).mliter;
+	volume_t airuse = cyl->gas_volume(a) - cyl->gas_volume(b);
 
 	/* milliliters per minute */
-	return lrint(airuse / atm * 60 / duration);
+	return lrint(airuse.mliter / atm * 60 / duration);
 }
 
 static velocity_t velocity(int speed)
@@ -471,7 +470,7 @@ static int sac_between(const struct dive *dive, const struct plot_info &pi, int 
 		return 0;
 
 	/* Get airuse for the set of cylinders over the range */
-	int airuse = 0;
+	volume_t airuse;
 	for (int i = 0; i < pi.nr_cylinders; i++) {
 		pressure_t a, b;
 
@@ -482,11 +481,11 @@ static int sac_between(const struct dive *dive, const struct plot_info &pi, int 
 		b.mbar = get_plot_pressure(pi, last, i);
 		const cylinder_t *cyl = dive->get_cylinder(i);
 		// TODO: Implement addition/subtraction on units.h types
-		int cyluse = cyl->gas_volume(a).mliter - cyl->gas_volume(b).mliter;
-		if (cyluse > 0)
+		volume_t cyluse = cyl->gas_volume(a) - cyl->gas_volume(b);
+		if (cyluse.mliter > 0)
 			airuse += cyluse;
 	}
-	if (!airuse)
+	if (!airuse.mliter)
 		return 0;
 
 	/* Calculate depthpressure integrated over time */
@@ -505,7 +504,7 @@ static int sac_between(const struct dive *dive, const struct plot_info &pi, int 
 	pressuretime /= 60;
 
 	/* SAC = mliter per minute */
-	return lrint(airuse / pressuretime);
+	return lrint(airuse.mliter / pressuretime);
 }
 
 /* Is there pressure data for all gases? */
@@ -1168,13 +1167,13 @@ static void fill_o2_values(const struct dive *dive, const struct divecomputer *d
 		if (dc->divemode == CCR || (dc->divemode == PSCR && dc->no_o2sensors)) {
 			if (i == 0) { // For 1st iteration, initialise the last_sensor values
 				for (j = 0; j < dc->no_o2sensors; j++)
-					last_sensor[j].mbar = entry.o2sensor[j].mbar;
+					last_sensor[j] = entry.o2sensor[j];
 			} else { // Now re-insert the missing oxygen pressure values
 				for (j = 0; j < dc->no_o2sensors; j++)
 					if (entry.o2sensor[j].mbar)
-						last_sensor[j].mbar = entry.o2sensor[j].mbar;
+						last_sensor[j] = entry.o2sensor[j];
 					else
-						entry.o2sensor[j].mbar = last_sensor[j].mbar;
+						entry.o2sensor[j] = last_sensor[j];
 			} // having initialised the empty o2 sensor values for this point on the profile,
 			amb_pressure.mbar = dive->depth_to_mbar(entry.depth);
 			o2pressure.mbar = calculate_ccr_po2(entry, dc); // ...calculate the po2 based on the sensor data
@@ -1467,7 +1466,7 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 
 	int last_sec = start.sec;
 
-	volume_t cylinder_volume = { .mliter = 0, };
+	volume_t cylinder_volume;
 	std::vector<int> start_pressures(pi.nr_cylinders, 0);
 	std::vector<int> last_pressures(pi.nr_cylinders, 0);
 	std::vector<int> bar_used(pi.nr_cylinders, 0);
@@ -1504,8 +1503,8 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 					const cylinder_t *cyl = d->get_cylinder(cylinder_index);
 
 					// TODO: Implement addition/subtraction on units.h types
-					volumes_used[cylinder_index] += cyl->gas_volume((pressure_t){ .mbar = last_pressures[cylinder_index] }).mliter -
-									cyl->gas_volume((pressure_t){ .mbar = next_pressure }).mliter;
+					volumes_used[cylinder_index] += (cyl->gas_volume((pressure_t){ .mbar = last_pressures[cylinder_index] }) -
+									 cyl->gas_volume((pressure_t){ .mbar = next_pressure })).mliter;
 				}
 
 				// check if the gas in this cylinder is being used
@@ -1561,7 +1560,7 @@ std::vector<std::string> compare_samples(const struct dive *d, const struct plot
 				if (cylinder_volume.mliter && cylinder_volume.mliter != cyl->type.size.mliter) {
 					cylindersizes_are_identical = false;
 				} else {
-					cylinder_volume.mliter = cyl->type.size.mliter;
+					cylinder_volume = cyl->type.size;
 				}
 			} else {
 				sac_is_determinable = false;

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -209,7 +209,6 @@ static void check_setpoint_events(const struct dive *, const struct divecomputer
 {
 	size_t i = 0;
 	pressure_t setpoint;
-	setpoint.mbar = 0;
 
 	event_loop loop("SP change", *dc);
 	bool found = false;
@@ -848,7 +847,7 @@ static void calculate_deco_information(struct deco_state *ds, const struct deco_
 
 	if (!in_planner) {
 		ds->deco_time = 0;
-		ds->first_ceiling_pressure.mbar = 0;
+		ds->first_ceiling_pressure = 0_bar;
 	} else {
 		ds->deco_time = planner_ds->deco_time;
 		ds->first_ceiling_pressure = planner_ds->first_ceiling_pressure;
@@ -1179,7 +1178,7 @@ static void fill_o2_values(const struct dive *dive, const struct divecomputer *d
 			o2pressure.mbar = calculate_ccr_po2(entry, dc); // ...calculate the po2 based on the sensor data
 			entry.o2pressure.mbar = std::min(o2pressure.mbar, amb_pressure.mbar);
 		} else {
-			entry.o2pressure.mbar = 0; // initialise po2 to zero for dctype = OC
+			entry.o2pressure = 0_bar; // initialise po2 to zero for dctype = OC
 		}
 	}
 }

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1293,10 +1293,11 @@ fraction_t string_to_fraction(const char *str)
 	/*
 	 * Don't permit values less than zero or greater than 100%
 	 */
+	// TODO: use std::clamp() once we have comparison on unit types
 	if (fraction.permille < 0)
-		fraction.permille = 0;
+		fraction = 0_percent;
 	else if (fraction.permille > 1000)
-		fraction.permille = 1000;
+		fraction = 100_percent;
 	return fraction;
 }
 

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -786,33 +786,6 @@ int parseTemperatureToMkelvin(const QString &text)
 	return mkelvin;
 }
 
-int parseWeightToGrams(const QString &text)
-{
-	int grams;
-	QString numOnly = text;
-	numOnly.replace(",", ".").remove(QRegularExpression("[^0-9.]"));
-	if (numOnly.isEmpty())
-		return 0;
-	double number = numOnly.toDouble();
-	if (text.contains(gettextFromC::tr("kg"), Qt::CaseInsensitive)) {
-		grams = lrint(number * 1000);
-	} else if (text.contains(gettextFromC::tr("lbs"), Qt::CaseInsensitive)) {
-		grams = lbs_to_grams(number);
-	} else {
-		switch (prefs.units.weight) {
-		case units::KG:
-			grams = lrint(number * 1000);
-			break;
-		case units::LBS:
-			grams = lbs_to_grams(number);
-			break;
-		default:
-			grams = 0;
-		}
-	}
-	return grams;
-}
-
 int parsePressureToMbar(const QString &text)
 {
 	int mbar;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -69,7 +69,6 @@ timestamp_t dateTimeToTimestamp(const QDateTime &t);
 int parseDurationToSeconds(const QString &text);
 int parseLengthToMm(const QString &text);
 int parseTemperatureToMkelvin(const QString &text);
-int parseWeightToGrams(const QString &text);
 int parsePressureToMbar(const QString &text);
 int parseGasMixO2(const QString &text);
 int parseGasMixHE(const QString &text);

--- a/core/sample.h
+++ b/core/sample.h
@@ -12,7 +12,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 {                                     // --------- -----  -----    -----               -----------
 	duration_t time;                  // int32_t    4  seconds  (0-34 yrs)             elapsed dive time up to this sample
 	duration_t stoptime;              // int32_t    4  seconds  (0-34 yrs)             time duration of next deco stop
-	duration_t ndl = { -1 };          // int32_t    4  seconds  (-1 no val, 0-34 yrs)  time duration before no-deco limit
+	duration_t ndl = { .seconds = -1 };// int32_t    4  seconds  (-1 no val, 0-34 yrs)  time duration before no-deco limit
 	duration_t tts;                   // int32_t    4  seconds  (0-34 yrs)             time duration to reach the surface
 	duration_t rbt;                   // int32_t    4  seconds  (0-34 yrs)             remaining bottom time
 	depth_t depth;                    // int32_t    4    mm     (0-2000 km)            dive depth of this sample
@@ -21,7 +21,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	pressure_t pressure[MAX_SENSORS]; // int32_t  2x4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
 	o2pressure_t o2sensor[MAX_O2_SENSORS];// uint16_t 6x2    mbar   (0-65 bar)             Up to 6 PO2 sensor values (rebreather)
-	bearing_t bearing = { -1 };       // int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
+	bearing_t bearing = { .degrees = -1 };// int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
 	int16_t sensor[MAX_SENSORS] = {}; // int16_t  2x2  sensorID (0-16k)                ID of cylinder pressure sensor
 	uint16_t cns = 0;                 // uint16_t   2     %     (0-64k %)              cns% accumulated
 	uint8_t heartbeat = 0;            // uint8_t    1  beats/m  (0-255)                heart rate measurement

--- a/core/statistics.cpp
+++ b/core/statistics.cpp
@@ -260,7 +260,7 @@ std::vector<volume_t> get_gas_used(struct dive *dive)
 		end = cyl.end.mbar ? cyl.end : cyl.sample_end;
 		// TODO: Implement addition/subtraction on units.h types
 		if (end.mbar && start.mbar > end.mbar)
-			gases[idx].mliter = cyl.gas_volume(start).mliter - cyl.gas_volume(end).mliter;
+			gases[idx] = cyl.gas_volume(start) - cyl.gas_volume(end);
 		else
 			gases[idx].mliter = 0;
 	}
@@ -291,8 +291,8 @@ std::pair<volume_t, volume_t> selected_dives_gas_parts()
 		for (auto &gas: get_gas_used(d.get())) {
 			if (gas.mliter) {
 				auto [o2, he] = get_gas_parts(d->get_cylinder(j)->gasmix, gas, O2_IN_AIR);
-				o2_tot.mliter += o2.mliter;
-				he_tot.mliter += he.mliter;
+				o2_tot += o2;
+				he_tot += he;
 			}
 			j++;
 		}

--- a/core/statistics.cpp
+++ b/core/statistics.cpp
@@ -275,8 +275,8 @@ static std::pair<volume_t, volume_t> get_gas_parts(struct gasmix mix, volume_t v
 	if (gasmix_is_air(mix))
 		return { volume_t() , volume_t() };
 
-	volume_t air { .mliter = (int)lrint(((double)vol.mliter * get_n2(mix)) / (1000 - o2_in_topup)) };
-	volume_t he { .mliter = (int)lrint(((double)vol.mliter * get_he(mix)) / 1000.0) };
+	volume_t air { .mliter = int_cast<int>(((double)vol.mliter * get_n2(mix)) / (1000 - o2_in_topup)) };
+	volume_t he { .mliter = int_cast<int>(((double)vol.mliter * get_he(mix)) / 1000.0) };
 	volume_t o2 { .mliter = vol.mliter - he.mliter - air.mliter };
 	return std::make_pair(o2, he);
 }

--- a/core/statistics.cpp
+++ b/core/statistics.cpp
@@ -275,9 +275,9 @@ static std::pair<volume_t, volume_t> get_gas_parts(struct gasmix mix, volume_t v
 	if (gasmix_is_air(mix))
 		return { volume_t() , volume_t() };
 
-	volume_t air = { (int)lrint(((double)vol.mliter * get_n2(mix)) / (1000 - o2_in_topup)) };
-	volume_t he = { (int)lrint(((double)vol.mliter * get_he(mix)) / 1000.0) };
-	volume_t o2 = { vol.mliter - he.mliter - air.mliter };
+	volume_t air { .mliter = (int)lrint(((double)vol.mliter * get_n2(mix)) / (1000 - o2_in_topup)) };
+	volume_t he { .mliter = (int)lrint(((double)vol.mliter * get_he(mix)) / 1000.0) };
+	volume_t o2 { .mliter = vol.mliter - he.mliter - air.mliter };
 	return std::make_pair(o2, he);
 }
 

--- a/core/statistics.cpp
+++ b/core/statistics.cpp
@@ -21,7 +21,7 @@
 
 static void process_temperatures(const struct dive &dp, stats_t &stats)
 {
-	temperature_t min_temp, mean_temp, max_temp = {.mkelvin = 0};
+	temperature_t min_temp, mean_temp, max_temp;
 
 	max_temp.mkelvin = dp.maxtemp.mkelvin;
 	if (max_temp.mkelvin && (!stats.max_temp.mkelvin || max_temp.mkelvin > stats.max_temp.mkelvin))
@@ -262,7 +262,7 @@ std::vector<volume_t> get_gas_used(struct dive *dive)
 		if (end.mbar && start.mbar > end.mbar)
 			gases[idx] = cyl.gas_volume(start) - cyl.gas_volume(end);
 		else
-			gases[idx].mliter = 0;
+			gases[idx] = 0_l;
 	}
 
 	return gases;
@@ -277,7 +277,7 @@ static std::pair<volume_t, volume_t> get_gas_parts(struct gasmix mix, volume_t v
 
 	volume_t air { .mliter = int_cast<int>(((double)vol.mliter * get_n2(mix)) / (1000 - o2_in_topup)) };
 	volume_t he { .mliter = int_cast<int>(((double)vol.mliter * get_he(mix)) / 1000.0) };
-	volume_t o2 { .mliter = vol.mliter - he.mliter - air.mliter };
+	volume_t o2 = vol - he - air;
 	return std::make_pair(o2, he);
 }
 

--- a/core/uemis.cpp
+++ b/core/uemis.cpp
@@ -353,7 +353,7 @@ void uemis::parse_divelog_binary(std::string_view base64, struct dive *dive)
 		u_sample++;
 	}
 	if (sample)
-		dive->dcs[0].duration.seconds = sample->time.seconds - 1;
+		dive->dcs[0].duration = sample->time - duration_t { .seconds = 1 };
 
 	/* get data from the footer */
 	add_extra_data(dc, "FW Version",

--- a/core/uemis.cpp
+++ b/core/uemis.cpp
@@ -254,7 +254,7 @@ void uemis::event(struct dive *dive, struct divecomputer *dc, struct sample *sam
 		sample->in_deco = true;
 		sample->stopdepth.mm = stopdepth;
 		sample->stoptime.seconds = u_sample->hold_time * 60;
-		sample->ndl.seconds = 0;
+		sample->ndl = 0_sec;
 	} else if (flags[0] & 128) {
 		/* safety stop - distinguished from deco stop by having
 		 * both ndl and stop information */
@@ -266,8 +266,8 @@ void uemis::event(struct dive *dive, struct divecomputer *dc, struct sample *sam
 		/* NDL */
 		sample->in_deco = false;
 		lastndl = sample->ndl.seconds = u_sample->hold_time * 60;
-		sample->stopdepth.mm = 0;
-		sample->stoptime.seconds = 0;
+		sample->stopdepth = 0_m;
+		sample->stoptime = 0_sec;
 	}
 #if UEMIS_DEBUG & 32
 	printf("%dm:%ds: p_amb_tol:%d surface:%d holdtime:%d holddepth:%d/%d ---> stopdepth:%d stoptime:%d ndl:%d\n",
@@ -326,9 +326,9 @@ void uemis::parse_divelog_binary(std::string_view base64, struct dive *dive)
 		 */
 		cylinder_t *cyl = dive->get_or_create_cylinder(i);
 		cyl->type.size.mliter = lrintf(volume);
-		cyl->type.workingpressure.mbar = 202600;
+		cyl->type.workingpressure = 202600_mbar;
 		cyl->gasmix.o2.permille = *(uint8_t *)(data.data() + 120 + 25 * (gasoffset + i)) * 10;
-		cyl->gasmix.he.permille = 0;
+		cyl->gasmix.he = 0_percent;
 	}
 	/* first byte of divelog data is at offset 0x123 */
 	size_t i = 0x123;
@@ -353,7 +353,7 @@ void uemis::parse_divelog_binary(std::string_view base64, struct dive *dive)
 		u_sample++;
 	}
 	if (sample)
-		dive->dcs[0].duration = sample->time - duration_t { .seconds = 1 };
+		dive->dcs[0].duration = sample->time - 1_sec;
 
 	/* get data from the footer */
 	add_extra_data(dc, "FW Version",

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -22,7 +22,7 @@ int get_pressure_units(int mb, const char **units)
 		unit = translate("gettextFromC", "bar");
 		break;
 	case units::PSI:
-		pressure = (int)lrint(mbar_to_PSI(mb));
+		pressure = int_cast<int>(mbar_to_PSI(mb));
 		unit = translate("gettextFromC", "psi");
 		break;
 	}

--- a/core/units.h
+++ b/core/units.h
@@ -61,6 +61,31 @@
  * actual value. So there is hopefully little fear of using a value
  * in millikelvin as Fahrenheit by mistake.
  *
+ * In general, to initialize a variable, use named initializers:
+ *	depth_t depth = { .mm = 10'000; }; // 10 m
+ * However, for convenience, we define a number of user-defined
+ * literals, which make the above more readable:
+ *	depht_t depth = 10_m;
+ * Currently, we only support integer literals, but might also
+ * do floating points if that seems practical.
+ *
+ * Currently we define:
+ *	_sec		-> duration_t in seconds
+ *	_min		-> duration_t in minutes
+ *	_mm		-> depth_t in millimeters
+ *	_m		-> depth_t in meters
+ *	_ft		-> depth_t in feet
+ *	_mbar		-> pressure_t in millibar
+ *	_bar		-> pressure_t in bar
+ *	_atm		-> pressure_t in atmospheres
+ *	_baro2		-> o2pressure_t in bar
+ *	_K		-> temperature_t in kelvin
+ *	_ml		-> volume_t in milliliters
+ *	_l		-> volume_t in liters
+ *	_percent	-> volume_t in liters
+ *	_permille	-> fraction_t in ‰
+ *	_percent	-> fraction_t in %
+ *
  * We don't actually use these all yet, so maybe they'll change, but
  * I made a number of types as guidelines.
  */

--- a/core/units.h
+++ b/core/units.h
@@ -15,7 +15,6 @@
 #define O2_DENSITY 1331 // mg/Liter
 #define N2_DENSITY 1165
 #define HE_DENSITY 166
-#define SURFACE_PRESSURE 1013 // mbar
 #define ZERO_C_IN_MKELVIN 273150 // mKelvin
 
 #define M_OR_FT(_m, _f) ((prefs.units.length == units::METERS) ? ((_m) * 1000) : (feet_to_mm(_f)))
@@ -345,12 +344,12 @@ static inline double to_PSI(pressure_t pressure)
 
 static inline double bar_to_atm(double bar)
 {
-	return bar / SURFACE_PRESSURE * 1000;
+	return bar / (1_atm).mbar * 1000;
 }
 
 static inline double mbar_to_atm(int mbar)
 {
-	return (double)mbar / SURFACE_PRESSURE;
+	return (double)mbar / (1_atm).mbar;
 }
 
 static inline double mbar_to_PSI(int mbar)
@@ -359,15 +358,13 @@ static inline double mbar_to_PSI(int mbar)
 	return to_PSI(p);
 }
 
-static inline int32_t altitude_to_pressure(int32_t altitude) 	// altitude in mm above sea level
-{						// returns atmospheric pressure in mbar
-	return (int32_t) (1013.0 * exp(- altitude / 7800000.0));
+static inline pressure_t altitude_to_pressure(int32_t altitude) { 	// altitude in mm above sea level
+	return pressure_t { .mbar = int_cast<int32_t> (1013.0 * exp(- altitude / 7800000.0)) };
 }
 
-
-static inline int32_t pressure_to_altitude(int32_t pressure)	// pressure in mbar
+static inline int32_t pressure_to_altitude(pressure_t pressure)
 {						// returns altitude in mm above sea level
-	return (int32_t) (log(1013.0 / pressure) * 7800000);
+	return (int32_t) (log(1013.0 / pressure.mbar) * 7800000);
 }
 
 /*

--- a/core/units.h
+++ b/core/units.h
@@ -247,11 +247,6 @@ static inline long feet_to_mm(double feet)
 	return lrint(feet * 304.8);
 }
 
-static inline int to_feet(depth_t depth)
-{
-	return int_cast<int>(mm_to_feet(depth.mm));
-}
-
 static inline double mkelvin_to_C(int mkelvin)
 {
 	return (mkelvin - ZERO_C_IN_MKELVIN) / 1000.0;

--- a/core/units.h
+++ b/core/units.h
@@ -67,6 +67,17 @@
  */
 using timestamp_t = int64_t;
 
+/*
+ * There is a semi-common pattern where lrint() is used to round
+ * doubles to long integers and then cast down to a less wide
+ * int. Since this is unwieldy, encapsulate this in this function
+ */
+template <typename INT>
+INT int_cast(double v)
+{
+	return static_cast<INT>(lrint(v));
+}
+
 // Base class for all unit types using the "Curiously recurring template pattern"
 // (https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
 // to implement addition, subtraction and negation.
@@ -190,8 +201,8 @@ static inline bool operator!=(const location_t &a, const location_t &b)
 static inline location_t create_location(double lat, double lon)
 {
 	location_t location = {
-		{ .udeg = (int) lrint(lat * 1000000) },
-		{ .udeg = (int) lrint(lon * 1000000) }
+		{ .udeg = int_cast<int>(lat * 1000000) },
+		{ .udeg = int_cast<int>(lon * 1000000) }
 	};
 	return location;
 }
@@ -208,7 +219,7 @@ static inline double grams_to_lbs(int grams)
 
 static inline int lbs_to_grams(double lbs)
 {
-	return (int)lrint(lbs * 453.6);
+	return int_cast<int>(lbs * 453.6);
 }
 
 static inline double ml_to_cuft(int ml)
@@ -238,7 +249,7 @@ static inline long feet_to_mm(double feet)
 
 static inline int to_feet(depth_t depth)
 {
-	return (int)lrint(mm_to_feet(depth.mm));
+	return int_cast<int>(mm_to_feet(depth.mm));
 }
 
 static inline double mkelvin_to_C(int mkelvin)

--- a/core/units.h
+++ b/core/units.h
@@ -120,6 +120,14 @@ struct duration_t : public unit_base<duration_t>
 {
 	int32_t seconds = 0; // durations up to 34 yrs
 };
+static inline duration_t operator""_sec(unsigned long long sec)
+{
+	return { .seconds = static_cast<int32_t>(sec) };
+}
+static inline duration_t operator""_min(unsigned long long min)
+{
+	return { .seconds = static_cast<int32_t>(min * 60) };
+}
 
 struct offset_t : public unit_base<offset_t>
 {
@@ -130,16 +138,44 @@ struct depth_t : public unit_base<depth_t> // depth to 2000 km
 {
 	int32_t mm = 0;
 };
+static inline depth_t operator""_mm(unsigned long long mm)
+{
+	return { .mm = static_cast<int32_t>(mm) };
+}
+static inline depth_t operator""_m(unsigned long long m)
+{
+	return { .mm = static_cast<int32_t>(m * 1000) };
+}
+static inline depth_t operator""_ft(unsigned long long ft)
+{
+	return { .mm = static_cast<int32_t>(round(ft * 304.8)) };
+}
 
 struct pressure_t : public unit_base<pressure_t>
 {
 	int32_t mbar = 0; // pressure up to 2000 bar
 };
+static inline pressure_t operator""_mbar(unsigned long long mbar)
+{
+	return { .mbar = static_cast<int32_t>(mbar) };
+}
+static inline pressure_t operator""_bar(unsigned long long bar)
+{
+	return { .mbar = static_cast<int32_t>(bar * 1000) };
+}
+static inline pressure_t operator""_atm(unsigned long long atm)
+{
+	return { .mbar = static_cast<int32_t>(round(atm * 1013.25)) };
+}
 
 struct o2pressure_t : public unit_base<o2pressure_t>
 {
 	uint16_t mbar = 0;
 };
+static inline o2pressure_t operator""_baro2(unsigned long long bar)
+{
+	return { .mbar = static_cast<uint16_t>(bar * 1000) };
+}
 
 struct bearing_t : public unit_base<bearing_t>
 {
@@ -150,6 +186,10 @@ struct temperature_t : public unit_base<temperature_t>
 {
 	uint32_t mkelvin = 0; // up to 4 MK (temperatures in K are always positive)
 };
+static inline temperature_t operator""_K(unsigned long long K)
+{
+	return { .mkelvin = static_cast<uint32_t>(K * 1000) };
+}
 
 struct temperature_sum_t : public unit_base<temperature_sum_t>
 {
@@ -160,11 +200,27 @@ struct volume_t : public unit_base<volume_t>
 {
 	int mliter = 0;
 };
+static inline volume_t operator""_ml(unsigned long long ml)
+{
+	return { .mliter = static_cast<int>(ml) };
+}
+static inline volume_t operator""_l(unsigned long long l)
+{
+	return { .mliter = static_cast<int>(l * 1000) };
+}
 
 struct fraction_t : public unit_base<fraction_t>
 {
 	int permille = 0;
 };
+static inline fraction_t operator""_permille(unsigned long long permille)
+{
+	return { .permille = static_cast<int>(permille) };
+}
+static inline fraction_t operator""_percent(unsigned long long percent)
+{
+	return { .permille = static_cast<int>(percent * 10) };
+}
 
 struct weight_t : public unit_base<weight_t>
 {

--- a/core/units.h
+++ b/core/units.h
@@ -67,8 +67,42 @@
  */
 using timestamp_t = int64_t;
 
+// Base class for all unit types using the "Curiously recurring template pattern"
+// (https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
+// to implement addition, subtraction and negation.
+// Multiplication and division (which result in a different type)
+// are not implemented. If we want that, we should switch to a proper
+// units libary.
+// Also note that some units may be based on unsigned integers and
+// therefore subtraction may be ill-defined.
 template <typename T>
 struct unit_base {
+	auto &get_base() {
+		auto &[v] = static_cast<T &>(*this);
+		return v;
+	}
+	auto get_base() const {
+		auto [v] = static_cast<const T &>(*this);
+		return v;
+	}
+	template <typename base_type>
+	static T from_base(base_type v) {
+		return { {}, v };
+	}
+	T operator+(const T &v2) const {
+		return from_base(get_base() + v2.get_base());
+	}
+	T &operator+=(const T &v2) {
+		get_base() += v2.get_base();
+		return static_cast<T &>(*this);
+	}
+	T operator-(const T &v2) const {
+		return from_base(get_base() - v2.get_base());
+	}
+	T &operator-=(const T &v2) {
+		get_base() -= v2.get_base();
+		return static_cast<T &>(*this);
+	}
 };
 
 struct duration_t : public unit_base<duration_t>

--- a/core/units.h
+++ b/core/units.h
@@ -67,62 +67,66 @@
  */
 using timestamp_t = int64_t;
 
-struct duration_t
+template <typename T>
+struct unit_base {
+};
+
+struct duration_t : public unit_base<duration_t>
 {
 	int32_t seconds = 0; // durations up to 34 yrs
 };
 
-struct offset_t
+struct offset_t : public unit_base<offset_t>
 {
 	int32_t seconds = 0; // offsets up to +/- 34 yrs
 };
 
-struct depth_t // depth to 2000 km
+struct depth_t : public unit_base<depth_t> // depth to 2000 km
 {
 	int32_t mm = 0;
 };
 
-struct pressure_t
+struct pressure_t : public unit_base<pressure_t>
 {
 	int32_t mbar = 0; // pressure up to 2000 bar
 };
 
-struct o2pressure_t
+struct o2pressure_t : public unit_base<o2pressure_t>
 {
 	uint16_t mbar = 0;
 };
 
-struct bearing_t
+struct bearing_t : public unit_base<bearing_t>
 {
 	int16_t degrees = 0;
 };
 
-struct temperature_t
+struct temperature_t : public unit_base<temperature_t>
 {
 	uint32_t mkelvin = 0; // up to 4 MK (temperatures in K are always positive)
 };
 
-struct  temperature_sum_t
+struct temperature_sum_t : public unit_base<temperature_sum_t>
 {
 	uint64_t mkelvin = 0; // up to 18446744073 MK (temperatures in K are always positive)
 };
 
-struct volume_t
+struct volume_t : public unit_base<volume_t>
 {
 	int mliter = 0;
 };
 
-struct fraction_t
+struct fraction_t : public unit_base<fraction_t>
 {
 	int permille = 0;
 };
 
-struct weight_t
+struct weight_t : public unit_base<weight_t>
 {
 	int grams = 0;
 };
 
-struct degrees_t
+struct degrees_t : public unit_base<degrees_t>
 {
 	int udeg = 0;
 };
@@ -152,8 +156,8 @@ static inline bool operator!=(const location_t &a, const location_t &b)
 static inline location_t create_location(double lat, double lon)
 {
 	location_t location = {
-		{ (int) lrint(lat * 1000000) },
-		{ (int) lrint(lon * 1000000) }
+		{ .udeg = (int) lrint(lat * 1000000) },
+		{ .udeg = (int) lrint(lon * 1000000) }
 	};
 	return location;
 }
@@ -255,7 +259,7 @@ static inline double mbar_to_atm(int mbar)
 
 static inline double mbar_to_PSI(int mbar)
 {
-	pressure_t p = { mbar };
+	pressure_t p = { .mbar = mbar };
 	return to_PSI(p);
 }
 

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -596,7 +596,7 @@ void DiveListView::mergeDives()
 void DiveListView::splitDives()
 {
 	for (struct dive *d: getDiveSelection())
-		Command::splitDives(d, duration_t{-1});
+		Command::splitDives(d, duration_t{ .seconds = -1});
 }
 
 void DiveListView::addDivesToTrip()

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -170,8 +170,9 @@ void DivePlannerWidget::settingsChanged()
 	ui.startTime->setDisplayFormat(QString::fromStdString(prefs.time_format));
 }
 
-void DivePlannerWidget::atmPressureChanged(const int pressure)
+void DivePlannerWidget::atmPressureChanged(int pressure_in_mbar)
 {
+	pressure_t pressure { .mbar = pressure_in_mbar };
 	DivePlannerPointsModel::instance()->setSurfacePressure(pressure);
 	ui.atmHeight->blockSignals(true);
 	ui.atmHeight->setValue((int) get_depth_units((int) pressure_to_altitude(pressure), NULL, NULL));
@@ -180,9 +181,9 @@ void DivePlannerWidget::atmPressureChanged(const int pressure)
 
 void DivePlannerWidget::heightChanged(const int height)
 {						// height is in ft or in meters
-	int pressure = (int) (altitude_to_pressure(units_to_depth((double) height).mm));
+	pressure_t pressure = altitude_to_pressure(units_to_depth((double) height).mm);
 	ui.ATMPressure->blockSignals(true);
-	ui.ATMPressure->setValue(pressure);
+	ui.ATMPressure->setValue(pressure.mbar);
 	ui.ATMPressure->blockSignals(false);
 	DivePlannerPointsModel::instance()->setSurfacePressure(pressure);
 }

--- a/desktop-widgets/profilewidget.cpp
+++ b/desktop-widgets/profilewidget.cpp
@@ -345,7 +345,7 @@ void ProfileWidget::exitEditMode()
 // Update depths of edited dive
 static void calcDepth(dive &d, int dcNr)
 {
-	d.maxdepth.mm = d.get_dc(dcNr)->maxdepth.mm = 0;
+	d.maxdepth = d.get_dc(dcNr)->maxdepth = 0_m;
 	divelog.dives.fixup_dive(d);
 }
 

--- a/desktop-widgets/simplewidgets.cpp
+++ b/desktop-widgets/simplewidgets.cpp
@@ -62,7 +62,8 @@ RenumberDialog::RenumberDialog(bool selectedOnlyIn, QWidget *parent) : QDialog(p
 void SetpointDialog::buttonClicked(QAbstractButton *button)
 {
 	if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::AcceptRole)
-		Command::addEventSetpointChange(d, dcNr, time, pressure_t { (int)(1000.0 * ui.spinbox->value()) });
+		Command::addEventSetpointChange(d, dcNr, time,
+						pressure_t { .mbar = (int)(1000.0 * ui.spinbox->value()) });
 }
 
 SetpointDialog::SetpointDialog(struct dive *dIn, int dcNrIn, int seconds) : QDialog(MainWindow::instance()),

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -460,7 +460,7 @@ void TabDiveInformation::updateTextBox(int event) // Either the text box has bee
 			setIndexNoSignal(ui->atmPressType, 0);          // reset combobox to mbar
 			break;
 		default:
-			atmpress.mbar = 1013;    // This line should never execute
+			atmpress = 1_atm;    // This line should never execute
 			break;
 		}
 		if (atmpress.mbar)

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -439,18 +439,18 @@ void TabDiveInformation::updateTextBox(int event) // Either the text box has bee
 					altitudeVal = feet_to_mm(altitudeVal); // imperial: convert altitude from feet to mm
 				else
 					altitudeVal = altitudeVal * 1000;     // metric: convert altitude from meters to mm
-				atmpress.mbar = altitude_to_pressure((int32_t) altitudeVal); // convert altitude (mm) to pressure (mbar)
+				atmpress = altitude_to_pressure((int32_t) altitudeVal); // convert altitude (mm) to pressure (mbar)
 				ui->atmPressVal->setText(QString::number(atmpress.mbar));
 				setIndexNoSignal(ui->atmPressType, 0);    // reset combobox to mbar
 			} else { // i.e. event == COMBO_CHANGED, that is, "m" or "ft" was selected from combobox
 				 // Show estimated altitude
 				bool ok;
 				double convertVal = 0.0010;	// Metric conversion fro mm to m
-				int pressure_as_integer = ui->atmPressVal->text().toInt(&ok,10);
+				pressure_t pressure = { .mbar = ui->atmPressVal->text().toInt(&ok,10) };
 				if (ok && ui->atmPressVal->text().length()) {  // Show existing atm press as an altitude:
 					if (prefs.units.length == units::FEET) // For imperial units
 						convertVal = mm_to_feet(1);    // convert from mm to ft
-					ui->atmPressVal->setText(QString::number((int)(pressure_to_altitude(pressure_as_integer) * convertVal)));
+					ui->atmPressVal->setText(QString::number((int)(pressure_to_altitude(pressure) * convertVal)));
 				}
 			}
 			break;

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1170,13 +1170,13 @@ static weight_t parseWeight(const QString &text)
 		return {};
 	double number = numOnly.toDouble();
 	if (text.contains(gettextFromC::tr("kg"), Qt::CaseInsensitive)) {
-		return { .grams = static_cast<int>(lrint(number * 1000)) };
+		return { .grams = int_cast<int>(number * 1000) };
 	} else if (text.contains(gettextFromC::tr("lbs"), Qt::CaseInsensitive)) {
 		return { .grams = lbs_to_grams(number) };
 	} else {
 		switch (prefs.units.weight) {
 		case units::KG:
-			return { .grams = static_cast<int>(lrint(number * 1000)) };
+			return { .grams = int_cast<int>(number * 1000) };
 		case units::LBS:
 			return { .grams = lbs_to_grams(number) };
 		default:

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1133,7 +1133,7 @@ bool QMLManager::checkDuration(struct dive *d, QString duration)
 		} else if (m6.hasMatch()) {
 			m = m6.captured(1).toInt();
 		}
-		d->dcs[0].duration.seconds = d->duration.seconds = h * 3600 + m * 60 + s;
+		d->dcs[0].duration = d->duration = duration_t { .seconds = h * 3600 + m * 60 + s };
 		if (is_dc_manually_added_dive(&d->dcs[0]))
 			d->dcs[0].samples.clear();
 		else

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1379,7 +1379,7 @@ void QMLManager::commitChanges(QString diveId, QString number, QString date, QSt
 			// let's create an actual profile so the desktop version can work it
 			// first clear out the mean depth (or the fake_dc() function tries
 			// to be too clever)
-			d->meandepth.mm = d->dcs[0].meandepth.mm = 0;
+			d->meandepth = d->dcs[0].meandepth = 0_m;
 			fake_dc(&d->dcs[0]);
 		}
 		divelog.dives.fixup_dive(*d);

--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -551,7 +551,7 @@ void ProfileScene::plotDive(const struct dive *dIn, int dcIn, DivePlannerPointsM
 	// while all other items are up there on the constructor.
 	qDeleteAll(eventItems);
 	eventItems.clear();
-	struct gasmix lastgasmix = d->get_gasmix_at_time(*currentdc, duration_t{1});
+	struct gasmix lastgasmix = d->get_gasmix_at_time(*currentdc, duration_t{ .seconds = 1 });
 
 	for (auto [idx, event]: enumerated_range(currentdc->events)) {
 		// if print mode is selected only draw headings, SP change, gas events or bookmark event

--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -551,7 +551,7 @@ void ProfileScene::plotDive(const struct dive *dIn, int dcIn, DivePlannerPointsM
 	// while all other items are up there on the constructor.
 	qDeleteAll(eventItems);
 	eventItems.clear();
-	struct gasmix lastgasmix = d->get_gasmix_at_time(*currentdc, duration_t{ .seconds = 1 });
+	struct gasmix lastgasmix = d->get_gasmix_at_time(*currentdc, 1_sec);
 
 	for (auto [idx, event]: enumerated_range(currentdc->events)) {
 		// if print mode is selected only draw headings, SP change, gas events or bookmark event

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -1334,7 +1334,7 @@ void ProfileWidget2::pictureOffsetChanged(dive *dIn, QString filenameIn, offset_
 			auto newPos = std::find_if(pictures.begin(), pictures.end(), [offset, &filename](const PictureEntry &e)
 						   { return std::tie(e.offset.seconds, e.filename) > std::tie(offset.seconds, filename); });
 			// Set new offset
-			oldPos->offset.seconds = offset.seconds;
+			oldPos->offset = offset;
 			updateThumbnailXPos(*oldPos);
 
 			// Move image from old to new position

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -753,7 +753,7 @@ void ProfileWidget2::splitDive(int seconds)
 {
 	if (!d)
 		return;
-	Command::splitDives(mutable_dive(), duration_t{ seconds });
+	Command::splitDives(mutable_dive(), duration_t{ .seconds = seconds });
 }
 
 void ProfileWidget2::addGasSwitch(int tank, int seconds)
@@ -1103,7 +1103,6 @@ void ProfileWidget2::updateThumbnail(QString filenameIn, QImage thumbnail, durat
 
 // Create a PictureEntry object and add its thumbnail to the scene if profile pictures are shown.
 ProfileWidget2::PictureEntry::PictureEntry(offset_t offsetIn, const std::string &filenameIn, ProfileWidget2 *profile, bool synchronous) : offset(offsetIn),
-	duration(duration_t {0}),
 	filename(filenameIn),
 	thumbnail(new DivePictureItem)
 {
@@ -1289,7 +1288,7 @@ void ProfileWidget2::dropEvent(QDropEvent *event)
 		QString filename;
 		dataStream >> filename;
 		QPointF mappedPos = mapToScene(event->pos());
-		offset_t offset { (int32_t)lrint(profileScene->timeAxis->valueAt(mappedPos)) };
+		offset_t offset { .seconds = (int32_t)lrint(profileScene->timeAxis->valueAt(mappedPos)) };
 		Command::setPictureOffset(mutable_dive(), filename, offset);
 
 		if (event->source() == this) {

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -86,7 +86,7 @@ static QVariant gas_usage_tooltip(const cylinder_t *cyl)
 	volume_t start = cyl->gas_volume(startp);
 	volume_t end = cyl->gas_volume(endp);
 	// TOOO: implement comparison and subtraction on units.h types.
-	volume_t used = (end.mliter && start.mliter > end.mliter) ? volume_t { start.mliter - end.mliter } : volume_t();
+	volume_t used = (end.mliter && start.mliter > end.mliter) ? volume_t { .mliter = start.mliter - end.mliter } : volume_t();
 
 	if (!used.mliter)
 		return gas_wp_tooltip(cyl);

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -410,7 +410,7 @@ bool CylindersModel::setData(const QModelIndex &index, const QVariant &value, in
 				cyl.gasmix.he.permille = 1000 - get_o2(cyl.gasmix);
 			pressure_t modpO2;
 			if (d->dcs[0].divemode == PSCR)
-				modpO2.mbar = prefs.decopo2 + (1000 - get_o2(cyl.gasmix)) * SURFACE_PRESSURE *
+				modpO2.mbar = prefs.decopo2 + (1000 - get_o2(cyl.gasmix)) * (1_atm).mbar *
 						prefs.o2consumption / prefs.decosac / prefs.pscr_ratio;
 			else
 				modpO2.mbar = prefs.decopo2;

--- a/qt-models/divelocationmodel.cpp
+++ b/qt-models/divelocationmodel.cpp
@@ -303,7 +303,6 @@ bool GPSLocationInformationModel::filterAcceptsRow(int sourceRow, const QModelIn
 
 GPSLocationInformationModel::GPSLocationInformationModel(QObject *parent) : QSortFilterProxyModel(parent),
 	ignoreDs(nullptr),
-	location({{0},{0}}),
 	distance(0)
 {
 	setSourceModel(LocationInformationModel::instance());

--- a/qt-models/divepicturemodel.cpp
+++ b/qt-models/divepicturemodel.cpp
@@ -15,8 +15,7 @@
 
 PictureEntry::PictureEntry(dive *dIn, const picture &p) : d(dIn),
 	filename(p.filename),
-	offsetSeconds(p.offset.seconds),
-	length({ 0 })
+	offsetSeconds(p.offset.seconds)
 {
 }
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -149,7 +149,6 @@ void DivePlannerPointsModel::loadFromDive(dive *dIn, int dcNrIn)
 	int j = 0;
 	int cylinderid = 0;
 
-	last_sp.mbar = 0;
 	divemode_loop loop(*dc);
 	for (int i = 0; i < plansamples - 1; i++) {
 		if (dc->last_manual_time.seconds && dc->last_manual_time.seconds > 120 && lasttime.seconds >= dc->last_manual_time.seconds)
@@ -216,7 +215,7 @@ void DivePlannerPointsModel::setupCylinders()
 bool DivePlannerPointsModel::updateMaxDepth()
 {
 	int prevMaxDepth = d->maxdepth.mm;
-	d->maxdepth.mm = 0;
+	d->maxdepth = 0_m;
 	for (int i = 0; i < rowCount(); i++) {
 		divedatapoint p = at(i);
 		if (p.depth.mm > d->maxdepth.mm)
@@ -1069,7 +1068,7 @@ bool DivePlannerPointsModel::tankInUse(int cylinderid) const
 void DivePlannerPointsModel::clear()
 {
 	cylinders.clear();
-	preserved_until.seconds = 0;
+	preserved_until = 0_sec;
 	beginResetModel();
 	divepoints.clear();
 	endResetModel();
@@ -1223,16 +1222,16 @@ void DivePlannerPointsModel::computeVariations(std::unique_ptr<struct diveplan> 
 	int my_instance = ++instanceCounter;
 	save.cache(&ds);
 
-	duration_t delta_time = { .seconds = 60 };
+	duration_t delta_time = 1_min;
 	QString time_units = tr("min");
 	depth_t delta_depth;
 	QString depth_units;
 
 	if (prefs.units.length == units::METERS) {
-		delta_depth.mm = 1000; // 1m
+		delta_depth = 1_m;
 		depth_units = tr("m");
 	} else {
-		delta_depth.mm = feet_to_mm(1.0); // 1ft
+		delta_depth = 1_ft;
 		depth_units = tr("ft");
 	}
 

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -609,7 +609,7 @@ void DivePlannerPointsModel::setVpmbConservatism(int level)
 	}
 }
 
-void DivePlannerPointsModel::setSurfacePressure(int pressure)
+void DivePlannerPointsModel::setSurfacePressure(pressure_t pressure)
 {
 	diveplan.surface_pressure = pressure;
 	emitDataChanged();
@@ -621,7 +621,7 @@ void DivePlannerPointsModel::setSalinity(int salinity)
 	emitDataChanged();
 }
 
-int DivePlannerPointsModel::getSurfacePressure() const
+pressure_t DivePlannerPointsModel::getSurfacePressure() const
 {
 	return diveplan.surface_pressure;
 }

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -296,7 +296,7 @@ QVariant DivePlannerPointsModel::data(const QModelIndex &index, int role) const
 		case CCSETPOINT:
 			return (divemode == CCR) ? (double)(p.setpoint / 1000.0) : QVariant();
 		case DEPTH:
-			return (int) lrint(get_depth_units(p.depth.mm, NULL, NULL));
+			return int_cast<int>(get_depth_units(p.depth.mm, NULL, NULL));
 		case RUNTIME:
 			return p.time / 60;
 		case DURATION:

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -52,7 +52,7 @@ public:
 	int ascratestopsDisplay() const;
 	int ascratelast6mDisplay() const;
 	int descrateDisplay() const;
-	int getSurfacePressure() const;
+	pressure_t getSurfacePressure() const;
 	int gfLow() const;
 	int gfHigh() const;
 
@@ -74,7 +74,7 @@ slots:
 	void setGFHigh(const int gfhigh);
 	void setGFLow(const int gflow);
 	void setVpmbConservatism(int level);
-	void setSurfacePressure(int pressure);
+	void setSurfacePressure(pressure_t pressure);
 	void setSalinity(int salinity);
 	void setBottomSac(double sac);
 	void setDecoSac(double sac);

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -1001,7 +1001,7 @@ void smartrak_import(const char *file, struct divelog *log)
 
 		/* No DC related data */
 		smtkdive->visibility = strtod((char *)col[coln(VISIBILITY)]->bind_ptr, NULL) > 25 ? 5 : lrint(strtod((char *)col[13]->bind_ptr, NULL) / 5);
-		weightsystem_t ws = { { .grams = (int)lrint(strtod((char *)col[coln(WEIGHT)]->bind_ptr, NULL) * 1000)}, std::string(), false };
+		weightsystem_t ws = { { .grams = int_cast<int>(strtod((char *)col[coln(WEIGHT)]->bind_ptr, NULL) * 1000)}, std::string(), false };
 		smtkdive->weightsystems.push_back(std::move(ws));
 		smtkdive->suit = get(suit_list, atoi((char *)col[coln(SUITIDX)]->bind_ptr) - 1);
 		smtk_build_location(mdb_clon, (char *)col[coln(SITEIDX)]->bind_ptr, &smtkdive->dive_site, log);

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -472,9 +472,9 @@ static bool is_same_cylinder(cylinder_t *cyl_a, cylinder_t *cyl_b)
 static void merge_cylinder_type(cylinder_type_t *src, cylinder_type_t *dst)
 {
 	if (!dst->size.mliter)
-		dst->size.mliter = src->size.mliter;
+		dst->size = src->size;
 	if (!dst->workingpressure.mbar)
-		dst->workingpressure.mbar = src->workingpressure.mbar;
+		dst->workingpressure = src->workingpressure;
 	if (dst->description.empty() || dst->description == "---") {
 		dst->description = std::move(src->description);
 	}

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -978,7 +978,7 @@ void smartrak_import(const char *file, struct divelog *log)
 				if (tmptank->gasmix.he.permille == 0)
 					tmptank->gasmix.he.permille = lrint(strtod((char *)col[i + hefraccol]->bind_ptr, NULL) * 10);
 			} else {
-				tmptank->gasmix.he.permille = 0;
+				tmptank->gasmix.he = 0_percent;
 			}
 			smtk_build_tank_info(mdb_clon, tmptank, (char *)col[i + tankidxcol]->bind_ptr);
 		}

--- a/smtk-import/smartrak.cpp
+++ b/smtk-import/smartrak.cpp
@@ -1001,7 +1001,7 @@ void smartrak_import(const char *file, struct divelog *log)
 
 		/* No DC related data */
 		smtkdive->visibility = strtod((char *)col[coln(VISIBILITY)]->bind_ptr, NULL) > 25 ? 5 : lrint(strtod((char *)col[13]->bind_ptr, NULL) / 5);
-		weightsystem_t ws = { {(int)lrint(strtod((char *)col[coln(WEIGHT)]->bind_ptr, NULL) * 1000)}, std::string(), false };
+		weightsystem_t ws = { { .grams = (int)lrint(strtod((char *)col[coln(WEIGHT)]->bind_ptr, NULL) * 1000)}, std::string(), false };
 		smtkdive->weightsystems.push_back(std::move(ws));
 		smtkdive->suit = get(suit_list, atoi((char *)col[coln(SUITIDX)]->bind_ptr) - 1);
 		smtk_build_location(mdb_clon, (char *)col[coln(SITEIDX)]->bind_ptr, &smtkdive->dive_site, log);

--- a/tests/testAirPressure.cpp
+++ b/tests/testAirPressure.cpp
@@ -34,8 +34,8 @@ void TestAirPressure::testReadAirPressure()
 
 void TestAirPressure::testConvertAltitudetoAirPressure()
 {
-	QCOMPARE(891,altitude_to_pressure(1000000)); // 1000 m altitude in mm
-	QCOMPARE(1013,altitude_to_pressure(0)); // sea level
+	QCOMPARE(891, altitude_to_pressure(1000000).mbar); // 1000 m altitude in mm
+	QCOMPARE(1013, altitude_to_pressure(0).mbar); // sea level
 }
 
 void TestAirPressure::testWriteReadBackAirPressure()

--- a/tests/testformatDiveGasString.cpp
+++ b/tests/testformatDiveGasString.cpp
@@ -19,8 +19,8 @@ void TestformatDiveGasString::test_air()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "air");
 }
@@ -30,9 +30,9 @@ void TestformatDiveGasString::test_nitrox()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 320;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 32_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "32%");
 }
@@ -42,16 +42,16 @@ void TestformatDiveGasString::test_nitrox_not_use()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 320;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 32_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 1000;
+	cylinder->gasmix.o2 = 100_percent;
 	cylinder->cylinder_use = NOT_USED;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "32%");
 }
@@ -61,15 +61,15 @@ void TestformatDiveGasString::test_nitrox_deco()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 320;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 32_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 1000;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 100_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "32…100%");
 }
@@ -79,15 +79,15 @@ void TestformatDiveGasString::test_reverse_nitrox_deco()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 1000;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 100_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 270;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 27_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "27…100%");
 }
@@ -97,10 +97,10 @@ void TestformatDiveGasString::test_trimix()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 210;
-	cylinder->gasmix.he.permille = 350;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 21_percent;
+	cylinder->gasmix.he = 35_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "21/35");
 }
@@ -110,23 +110,23 @@ void TestformatDiveGasString::test_trimix_deco()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 210;
-	cylinder->gasmix.he.permille = 350;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 21_percent;
+	cylinder->gasmix.he = 35_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 500;
-	cylinder->gasmix.he.permille = 200;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 50_percent;
+	cylinder->gasmix.he = 20_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(2);
 
-	cylinder->gasmix.o2.permille = 1000;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 100_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "21/35…100%");
 }
@@ -136,23 +136,23 @@ void TestformatDiveGasString::test_reverse_trimix_deco()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 1000;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 100_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 500;
-	cylinder->gasmix.he.permille = 200;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 50_percent;
+	cylinder->gasmix.he = 20_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(2);
 
-	cylinder->gasmix.o2.permille = 210;
-	cylinder->gasmix.he.permille = 350;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 21_percent;
+	cylinder->gasmix.he = 35_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "21/35…100%");
 }
@@ -162,17 +162,17 @@ void TestformatDiveGasString::test_trimix_and_nitrox_same_o2()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 250;
-	cylinder->gasmix.he.permille = 0;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 25_percent;
+	cylinder->gasmix.he = 0_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 250;
-	cylinder->gasmix.he.permille = 250;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 25_percent;
+	cylinder->gasmix.he = 25_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "25/25");
 }
@@ -182,17 +182,17 @@ void TestformatDiveGasString::test_trimix_and_nitrox_lower_o2()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 220;
-	cylinder->gasmix.he.permille = 0;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 22_percent;
+	cylinder->gasmix.he = 0_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 250;
-	cylinder->gasmix.he.permille = 250;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 25_percent;
+	cylinder->gasmix.he = 25_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "25/25");
 }
@@ -202,18 +202,18 @@ void TestformatDiveGasString::test_ccr()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 1000;
+	cylinder->gasmix.o2 = 100_percent;
 	cylinder->cylinder_use = OXYGEN;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 210;
-	cylinder->gasmix.he.permille = 350;
+	cylinder->gasmix.o2 = 21_percent;
+	cylinder->gasmix.he = 35_percent;
 	cylinder->cylinder_use = DILUENT;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "21/35");
 }
@@ -223,25 +223,25 @@ void TestformatDiveGasString::test_ccr_bailout()
 	struct dive dive;
 	cylinder_t *cylinder = dive.get_or_create_cylinder(0);
 
-	cylinder->gasmix.o2.permille = 1000;
+	cylinder->gasmix.o2 = 100_percent;
 	cylinder->cylinder_use = OXYGEN;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(1);
 
-	cylinder->gasmix.o2.permille = 220;
-	cylinder->gasmix.he.permille = 200;
+	cylinder->gasmix.o2 = 22_percent;
+	cylinder->gasmix.he = 20_percent;
 	cylinder->cylinder_use = DILUENT;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	cylinder = dive.get_or_create_cylinder(2);
 
-	cylinder->gasmix.o2.permille = 210;
-	cylinder->gasmix.he.permille = 0;
-	cylinder->start.mbar = 230000;
-	cylinder->end.mbar = 100000;
+	cylinder->gasmix.o2 = 21_percent;
+	cylinder->gasmix.he = 0_percent;
+	cylinder->start = 230_bar;
+	cylinder->end = 100_bar;
 
 	QCOMPARE(formatDiveGasString(&dive), "22/20");
 }

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -47,10 +47,10 @@ diveplan setupPlan()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 150}, {.permille = 450}};
-	struct gasmix ean36 = {{.permille = 360}, {}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 15_percent, 45_percent};
+	struct gasmix ean36 = { 36_percent, 0_percent};
+	struct gasmix oxygen = { 100_percent, 0_percent};
+	pressure_t po2 = 1600_mbar;;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -58,8 +58,8 @@ diveplan setupPlan()
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean36;
 	cyl2->gasmix = oxygen;
 	reset_cylinders(&dive, true);
@@ -82,10 +82,10 @@ diveplan setupPlanVpmb45m30mTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 210}, {.permille = 350}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 21_percent, 35_percent};
+	struct gasmix ean50 = { 50_percent, 0_percent};
+	struct gasmix oxygen = { 100_percent, 0_percent};
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -93,8 +93,8 @@ diveplan setupPlanVpmb45m30mTx()
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 24000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 24_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
 	reset_cylinders(&dive, true);
@@ -117,10 +117,10 @@ diveplan setupPlanVpmb60m10mTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
-	struct gasmix tx50_15 = {{.permille = 500}, {.permille = 150}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 18_percent, 45_percent };
+	struct gasmix tx50_15 = { 50_percent, 15_percent };
+	struct gasmix oxygen = { 100_percent, 0_percent };
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -128,8 +128,8 @@ diveplan setupPlanVpmb60m10mTx()
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 24000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 24_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = tx50_15;
 	cyl2->gasmix = oxygen;
 	reset_cylinders(&dive, true);
@@ -150,12 +150,12 @@ diveplan setupPlanVpmb60m30minAir()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 210}, {}};
+	struct gasmix bottomgas = { 21_percent, 0_percent};
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 100000;
-	cyl0->type.workingpressure.mbar = 232000;
-	dive.surface_pressure.mbar = 1013;
+	cyl0->type.size = 100_l;
+	cyl0->type.workingpressure = 232_bar;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
@@ -172,19 +172,19 @@ diveplan setupPlanVpmb60m30minEan50()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 210}, {}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 21_percent, 0_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent };
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean50;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
@@ -202,19 +202,19 @@ diveplan setupPlanVpmb60m30minTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 18_percent, 45_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent };
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean50;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(60, 200) * 60 / M_OR_FT(99, 330);
@@ -232,12 +232,12 @@ diveplan setupPlanVpmbMultiLevelAir()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 210}, {}};
+	struct gasmix bottomgas = { 21_percent, 0_percent };
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 200000;
-	cyl0->type.workingpressure.mbar = 232000;
-	dive.surface_pressure.mbar = 1013;
+	cyl0->type.size = 200_l;
+	cyl0->type.workingpressure = 232_bar;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(20, 66) * 60 / M_OR_FT(99, 330);
@@ -256,10 +256,10 @@ diveplan setupPlanVpmb100m60min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 18_percent, 45_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent };
+	struct gasmix oxygen = { 100_percent, 0_percent };
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -267,11 +267,11 @@ diveplan setupPlanVpmb100m60min()
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 200000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 200_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
@@ -290,10 +290,10 @@ diveplan setupPlanVpmb100m10min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 18_percent, 45_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent};
+	struct gasmix oxygen = { 100_percent, 0_percent};
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -301,11 +301,11 @@ diveplan setupPlanVpmb100m10min()
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 60000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 60_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = ean50;
 	cyl2->gasmix = oxygen;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(99, 330);
@@ -324,12 +324,12 @@ diveplan setupPlanVpmb30m20min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 210}, {}};
+	struct gasmix bottomgas = { 21_percent, 0_percent };
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
-	dive.surface_pressure.mbar = 1013;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(30, 100) * 60 / M_OR_FT(18, 60);
@@ -346,11 +346,11 @@ diveplan setupPlanVpmb100mTo70m30min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{.permille = 120}, {.permille = 650}};
-	struct gasmix tx21_35 = {{.permille = 210}, {.permille = 350}};
-	struct gasmix ean50 = {{.permille = 500}, {}};
-	struct gasmix oxygen = {{.permille = 1000}, {}};
-	pressure_t po2 = {.mbar = 1600};
+	struct gasmix bottomgas = { 12_percent, 65_percent };
+	struct gasmix tx21_35 = { 21_percent, 35_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent };
+	struct gasmix oxygen = { 100_percent, 0_percent };
+	pressure_t po2 = 1600_mbar;
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -359,12 +359,12 @@ diveplan setupPlanVpmb100mTo70m30min()
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cylinder_t *cyl2 = dive.get_or_create_cylinder(2);
 	cyl0->gasmix = bottomgas;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = tx21_35;
 	cyl2->gasmix = ean50;
 	cyl3->gasmix = oxygen;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	int droptime = M_OR_FT(100, 330) * 60 / M_OR_FT(18, 60);
@@ -388,8 +388,8 @@ diveplan setupPlanSeveralGases()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix ean36 = {{.permille = 360}, {}};
-	struct gasmix tx11_50 = {{.permille = 110}, {.permille = 500}};
+	struct gasmix ean36 = { 36_percent, 0_percent };
+	struct gasmix tx11_50 = { 11_percent, 50_percent };
 
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
@@ -397,10 +397,10 @@ diveplan setupPlanSeveralGases()
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = ean36;
-	cyl0->type.size.mliter = 36000;
-	cyl0->type.workingpressure.mbar = 232000;
+	cyl0->type.size = 36_l;
+	cyl0->type.workingpressure = 232_bar;
 	cyl1->gasmix = tx11_50;
-	dive.surface_pressure.mbar = 1013;
+	dive.surface_pressure = 1_atm;
 	reset_cylinders(&dive, true);
 
 	plan_add_segment(dp, 120, 40000, 0, 0, true, OC);
@@ -420,10 +420,10 @@ diveplan setupPlanCcr()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	pressure_t po2 = {.mbar = 1600};
-	struct gasmix diluent = {{.permille = 200}, {.permille = 210}};
-	struct gasmix ean53 = {{.permille = 530}, {}};
-	struct gasmix tx19_33 = {{.permille = 190}, {.permille = 330}};
+	pressure_t po2 = 1600_mbar;
+	struct gasmix diluent = { 20_percent, 21_percent};
+	struct gasmix ean53 = { 53_percent, 0_percent};
+	struct gasmix tx19_33 = { 19_percent, 33_percent};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -432,8 +432,8 @@ diveplan setupPlanCcr()
 	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
 	cyl0->gasmix = diluent;
 	cyl0->depth = dive.gas_mod(diluent, po2, M_OR_FT(3, 10));
-	cyl0->type.size.mliter = 3000;
-	cyl0->type.workingpressure.mbar = 200000;
+	cyl0->type.size = 3_l;
+	cyl0->type.workingpressure = 200_bar;
 	cyl0->cylinder_use = DILUENT;
 	cyl1->gasmix = ean53;
 	cyl1->depth = dive.gas_mod(ean53, po2, M_OR_FT(3, 10));
@@ -754,7 +754,7 @@ void TestPlan::testMultipleGases()
 	save_dive(stdout, dive, false);
 #endif
 
-	gasmix gas = dive.get_gasmix_at_time(dive.dcs[0], {.seconds = 20 * 60 + 1});
+	gasmix gas = dive.get_gasmix_at_time(dive.dcs[0], 20_min + 1_sec);
 	QCOMPARE(get_o2(gas), 110);
 	QVERIFY(compareDecoTime(dive.dcs[0].duration.seconds, 2480u, 2480u));
 }
@@ -934,17 +934,17 @@ void TestPlan::testCcrBailoutGasSelection()
 #endif
 
 	// check diluent used
-	cylinder_t *cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 20 * 60 - 1 }));
+	cylinder_t *cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], 20_min - 1_sec));
 	QCOMPARE(cylinder->cylinder_use, DILUENT);
 	QCOMPARE(get_o2(cylinder->gasmix), 200);
 
 	// check deep bailout used
-	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 20 * 60 + 1 }));
+	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], 20_min + 1_sec));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 190);
 
 	// check shallow bailout used
-	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 30 * 60 }));
+	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], 30_min));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 530);
 

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -47,10 +47,10 @@ diveplan setupPlan()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{150}, {450}};
-	struct gasmix ean36 = {{360}, {0}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 150}, {.permille = 450}};
+	struct gasmix ean36 = {{.permille = 360}, {}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -82,10 +82,10 @@ diveplan setupPlanVpmb45m30mTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{210}, {350}};
-	struct gasmix ean50 = {{500}, {0}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 210}, {.permille = 350}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -117,10 +117,10 @@ diveplan setupPlanVpmb60m10mTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{180}, {450}};
-	struct gasmix tx50_15 = {{500}, {150}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
+	struct gasmix tx50_15 = {{.permille = 500}, {.permille = 150}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -150,7 +150,7 @@ diveplan setupPlanVpmb60m30minAir()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{210}, {0}};
+	struct gasmix bottomgas = {{.permille = 210}, {}};
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 100000;
@@ -172,9 +172,9 @@ diveplan setupPlanVpmb60m30minEan50()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{210}, {0}};
-	struct gasmix ean50 = {{500}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 210}, {}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -202,9 +202,9 @@ diveplan setupPlanVpmb60m30minTx()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{180}, {450}};
-	struct gasmix ean50 = {{500}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -232,7 +232,7 @@ diveplan setupPlanVpmbMultiLevelAir()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{210}, {0}};
+	struct gasmix bottomgas = {{.permille = 210}, {}};
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 200000;
@@ -256,10 +256,10 @@ diveplan setupPlanVpmb100m60min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{180}, {450}};
-	struct gasmix ean50 = {{500}, {0}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -290,10 +290,10 @@ diveplan setupPlanVpmb100m10min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{180}, {450}};
-	struct gasmix ean50 = {{500}, {0}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 180}, {.permille = 450}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -324,7 +324,7 @@ diveplan setupPlanVpmb30m20min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{210}, {0}};
+	struct gasmix bottomgas = {{.permille = 210}, {}};
 	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
 	cyl0->gasmix = bottomgas;
 	cyl0->type.size.mliter = 36000;
@@ -346,11 +346,11 @@ diveplan setupPlanVpmb100mTo70m30min()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix bottomgas = {{120}, {650}};
-	struct gasmix tx21_35 = {{210}, {350}};
-	struct gasmix ean50 = {{500}, {0}};
-	struct gasmix oxygen = {{1000}, {0}};
-	pressure_t po2 = {1600};
+	struct gasmix bottomgas = {{.permille = 120}, {.permille = 650}};
+	struct gasmix tx21_35 = {{.permille = 210}, {.permille = 350}};
+	struct gasmix ean50 = {{.permille = 500}, {}};
+	struct gasmix oxygen = {{.permille = 1000}, {}};
+	pressure_t po2 = {.mbar = 1600};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -388,8 +388,8 @@ diveplan setupPlanSeveralGases()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	struct gasmix ean36 = {{360}, {0}};
-	struct gasmix tx11_50 = {{110}, {500}};
+	struct gasmix ean36 = {{.permille = 360}, {}};
+	struct gasmix tx11_50 = {{.permille = 110}, {.permille = 500}};
 
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
@@ -420,10 +420,10 @@ diveplan setupPlanCcr()
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
-	pressure_t po2 = {1600};
-	struct gasmix diluent = {{200}, {210}};
-	struct gasmix ean53 = {{530}, {0}};
-	struct gasmix tx19_33 = {{190}, {330}};
+	pressure_t po2 = {.mbar = 1600};
+	struct gasmix diluent = {{.permille = 200}, {.permille = 210}};
+	struct gasmix ean53 = {{.permille = 530}, {}};
+	struct gasmix tx19_33 = {{.permille = 190}, {.permille = 330}};
 	// Note: we add the highest-index cylinder first, because
 	// pointers to cylinders are not stable when reallocating.
 	// For testing OK - don't do this in actual code!
@@ -754,7 +754,7 @@ void TestPlan::testMultipleGases()
 	save_dive(stdout, dive, false);
 #endif
 
-	gasmix gas = dive.get_gasmix_at_time(dive.dcs[0], {20 * 60 + 1});
+	gasmix gas = dive.get_gasmix_at_time(dive.dcs[0], {.seconds = 20 * 60 + 1});
 	QCOMPARE(get_o2(gas), 110);
 	QVERIFY(compareDecoTime(dive.dcs[0].duration.seconds, 2480u, 2480u));
 }
@@ -934,17 +934,17 @@ void TestPlan::testCcrBailoutGasSelection()
 #endif
 
 	// check diluent used
-	cylinder_t *cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { 20 * 60 - 1 }));
+	cylinder_t *cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 20 * 60 - 1 }));
 	QCOMPARE(cylinder->cylinder_use, DILUENT);
 	QCOMPARE(get_o2(cylinder->gasmix), 200);
 
 	// check deep bailout used
-	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { 20 * 60 + 1 }));
+	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 20 * 60 + 1 }));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 190);
 
 	// check shallow bailout used
-	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { 30 * 60 }));
+	cylinder = dive.get_cylinder(get_cylinderid_at_time(&dive, &dive.dcs[0], { .seconds = 30 * 60 }));
 	QCOMPARE(cylinder->cylinder_use, OC_GAS);
 	QCOMPARE(get_o2(cylinder->gasmix), 530);
 

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -41,7 +41,7 @@ diveplan setupPlan()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.gfhigh = 100;
 	dp.gflow = 100;
 	dp.bottomsac = prefs.bottomsac;
@@ -76,7 +76,7 @@ diveplan setupPlanVpmb45m30mTx()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.gfhigh = 100;
 	dp.gflow = 100;
 	dp.bottomsac = prefs.bottomsac;
@@ -111,7 +111,7 @@ diveplan setupPlanVpmb60m10mTx()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.gfhigh = 100;
 	dp.gflow = 100;
 	dp.bottomsac = prefs.bottomsac;
@@ -146,7 +146,7 @@ diveplan setupPlanVpmb60m30minAir()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -168,7 +168,7 @@ diveplan setupPlanVpmb60m30minEan50()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -198,7 +198,7 @@ diveplan setupPlanVpmb60m30minTx()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -228,7 +228,7 @@ diveplan setupPlanVpmbMultiLevelAir()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -252,7 +252,7 @@ diveplan setupPlanVpmb100m60min()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -286,7 +286,7 @@ diveplan setupPlanVpmb100m10min()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -320,7 +320,7 @@ diveplan setupPlanVpmb30m20min()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -342,7 +342,7 @@ diveplan setupPlanVpmb100mTo70m30min()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -384,7 +384,7 @@ diveplan setupPlanSeveralGases()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.bottomsac = prefs.bottomsac;
 	dp.decosac = prefs.decosac;
 
@@ -414,7 +414,7 @@ diveplan setupPlanCcr()
 {
 	diveplan dp;
 	dp.salinity = 10300;
-	dp.surface_pressure = 1013;
+	dp.surface_pressure = 1_atm;
 	dp.gflow = 50;
 	dp.gfhigh = 70;
 	dp.bottomsac = prefs.bottomsac;

--- a/tests/testunitconversion.cpp
+++ b/tests/testunitconversion.cpp
@@ -17,7 +17,7 @@ void TestUnitConversion::testUnitConversions()
 	QCOMPARE(C_to_mkelvin(373.85), 647000UL);
 	QCOMPARE(nearly_equal(psi_to_bar(14.6959488), 1.01325), true);
 	QCOMPARE(psi_to_mbar(14.6959488), 1013L);
-	QCOMPARE(nearly_equal(to_PSI(pressure_t{ .mbar = 1013}), 14.6923228594), true);
+	QCOMPARE(nearly_equal(to_PSI(1_atm), 14.6923228594), true);
 	QCOMPARE(nearly_equal(bar_to_atm(1.013), 1.0), true);
 	QCOMPARE(nearly_equal(mbar_to_atm(1013), 1.0), true);
 	QCOMPARE(nearly_equal(mbar_to_PSI(1013), 14.6923228594), true);

--- a/tests/testunitconversion.cpp
+++ b/tests/testunitconversion.cpp
@@ -11,7 +11,6 @@ void TestUnitConversion::testUnitConversions()
 	QCOMPARE(nearly_equal(cuft_to_l(1), 28.316847), true);
 	QCOMPARE(nearly_equal(mm_to_feet(1000), 3.280840), true);
 	QCOMPARE(feet_to_mm(1), 305L);
-	QCOMPARE(to_feet(depth_t{ .mm = 1'000}), 3);
 	QCOMPARE(nearly_equal(mkelvin_to_C(647000), 373.85), true);
 	QCOMPARE(nearly_equal(mkelvin_to_F(647000), 704.93), true);
 	QCOMPARE(F_to_mkelvin(704.93), 647000UL);

--- a/tests/testunitconversion.cpp
+++ b/tests/testunitconversion.cpp
@@ -11,14 +11,14 @@ void TestUnitConversion::testUnitConversions()
 	QCOMPARE(nearly_equal(cuft_to_l(1), 28.316847), true);
 	QCOMPARE(nearly_equal(mm_to_feet(1000), 3.280840), true);
 	QCOMPARE(feet_to_mm(1), 305L);
-	QCOMPARE(to_feet((depth_t){1000}), 3);
+	QCOMPARE(to_feet(depth_t{ .mm = 1'000}), 3);
 	QCOMPARE(nearly_equal(mkelvin_to_C(647000), 373.85), true);
 	QCOMPARE(nearly_equal(mkelvin_to_F(647000), 704.93), true);
 	QCOMPARE(F_to_mkelvin(704.93), 647000UL);
 	QCOMPARE(C_to_mkelvin(373.85), 647000UL);
 	QCOMPARE(nearly_equal(psi_to_bar(14.6959488), 1.01325), true);
 	QCOMPARE(psi_to_mbar(14.6959488), 1013L);
-	QCOMPARE(nearly_equal(to_PSI((pressure_t){1013}), 14.6923228594), true);
+	QCOMPARE(nearly_equal(to_PSI(pressure_t{ .mbar = 1013}), 14.6923228594), true);
 	QCOMPARE(nearly_equal(bar_to_atm(1.013), 1.0), true);
 	QCOMPARE(nearly_equal(mbar_to_atm(1013), 1.0), true);
 	QCOMPARE(nearly_equal(mbar_to_PSI(1013), 14.6923228594), true);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The unit types weren't the worst idea, as they make their base type explicit to the user. However, they were used very inconsistently, presumably because they are a pain to use.

This PR adds convenience operators so that the user needn't know the base type when adding  / subtracting.

The biggest gain will probably be comparison function, but for those I want to wait until we up the compiler version to C++20. Then one has to only implement a single `<=>` operator (a.k.a the space ship operator) instead of (`=`, `!=`, `<`, `>`, `<=`, `>=`). Then one should be able to use other convenience functions, such as `std::min`, `std::max` and `std:::clamp`.

Multiplication / division by scalars should obviously also be supported.

Note: related to #4237.