### PR TITLE
Create UUID when adding a dive site to core

### DIFF
--- a/commands/command_divesite.cpp
+++ b/commands/command_divesite.cpp
@@ -30,7 +30,7 @@ static std::vector<dive_site *> addDiveSites(std::vector<std::unique_ptr<dive_si
 		}
 
 		// Add dive site to core, but remember a non-owning pointer first.
-		auto add_res = divelog.sites.put(std::move(ds)); // Return ownership to backend.
+		auto add_res = divelog.sites.register_site(std::move(ds)); // Return ownership to backend.
 		res.push_back(add_res.ptr);
 		emit diveListNotifier.diveSiteAdded(res.back(), add_res.idx); // Inform frontend of new dive site.
 	}


### PR DESCRIPTION
3f8b4604be introduced a bug: it replaced alloc_dive_site() by the divesite constructor. However, the latter does not generate a UUID (for that it would have to access the dive site table).

Thus newly added dive sites had no UUID and could not be saved properly.

Use the register_site() instead of the put() function when adding the dive site to the core, so that the UUID is created if needed.

This needs an audit.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Bug fix for creation of dive sites.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Create UUID when adding UUID-less dive site to core