### PR TITLE
planner: fix calculations of variations [alternative to #4369]

### DIFF
--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -131,8 +131,7 @@ private:
 	void createTemporaryPlan();
 	struct diveplan diveplan;
 	void computeVariationsDone(QString text);
-	void computeVariations(std::unique_ptr<struct diveplan> plan, const struct deco_state *ds);
-	void computeVariationsFreeDeco(std::unique_ptr<struct diveplan> plan, std::unique_ptr<struct deco_state> ds);
+	void computeVariations(struct diveplan plan, struct deco_state ds); // Note: works on copies of plan and ds
 	int analyzeVariations(const std::vector<decostop> &min, const std::vector<decostop> &mid, const std::vector<decostop> &max, const char *unit);
 	struct dive *d;
 	int dcNr;


### PR DESCRIPTION
In 8704a8b the code in cloneDiveplan() was replaced by a simple assignement statement.

Alas, the original code was more complex: it copied only up to a certain point (it stopped at automatically generated steps).

The new behavior made the calculations of variations fail, because a call to plan() adds deco stops.

Therefore, copy the plan _before_ calling plan().

Fixes #4368

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Alternative version of #4369. I really don't understand what that `lock_planner()` stuff is about. This all looks very fishy to me.

Please comment.