### PR TITLE
Windows: Switch to Build on ubuntu 24.04

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: docker://subsurface/mxe-build:3.2.0
+      image: docker://subsurface/mxe-build:3.3.0
 
     steps:
     - name: checkout sources

--- a/packaging/windows/docker-build.sh
+++ b/packaging/windows/docker-build.sh
@@ -34,7 +34,7 @@ if [[ -z "${CONTAINER_ID}" ]]; then
 		croak "Please make sure GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL are set for the first run of this script."
 	fi
 
-	docker create -v ${SUBSURFACE_ROOT}:${CONTAINER_SUBSURFACE_DIR} --name=${CONTAINER_NAME} subsurface/mxe-build:3.2.0 sleep infinity
+	docker create -v ${SUBSURFACE_ROOT}:${CONTAINER_SUBSURFACE_DIR} --name=${CONTAINER_NAME} subsurface/mxe-build:3.3.0 sleep infinity
 fi
 
 # Start the container


### PR DESCRIPTION
Switch the Windows build to run on ubuntu 24.04, and also update to use the latest version of MXE.

Signed-off-by: Michael Keller <github@ike.ch>
