### PR TITLE
core: add missing types to return values

### DIFF
--- a/core/units.h
+++ b/core/units.h
@@ -146,11 +146,11 @@ struct duration_t : public unit_base<duration_t>
 };
 static inline duration_t operator""_sec(unsigned long long sec)
 {
-	return { .seconds = static_cast<int32_t>(sec) };
+	return duration_t { .seconds = static_cast<int32_t>(sec) };
 }
 static inline duration_t operator""_min(unsigned long long min)
 {
-	return { .seconds = static_cast<int32_t>(min * 60) };
+	return duration_t { .seconds = static_cast<int32_t>(min * 60) };
 }
 
 struct offset_t : public unit_base<offset_t>
@@ -164,15 +164,15 @@ struct depth_t : public unit_base<depth_t> // depth to 2000 km
 };
 static inline depth_t operator""_mm(unsigned long long mm)
 {
-	return { .mm = static_cast<int32_t>(mm) };
+	return depth_t { .mm = static_cast<int32_t>(mm) };
 }
 static inline depth_t operator""_m(unsigned long long m)
 {
-	return { .mm = static_cast<int32_t>(m * 1000) };
+	return depth_t { .mm = static_cast<int32_t>(m * 1000) };
 }
 static inline depth_t operator""_ft(unsigned long long ft)
 {
-	return { .mm = static_cast<int32_t>(round(ft * 304.8)) };
+	return depth_t { .mm = static_cast<int32_t>(round(ft * 304.8)) };
 }
 
 struct pressure_t : public unit_base<pressure_t>
@@ -181,15 +181,15 @@ struct pressure_t : public unit_base<pressure_t>
 };
 static inline pressure_t operator""_mbar(unsigned long long mbar)
 {
-	return { .mbar = static_cast<int32_t>(mbar) };
+	return pressure_t { .mbar = static_cast<int32_t>(mbar) };
 }
 static inline pressure_t operator""_bar(unsigned long long bar)
 {
-	return { .mbar = static_cast<int32_t>(bar * 1000) };
+	return pressure_t { .mbar = static_cast<int32_t>(bar * 1000) };
 }
 static inline pressure_t operator""_atm(unsigned long long atm)
 {
-	return { .mbar = static_cast<int32_t>(round(atm * 1013.25)) };
+	return pressure_t { .mbar = static_cast<int32_t>(round(atm * 1013.25)) };
 }
 
 struct o2pressure_t : public unit_base<o2pressure_t>
@@ -198,7 +198,7 @@ struct o2pressure_t : public unit_base<o2pressure_t>
 };
 static inline o2pressure_t operator""_baro2(unsigned long long bar)
 {
-	return { .mbar = static_cast<uint16_t>(bar * 1000) };
+	return o2pressure_t { .mbar = static_cast<uint16_t>(bar * 1000) };
 }
 
 struct bearing_t : public unit_base<bearing_t>
@@ -212,7 +212,7 @@ struct temperature_t : public unit_base<temperature_t>
 };
 static inline temperature_t operator""_K(unsigned long long K)
 {
-	return { .mkelvin = static_cast<uint32_t>(K * 1000) };
+	return temperature_t { .mkelvin = static_cast<uint32_t>(K * 1000) };
 }
 
 struct temperature_sum_t : public unit_base<temperature_sum_t>
@@ -226,11 +226,11 @@ struct volume_t : public unit_base<volume_t>
 };
 static inline volume_t operator""_ml(unsigned long long ml)
 {
-	return { .mliter = static_cast<int>(ml) };
+	return volume_t { .mliter = static_cast<int>(ml) };
 }
 static inline volume_t operator""_l(unsigned long long l)
 {
-	return { .mliter = static_cast<int>(l * 1000) };
+	return volume_t { .mliter = static_cast<int>(l * 1000) };
 }
 
 struct fraction_t : public unit_base<fraction_t>
@@ -239,11 +239,11 @@ struct fraction_t : public unit_base<fraction_t>
 };
 static inline fraction_t operator""_permille(unsigned long long permille)
 {
-	return { .permille = static_cast<int>(permille) };
+	return fraction_t { .permille = static_cast<int>(permille) };
 }
 static inline fraction_t operator""_percent(unsigned long long percent)
 {
-	return { .permille = static_cast<int>(percent * 10) };
+	return fraction_t { .permille = static_cast<int>(percent * 10) };
 }
 
 struct weight_t : public unit_base<weight_t>


### PR DESCRIPTION
Fixes build failing on Debian Buster (gcc 8.3.0) with:

/build/subsurface-beta-202409160411/./core/units.h: In function 'duration_t operator""_sec(long long unsigned int)': /build/subsurface-beta-202409160411/./core/units.h:149:48: error: could not convert '{((int32_t)sec)}' from '<brace-enclosed initializer list>' to 'duration_t'
  return { .seconds = static_cast<int32_t>(sec) };

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
See comments at https://github.com/subsurface/subsurface/commit/ae81b42fe26fb0f93711d931513421aeb68cc3b5#r146776769

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
@bstoeger 