### PR TITLE
Avoid UTF8->UTF16->UTF8 roundtrip when logging on mobile

### DIFF
--- a/core/errorhelper.cpp
+++ b/core/errorhelper.cpp
@@ -12,7 +12,7 @@
 #endif
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-extern void writeToAppLogFile(QString logText);
+extern void writeToAppLogFile(const std::string &logText);
 #endif
 
 int verbose;
@@ -26,7 +26,7 @@ void report_info(const char *fmt, ...)
 	LOG_MSG("INFO: %s\n", s.c_str());
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-	writeToAppLogFile(s.c_str());
+	writeToAppLogFile(s);
 #endif
 }
 
@@ -41,7 +41,7 @@ int report_error(const char *fmt, ...)
 	LOG_MSG("ERROR: %s\n", s.c_str());
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-	writeToAppLogFile(s.c_str());
+	writeToAppLogFile(s);
 #endif
 
 	/* if there is no error callback registered, don't produce errors */

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1849,20 +1849,20 @@ void QMLManager::setBtEnabled(bool value)
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
 
-void writeToAppLogFile(QString logText)
+void writeToAppLogFile(const std::string &logText)
 {
 	// write to storage and flush so that the data doesn't get lost
-	logText.append("\n");
 	QMLManager *self = QMLManager::instance();
 	if (self) {
 		self->writeToAppLogFile(logText);
 	}
 }
 
-void QMLManager::writeToAppLogFile(QString logText)
+void QMLManager::writeToAppLogFile(const std::string &logText)
 {
 	if (appLogFileOpen) {
-		appLogFile.write(qPrintable(logText));
+		std::string line = logText + "\n";
+		appLogFile.write(line.c_str());
 		appLogFile.flush();
 	}
 }

--- a/mobile-widgets/qmlmanager.h
+++ b/mobile-widgets/qmlmanager.h
@@ -167,7 +167,7 @@ public:
 	QObject *qmlWindow;
 
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-	void writeToAppLogFile(QString logText);
+	void writeToAppLogFile(const std::string &logText);
 #endif
 	qPrefCloudStorage::cloud_status oldStatus() const;
 	void setOldStatus(const qPrefCloudStorage::cloud_status value);


### PR DESCRIPTION
Make writeToAppLogFile() take an std::string parameter to avoid an unnecessary UTF8->UTF16->UTF8 (std::string->QString->char *) roundtrip.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Tiny code cleanup that avoids unnecessary UTF8->UTF16->UTF8 conversions.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Follow up to #4385.