### PR TITLE
Profile: Stop Hiding All Compass Headings.

### DIFF
--- a/profile-widget/diveeventitem.cpp
+++ b/profile-widget/diveeventitem.cpp
@@ -77,12 +77,9 @@ void DiveEventItem::setupPixmap(struct gasmix lastgasmix, const DivePixmaps &pix
 		}
 	} else if ((((ev.flags & SAMPLE_FLAGS_SEVERITY_MASK) >> SAMPLE_FLAGS_SEVERITY_SHIFT) == 1) ||
 		    // those are useless internals of the dive computer
-		   same_string_caseinsensitive(ev.name.c_str(), "heading") ||
 		   (same_string_caseinsensitive(ev.name.c_str(), "SP change") && ev.time.seconds == 0)) {
-		// 2 cases:
-		// a) some dive computers have heading in every sample
-		// b) at t=0 we might have an "SP change" to indicate dive type
-		// in both cases we want to get the right data into the tooltip but don't want the visual clutter
+		// at t=0 we might have an "SP change" to indicate dive type
+		// we want to get the right data into the tooltip but don't want the visual clutter
 		// so set an "almost invisible" pixmap (a narrow but somewhat tall, basically transparent pixmap)
 		// that allows tooltips to work when we don't want to show a specific
 		// pixmap for an event, but want to show the event value in the tooltip


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
It seems to be over the top to hide all compass heading information just
because _some_ dive computers log them for every sample.
A better approach will be to either suppress these in the parser for the
affected dive computer, or let the user suppress them in the
profile if they wish to do so.
Since there is no information in the comments about the manufacturer /
model of the affected dive computer, this is implementing a 'scream
test'.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
https://github.com/mikeller/ostc4/pull/27

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
