### PR TITLE
Make the "Save dive data as subtitles" feature more configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+desktop: update "Save dive data as subtitles" feature to make it more configurable.
 bluetooth: fix crash on MacOS when doing first download from a new BLE device
 statistics: show proper dates in January
 desktop: add country to the fields indexed for full text search

--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -1816,14 +1816,51 @@ from the _Media_ tab as well as the dive profile.
 
 By right-clicking on a video and selecting the "Save dive data as subtitles" option, a subtitles
 file with the same name as the video but with an ".ass" extension is created that contains
-time dependent dive data (runtime, depth, temperature, NDL, TTS, surface GF) to be overlayed
-with the video. The VLC video player automatically finds this file upon playing the video
-and overlays the dive data. Alternatively, the ffmpeg video encoder can be used to create a
+time dependent dive data to be overlayed with the video. The format of the subtitle is specified
+in the _Media preferences_ (_File->Preferences->Media_). The tags used in the format string are
+replaced with the actual values, if present, or removed if not present in the data.
+The VLC video player automatically finds this file upon playing
+the video and overlays the dive data. Alternatively, the ffmpeg video encoder can be used to create a
 new video file with the dive data encoded in the video stream. To do so run
 
 	ffmpeg -v video.mp4 -vf "ass=video.ass" video_with_data.mp4
 
 from the command line. You need to have the libass library installed.
+
+Available tags are:
+* Dive time: [time]
+* Depth: [depth]
+* Temperature: [temperature]
+* Ceiling: [ceiling]
+* NDL: [ndl]
+* TTS: [tts]
+* RBT: [rbt]
+* Stop time: [stoptime]
+* Stop depth: [stopdepth]
+* CNS: [cns]
+* SAC: [sac]
+* pO₂: [p_o2]
+* pN₂: [p_n2]
+* pHe: [p_he]
+* O₂ pressure (rebreather): [o2_pressure]
+* O₂ setpoint: [o2_setpoint]
+* SCR ΔpO₂: [scr_oc_po2]
+* MOD: [mod]
+* EAD: [ead]
+* END: [end]
+* EADD: [eadd]
+* Vertical speed: [speed]
+* In deco (calculated): [in_deco]
+* NDL (calculated): [ndl_calc]
+* TTS (calculated): [tts_calc]
+* Stop time (calculated): [stoptime_calc]
+* Stop depth (calculated): [stopdepth_calc]
+* Heartrate: [heartrate]
+* Bearing: [bearing]
+* Surface GF: [surface_gf]
+* Current GF: [current_gf]
+* Density: [density]
+* ICD Warning: [icd_warning]
 
 ==== Media on an external hard disk
 Most underwater photographers store media on an external drive. If such a drive can be mapped by the operating system

--- a/core/pref.h
+++ b/core/pref.h
@@ -113,6 +113,7 @@ struct preferences {
 	bool	    extract_video_thumbnails;
 	int	    extract_video_thumbnails_position; // position in stream: 0=first 100=last second
 	std::string ffmpeg_executable; // path of ffmpeg binary
+	std::string	subtitles_format_string; // Format string for subtitles generated from the dive data
 	int         defaultsetpoint; // default setpoint in mbar
 	std::string default_filename;
 	enum def_file_behavior default_file_behavior;

--- a/core/save-profiledata.cpp
+++ b/core/save-profiledata.cpp
@@ -47,10 +47,10 @@ static std::string video_time(int secs)
 	return format_string_std("%d:%02d:%02d.000,", hours, mins, secs);
 }
 
-void replace_all(std::string& str, const std::string& old_value, const std::string& new_value) {
+static void replace_all(std::string &str, const std::string &old_value, const std::string &new_value) {
     if (old_value.empty())
         return;
-    size_t start_pos = std::string::npos;
+    size_t start_pos = 0;
     while ((start_pos = str.find(old_value, start_pos)) != std::string::npos) {
         str.replace(start_pos, old_value.length(), new_value);
         start_pos += new_value.length(); // In case 'new_value' contains 'old_value', like replacing 'x' with 'yx'

--- a/core/settings/qPrefMedia.cpp
+++ b/core/settings/qPrefMedia.cpp
@@ -15,6 +15,7 @@ void qPrefMedia::loadSync(bool doSync)
 	disk_extract_video_thumbnails(doSync);
 	disk_extract_video_thumbnails_position(doSync);
 	disk_ffmpeg_executable(doSync);
+	disk_subtitles_format_string(doSync);
 	disk_auto_recalculate_thumbnails(doSync);
 	disk_auto_recalculate_thumbnails(doSync);
 }
@@ -23,3 +24,4 @@ HANDLE_PREFERENCE_BOOL(Media, "auto_recalculate_thumbnails", auto_recalculate_th
 HANDLE_PREFERENCE_BOOL(Media, "extract_video_thumbnails", extract_video_thumbnails);
 HANDLE_PREFERENCE_INT(Media, "extract_video_thumbnails_position", extract_video_thumbnails_position);
 HANDLE_PREFERENCE_TXT(Media, "ffmpeg_executable", ffmpeg_executable);
+HANDLE_PREFERENCE_TXT(Media, "subtitles_format_string", subtitles_format_string);

--- a/core/settings/qPrefMedia.h
+++ b/core/settings/qPrefMedia.h
@@ -11,6 +11,7 @@ class qPrefMedia : public QObject {
 	Q_PROPERTY(bool extract_video_thumbnails READ extract_video_thumbnails WRITE set_extract_video_thumbnails NOTIFY extract_video_thumbnailsChanged)
 	Q_PROPERTY(int extract_video_thumbnails_position READ extract_video_thumbnails_position WRITE set_extract_video_thumbnails_position NOTIFY extract_video_thumbnails_positionChanged)
 	Q_PROPERTY(QString ffmpeg_executable READ ffmpeg_executable WRITE set_ffmpeg_executable  NOTIFY ffmpeg_executableChanged)
+	Q_PROPERTY(QString subtitles_format_string READ subtitles_format_string WRITE set_subtitles_format_string  NOTIFY subtitles_format_stringChanged)
 
 public:
 	static qPrefMedia *instance();
@@ -25,18 +26,21 @@ public:
 	static bool extract_video_thumbnails() { return prefs.extract_video_thumbnails; }
 	static int extract_video_thumbnails_position() { return prefs.extract_video_thumbnails_position; }
 	static QString ffmpeg_executable() { return QString::fromStdString(prefs.ffmpeg_executable); }
+	static QString subtitles_format_string() { return QString::fromStdString(prefs.subtitles_format_string); }
 
 public slots:
 	static void set_auto_recalculate_thumbnails(bool value);
 	static void set_extract_video_thumbnails(bool value);
 	static void set_extract_video_thumbnails_position(int value);
 	static void set_ffmpeg_executable(const QString& value);
+	static void set_subtitles_format_string(const QString& value);
 
 signals:
 	void auto_recalculate_thumbnailsChanged(bool value);
 	void extract_video_thumbnailsChanged(bool value);
 	void extract_video_thumbnails_positionChanged(int value);
 	void ffmpeg_executableChanged(const QString& value);
+	void subtitles_format_stringChanged(const QString& value);
 
 private:
 	qPrefMedia() {}
@@ -45,6 +49,7 @@ private:
 	static void disk_extract_video_thumbnails(bool doSync);
 	static void disk_extract_video_thumbnails_position(bool doSync);
 	static void disk_ffmpeg_executable(bool doSync);
+	static void disk_subtitles_format_string(bool doSync);
 
 };
 

--- a/core/subsurfacestartup.cpp
+++ b/core/subsurfacestartup.cpp
@@ -197,6 +197,7 @@ void setup_system_prefs()
 	default_prefs.divelist_font = system_divelist_default_font;
 	default_prefs.font_size = system_divelist_default_font_size;
 	default_prefs.ffmpeg_executable = "ffmpeg";
+	default_prefs.subtitles_format_string = "[time] D=[depth] T=[temperature] sGF=[surface_gf]";
 
 #if !defined(SUBSURFACE_MOBILE)
 	default_prefs.default_filename = system_default_filename();

--- a/desktop-widgets/preferences/preferences_media.cpp
+++ b/desktop-widgets/preferences/preferences_media.cpp
@@ -71,6 +71,7 @@ void PreferencesMedia::refreshSettings()
 	ui->extractVideoThumbnails->setChecked(qPrefMedia::extract_video_thumbnails());
 	ui->videoThumbnailPosition->setValue(qPrefMedia::extract_video_thumbnails_position());
 	ui->ffmpegExecutable->setText(qPrefMedia::ffmpeg_executable());
+	ui->subtitlesFormatString->setText(qPrefMedia::subtitles_format_string());
 
 	ui->auto_recalculate_thumbnails->setChecked(prefs.auto_recalculate_thumbnails);
 }
@@ -81,5 +82,6 @@ void PreferencesMedia::syncSettings()
 	media->set_extract_video_thumbnails(ui->extractVideoThumbnails->isChecked());
 	media->set_extract_video_thumbnails_position(ui->videoThumbnailPosition->value());
 	media->set_ffmpeg_executable(ui->ffmpegExecutable->text());
+	media->set_subtitles_format_string(ui->subtitlesFormatString->text());
 	qPrefMedia::set_auto_recalculate_thumbnails(ui->auto_recalculate_thumbnails->isChecked());
 }

--- a/desktop-widgets/preferences/preferences_media.ui
+++ b/desktop-widgets/preferences/preferences_media.ui
@@ -170,6 +170,319 @@
     </widget>
    </item>
 
+   <item>
+    <widget class="QGroupBox" name="groupBox_11">
+     <property name="title">
+      <string>Dive data as subtitles</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="horizontalSpacing">
+       <number>5</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>5</number>
+      </property>
+      <property name="margin">
+       <number>5</number>
+      </property>
+
+      <item row="0" column="0">
+       <widget class="QLabel" name="subtitlesFormatStringLabel">
+        <property name="text">
+         <string>Subtitle format string:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLineEdit" name="subtitlesFormatString"/>
+        </item>
+       </layout>
+      </item>
+      
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="label_help_video_4">
+        <property name="toolTip">
+         <string extracomment="Help info 4"/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Available tags:</string>
+        </property>
+       </widget>
+      </item>
+      
+      <item row="2" column="0">
+       <widget class="QLabel" name="subtitlesTimeLabel">
+        <property name="text">
+         <string>Dive time: [time]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0">
+       <widget class="QLabel" name="subtitlesDepthLabel">
+        <property name="text">
+         <string>Depth: [depth]</string>
+        </property>
+       </widget>
+      </item>
+      
+      <item row="4" column="0">
+       <widget class="QLabel" name="subtitlesTemperatureLabel">
+        <property name="text">
+         <string>Temperature: [temperature]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="5" column="0">
+       <widget class="QLabel" name="subtitlesCeilingLabel">
+        <property name="text">
+         <string>Ceiling: [ceiling]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="6" column="0">
+       <widget class="QLabel" name="subtitlesNdlLabel">
+        <property name="text">
+         <string>NDL: [ndl]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="7" column="0">
+       <widget class="QLabel" name="subtitlesTtsLabel">
+        <property name="text">
+         <string>TTS: [tts]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="8" column="0">
+       <widget class="QLabel" name="subtitlesRbtLabel">
+        <property name="text">
+         <string>RBT: [rbt]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="9" column="0">
+       <widget class="QLabel" name="subtitlesStoptimeLabel">
+        <property name="text">
+         <string>Stop time: [stoptime]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="10" column="0">
+       <widget class="QLabel" name="subtitlesStopdepthLabel">
+        <property name="text">
+         <string>Stop depth: [stopdepth]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="11" column="0">
+       <widget class="QLabel" name="subtitlesCnsLabel">
+        <property name="text">
+         <string>CNS: [cns]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="12" column="0">
+       <widget class="QLabel" name="subtitlesSacLabel">
+        <property name="text">
+         <string>SAC: [sac]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="13" column="0">
+       <widget class="QLabel" name="subtitlesPO2Label">
+        <property name="text">
+         <string>pO₂: [p_o2]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="14" column="0">
+       <widget class="QLabel" name="subtitlesPN2Label">
+        <property name="text">
+         <string>pN₂: [p_n2]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="15" column="0">
+       <widget class="QLabel" name="subtitlesPHeLabel">
+        <property name="text">
+         <string>pHe: [p_he]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="16" column="0">
+       <widget class="QLabel" name="subtitlesO2pressureLabel">
+        <property name="text">
+         <string>O₂ pressure (rebreather): [o2_pressure]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="17" column="0">
+       <widget class="QLabel" name="subtitlesO2setpointLabel">
+        <property name="text">
+         <string>O₂ setpoint: [o2_setpoint]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="18" column="0">
+       <widget class="QLabel" name="subtitlesScr_oc_p02Label">
+        <property name="text">
+          <string>SCR ΔpO₂: [scr_oc_po2]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="1">
+       <widget class="QLabel" name="subtitlesModLabel">
+        <property name="text">
+         <string>MOD: [mod]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="1">
+       <widget class="QLabel" name="subtitlesEadLabel">
+        <property name="text">
+         <string>EAD: [ead]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="4" column="1">
+       <widget class="QLabel" name="subtitlesEndLabel">
+        <property name="text">
+         <string>END: [end]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="5" column="1">
+       <widget class="QLabel" name="subtitlesEaddLabel">
+        <property name="text">
+         <string>EADD: [eadd]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="6" column="1">
+       <widget class="QLabel" name="subtitlesSpeedLabel">
+        <property name="text">
+         <string>Vertical speed: [speed]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="7" column="1">
+       <widget class="QLabel" name="subtitlesIn_deco_calcLabel">
+        <property name="text">
+         <string>In deco (calculated): [in_deco]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="8" column="1">
+       <widget class="QLabel" name="subtitlesNdlCalcLabel">
+        <property name="text">
+         <string>NDL (calculated): [ndl_calc]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="9" column="1">
+       <widget class="QLabel" name="subtitlesTts_calcLabel">
+        <property name="text">
+         <string>TTS (calculated): [tts_calc]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="10" column="1">
+       <widget class="QLabel" name="subtitlesStoptime_calcLabel">
+        <property name="text">
+         <string>Stop time (calculated): [stoptime_calc]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="11" column="1">
+       <widget class="QLabel" name="subtitlesStopdepth_calcLabel">
+        <property name="text">
+         <string>Stop depth (calculated): [stopdepth_calc]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="12" column="1">
+       <widget class="QLabel" name="subtitlesHeartrateLabel">
+        <property name="text">
+         <string>Heartrate: [heartrate]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="13" column="1">
+       <widget class="QLabel" name="subtitlesBearingLabel">
+        <property name="text">
+         <string>Bearing: [bearing]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="14" column="1">
+       <widget class="QLabel" name="subtitlesSurface_gfLabel">
+        <property name="text">
+         <string>Surface GF: [surface_gf]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="15" column="1">
+       <widget class="QLabel" name="subtitlesCurrent_gfLabel">
+        <property name="text">
+         <string>Current GF: [current_gf]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="16" column="1">
+       <widget class="QLabel" name="subtitlesDensityLabel">
+        <property name="text">
+         <string>Density: [density]</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="17" column="1">
+       <widget class="QLabel" name="subtitlesIcd_warningLabel">
+        <property name="text">
+         <string>ICD Warning: [icd_warning]</string>
+        </property>
+       </widget>
+      </item>
+
+     </layout>
+    </widget>
+   </item>
+
    <item row="5" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -186,6 +499,7 @@
 
   </layout>
  </widget>
+
  <resources/>
  <connections>
  </connections>


### PR DESCRIPTION
Previously, the subtitle generation was hardcoded, making it unsuitable if you didn't want all of the displayed values. This has been replaced by a format string that is configurable in the settings, using predefined tags that are replaced with the values. The default value for this has been set to (mostly) match the currently generated subtitle string. This also provides a good starting point for users that want to modify the string.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Previously, the subtitle generation was hardcoded, making it unsuitable if you didn't want all of the displayed values. This has been replaced by a format string configurable in the settings, using predefined tags replaced with the corresponding values. The default value for this has been set to (mostly) match the currently generated subtitle string. This also provides a good starting point for users who want to modify the string. Further, a small fix has been added where the subtitles now start at the beginning of the video, and not at the first datapoint after the video starts. A table of the available tags has also been added directly below the input field.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Added "Subtitle format string" and "Available tags" under a new "Dive data as subtitles" section in the Media preferences.
2) Added `subtitles_format_string` to `preferences` struct.
3) Updated `format_st_event` to use the `subtitles_format_string` and replace the tags.
4) Added translation messages to translation source.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
Release note has been added at top of `CHANGELOG.md`

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
New setting in media preferences to specify the subtitle format string.
