### PR TITLE
planner: fix calculations of variations [potential fix for #4368]

### DIFF
--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -74,6 +74,17 @@ diveplan::~diveplan()
 {
 }
 
+diveplan diveplan::copy_planned_segments() const
+{
+	diveplan res = *this;
+
+	// Remove non manually added entries
+	auto it = std::find_if(res.dp.begin(), res.dp.end(),
+			       [] (const divedatapoint &dp) { return dp.time && !dp.entered; });
+	res.dp.erase(it, res.dp.end());
+	return res;
+}
+
 bool diveplan::is_empty() const
 {
 	return std::none_of(dp.begin(), dp.end(), [](const divedatapoint &dp) { return dp.time != 0; });

--- a/core/planner.h
+++ b/core/planner.h
@@ -53,6 +53,7 @@ struct diveplan {
 	bool is_empty() const;
 	void add_plan_to_notes(struct dive &dive, bool show_disclaimer, planner_error_t error);
 	int duration() const;
+	diveplan copy_planned_segments() const; // copy diveplan, but ignore automatically added stops
 };
 
 struct deco_state_cache;

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1127,7 +1127,7 @@ void DivePlannerPointsModel::updateDiveProfile()
 	if (isPlanner() && shouldComputeVariations()) {
 		auto plan_copy = std::make_unique<struct diveplan>();
 		lock_planner();
-		*plan_copy = diveplan;
+		*plan_copy = diveplan.copy_planned_segments();
 		unlock_planner();
 #ifdef VARIATIONS_IN_BACKGROUND
 		// Since we're calling computeVariations asynchronously and plan_deco_state is allocated
@@ -1252,6 +1252,7 @@ void DivePlannerPointsModel::computeVariations(std::unique_ptr<struct diveplan> 
 	auto deeper = plan(&ds, plan_copy, dive.get(), dcNr, 1, cache, true, false);
 	save.restore(&ds, false);
 
+	plan_copy = *original_plan;
 	second_to_last(plan_copy.dp).depth.mm -= delta_depth.mm;
 	plan_copy.dp.back().depth.mm -= delta_depth.mm;
 	if (my_instance != instanceCounter)
@@ -1266,6 +1267,7 @@ void DivePlannerPointsModel::computeVariations(std::unique_ptr<struct diveplan> 
 	auto longer = plan(&ds, plan_copy, dive.get(), dcNr, 1, cache, true, false);
 	save.restore(&ds, false);
 
+	plan_copy = *original_plan;
 	plan_copy.dp.back().time -= delta_time.seconds;
 	if (my_instance != instanceCounter)
 		return;
@@ -1313,7 +1315,7 @@ void DivePlannerPointsModel::createPlan(bool saveAsNew)
 	if (shouldComputeVariations()) {
 		auto plan_copy = std::make_unique<struct diveplan>();
 		lock_planner();
-		*plan_copy = diveplan;
+		*plan_copy = diveplan.copy_planned_segments();
 		unlock_planner();
 		computeVariations(std::move(plan_copy), &ds_after_previous_dives);
 	}


### PR DESCRIPTION
In 8704a8b6f97920090d144919b4546344e7df8bd8 the code in cloneDiveplan() was replaced by a simple assignement statement.

Alas, the original code was more complex: it copied only up to a certain point (it stopped at automatically generated steps).

The new behavior made the calculations of variations fail.

Therefore, readd a function that copies a dive plan, but "forgets" the automatically added stops.

Fixes #4368

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Potential fix for #4368. See commit description and discussion in #4368. Please check / comment.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Remove automatically added stops when copying dive plan.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Hopefully fixes #4368.
