### PR TITLE
mobile: fix dive detail scrolling

### DIFF
--- a/mobile-widgets/qml/DiveDetails.qml
+++ b/mobile-widgets/qml/DiveDetails.qml
@@ -399,6 +399,8 @@ Kirigami.Page {
 			delegate: Flickable {
 				id: internalScrollView
 				width: diveDetailsListView.width
+				height: diveDetailsListView.height
+				contentHeight: diveDetails.height
 				boundsBehavior: Flickable.StopAtBounds
 				property var modelData: model
 				DiveDetailsView {
@@ -423,6 +425,7 @@ Kirigami.Page {
 		anchors.fill: parent
 		leftMargin: Kirigami.Units.smallSpacing
 		rightMargin: Kirigami.Units.smallSpacing
+		contentHeight: detailsEdit.height
 		// start invisible and scaled down, to get the transition
 		// off to the right start
 		visible: false


### PR DESCRIPTION
When using the current version of Subsurface-mobile, you cannot scroll the dive details (i.e. you cannot see the bottom of the dive information, depending on the size of your screen), nor can you scroll the notes editor.

I'm not sure how I didn't stumble across this earlier, but a git bisect appears to pinpoint commit a39f0e2891 ("Mobile: Fix QML Warnings.") which is quite old.

Partially reverting this seems sufficient to get scrolling for the dive details and dive notes edit working again.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller 