### PR TITLE
export-html: prevent invalid json

### DIFF
--- a/core/save-html.cpp
+++ b/core/save-html.cpp
@@ -92,7 +92,8 @@ static void write_dive_status(struct membuffer *b, const struct dive &dive)
 
 static void put_HTML_bookmarks(struct membuffer *b, const struct dive &dive)
 {
-	const char *separator = "\"events\":[";
+	const char *separator = "";
+	put_string(b, "\"events\":[");
 	for (const auto &ev: dive.dcs[0].events) {
 		put_string(b, separator);
 		separator = ", ";


### PR DESCRIPTION
A dive without events could lead to json with extra closing brackets that prevents browsers from rendering the dive log.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
we had three different ways with how we dealt with writing the `key` part of the json key/value when writing out HTML. One of them was flat out wrong in the case that the structure was empty. A dive with no events would have an extra `],` at the end, which caused the browser to fail to parse the json and no dive list to be shown.

With this change we always write `"events": [],` (and add events within the brackets if there are any), which should ensure correct json.

