### PR TITLE
Ubuntu: update supported versions

### DIFF
--- a/packaging/ubuntu/make-package.sh
+++ b/packaging/ubuntu/make-package.sh
@@ -105,7 +105,7 @@ debuild -S -d
 # create builds for the newer Ubuntu releases that Launchpad supports
 #
 rel=focal
-others="jammy mantic noble"
+others="jammy noble oracular"
 for next in $others
 do
 	sed -i "s/${rel}/${next}/g" debian/changelog


### PR DESCRIPTION
Drop 23.10 / Mantic
Add  24.10 / Oracular

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Not quite as late as usual, but of course already late.
I pushed the private headers, so I *think* this should do the right thing after being merged.
I need to remind myself (as usual) how to ensure that the current branch gets built for the new version as well...