### PR TITLE
Round MOD to lower depths

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -2457,7 +2457,9 @@ int dive::mbar_to_depth(int mbar) const
 depth_t dive::gas_mod(struct gasmix mix, pressure_t po2_limit, int roundto) const
 {
 	double depth = (double) mbar_to_depth(po2_limit.mbar * 1000 / get_o2(mix));
-	return depth_t { .mm = int_cast<int>(depth / roundto) * roundto };
+	// Rounding should be towards lower=safer depths but we give a bit
+	// of fudge to all to switch to o2 at 6m. So from .9 we round up.
+	return depth_t { .mm = (int)(depth / roundto + 0.1) * roundto };
 }
 
 /* Maximum narcotic depth rounded to multiples of roundto mm */

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -865,17 +865,17 @@ void TestPlan::testVpmbMetricRepeat()
 
 	// check minimum gas result
 	dp = std::find_if(testPlan.dp.begin(), testPlan.dp.end(), [](auto &dp) { return dp.minimum_gas.mbar != 0; });
-	QCOMPARE(lrint(dp == testPlan.dp.end() ? 0.0 : dp->minimum_gas.mbar / 1000.0), 80l);
+	QCOMPARE(lrint(dp == testPlan.dp.end() ? 0.0 : dp->minimum_gas.mbar / 1000.0), 85l);
 	// print first ceiling
 	printf("First ceiling %.1f m\n", dive.mbar_to_depth(test_deco_state.first_ceiling_pressure.mbar) * 0.001);
 	QVERIFY(dive.dcs[0].events.size() >= 3);
-	// check first gas change to 21/35 at 66m
+	// check first gas change to 21/35 at 63m
 	struct event *ev = &dive.dcs[0].events[0];
 	QVERIFY(ev != NULL);
 	QCOMPARE(ev->gas.index, 1);
 	QCOMPARE(ev->gas.mix.o2.permille, 210);
 	QCOMPARE(ev->gas.mix.he.permille, 350);
-	QCOMPARE(get_depth_at_time(&dive.dcs[0], ev->time.seconds), 66000);
+	QCOMPARE(get_depth_at_time(&dive.dcs[0], ev->time.seconds), 63000);
 	// check second gas change to EAN50 at 21m
 	ev = &dive.dcs[0].events[1];
 	QCOMPARE(ev->gas.index, 2);


### PR DESCRIPTION
When computing the suggested switch depth for a gas, we should take the next stop depth above the MOD, i.e. round down. Otherwise we can produce MOD violation warnings.

We need, however, a bit of fudge as otherwise we do not suggest to switch to o2 at 6m.

Fixes #4365

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
