### PR TITLE
Profile: Improve Display of Bailout / Loop Events.

### DIFF
--- a/core/dive.h
+++ b/core/dive.h
@@ -7,6 +7,7 @@
 #include "divemode.h"
 #include "divecomputer.h"
 #include "equipment.h"
+#include "event.h"
 #include "picture.h" // TODO: remove
 #include "tag.h"
 
@@ -103,9 +104,9 @@ struct dive {
 	bool likely_same(const struct dive &b) const;
 	bool is_cylinder_used(int idx) const;
 	bool is_cylinder_prot(int idx) const;
-	int get_cylinder_index(const struct event &ev) const;
+	int get_cylinder_index(const struct event &ev, const struct divecomputer &dc) const;
 	bool has_gaschange_event(const struct divecomputer *dc, int idx) const;
-	struct gasmix get_gasmix_from_event(const struct event &ev) const;
+	std::pair<const struct gasmix, divemode_t> get_gasmix_from_event(const struct event &ev, const struct divecomputer &dc) const;
 	struct gasmix get_gasmix_at_time(const struct divecomputer &dc, duration_t time) const;
 	cylinder_t *get_cylinder(int idx);
 	cylinder_t *get_or_create_cylinder(int idx);
@@ -152,6 +153,8 @@ struct dive_or_trip {
 extern void cylinder_renumber(struct dive &dive, int mapping[]);
 extern int same_gasmix_cylinder(const cylinder_t &cyl, int cylid, const struct dive *dive, bool check_unused);
 extern bool is_cylinder_use_appropriate(const struct divecomputer &dc, const cylinder_t &cyl, bool allowNonUsable);
+extern divemode_t get_effective_divemode(const struct divecomputer &dc, const struct cylinder_t &cylinder);
+extern std::tuple<divemode_t, int, const struct gasmix *> get_dive_status_at(const struct dive &dive, const struct divecomputer &dc, int seconds, divemode_loop *loop_mode = nullptr, gasmix_loop *loop_gas = nullptr);
 
 /* Data stored when copying a dive */
 struct dive_paste_data {

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -200,19 +200,20 @@ void fake_dc(struct divecomputer *dc)
 }
 
 divemode_loop::divemode_loop(const struct divecomputer &dc) :
-	last(dc.divemode), loop("modechange", dc)
+	last(dc.divemode), last_time(0), loop("modechange", dc)
 {
 	/* on first invocation, get first event (if any) */
 	ev = loop.next();
 }
 
-divemode_t divemode_loop::at(int time)
+std::pair<divemode_t, int> divemode_loop::at(int time)
 {
 	while (ev && ev->time.seconds <= time) {
 		last = static_cast<divemode_t>(ev->value);
+		last_time = ev->time.seconds;
 		ev = loop.next();
 	}
-	return last;
+	return std::make_pair(last, last_time);
 }
 
 /* helper function to make it easier to work with our structures

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -424,8 +424,8 @@ static void add_dive_to_deco(struct deco_state *ds, const struct dive &dive, boo
 {
 	const struct divecomputer *dc = &dive.dcs[0];
 
-	gasmix_loop loop(dive, dive.dcs[0]);
-	divemode_loop loop_d(dive.dcs[0]);
+	gasmix_loop loop_gas(dive, dive.dcs[0]);
+	divemode_loop loop_mode(dive.dcs[0]);
 	for (auto [psample, sample]: pairwise_range(dc->samples)) {
 		int t0 = psample.time.seconds;
 		int t1 = sample.time.seconds;
@@ -433,9 +433,9 @@ static void add_dive_to_deco(struct deco_state *ds, const struct dive &dive, boo
 
 		for (j = t0; j < t1; j++) {
 			depth_t depth = interpolate(psample.depth, sample.depth, j - t0, t1 - t0);
-			auto gasmix = loop.at(j).first;
-			add_segment(ds, dive.depth_to_bar(depth), gasmix, 1, sample.setpoint.mbar,
-				    loop_d.at(j), dive.sac,
+			[[maybe_unused]] auto [divemode, _cylinder_index, gasmix] = get_dive_status_at(dive, dive.dcs[0], j);
+			add_segment(ds, dive.depth_to_bar(depth), *gasmix, 1, sample.setpoint.mbar,
+				    divemode, dive.sac,
 				    in_planner);
 		}
 	}

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -27,7 +27,7 @@ cylinder_t::~cylinder_t() = default;
 static cylinder_t make_surface_air_cylinder()
 {
 	cylinder_t res;
-	res.cylinder_use = NOT_USED;
+	res.cylinder_use = OC_GAS;
 	return res;
 }
 static const cylinder_t surface_air_cylinder = make_surface_air_cylinder();

--- a/core/event.h
+++ b/core/event.h
@@ -73,19 +73,20 @@ class gasmix_loop {
 	const struct event *next_event;
 	int last_cylinder_index;
 	int last_time;
+	std::pair<gasmix, int> get_last_gasmix();
 public:
 	gasmix_loop(const struct dive &dive, const struct divecomputer &dc);
 	// Return the next cylinder index / gasmix from the list of gas switches
 	// and the time in seconds when this gas switch happened
 	// (including the potentially imaginary first gas switch to cylinder 0 / air)
-	std::pair<int, int> next_cylinder_index(); // -1 -> end
-	std::pair<gasmix, int> next(); // gasmix_invalid -> end
+	std::pair<int, int> next_cylinder_index(); // <-1, 0> => implicit air cylinder, <-1, INT_MAX> => end
+	std::pair<gasmix, int> next(); // <gasmix_invalid, INT_MAX> => end
 
 	// Return the cylinder index / gasmix at a given time during the dive
 	// and the time in seconds when this switch to this gas happened
 	// (including the potentially imaginary first gas switch to cylinder 0 / air)
-	std::pair<int, int> cylinder_index_at(int time); // -1 -> end
-	std::pair<gasmix, int> at(int time); // gasmix_invalid -> end
+	std::pair<int, int> cylinder_index_at(int time); // <-1, 0> => implicit air cylinder
+	std::pair<gasmix, int> at(int time);
 
 	bool has_next() const;
 };
@@ -93,12 +94,14 @@ public:
 /* Get divemodes at increasing timestamps. */
 class divemode_loop {
 	divemode_t last;
+	int last_time;
 	event_loop loop;
 	const struct event *ev;
 public:
 	divemode_loop(const struct divecomputer &dc);
 	// Return the divemode at a given time during the dive
-	divemode_t at(int time);
+	// and the time in seconds when the switch to this divemode has happened
+	std::pair<divemode_t, int> at(int time);
 };
 
 extern const struct event *get_first_event(const struct divecomputer &dc, const std::string &name);

--- a/core/gaspressures.cpp
+++ b/core/gaspressures.cpp
@@ -198,7 +198,7 @@ static void fill_missing_tank_pressures(const struct dive *dive, struct plot_inf
 	dump_pr_track(cyl, track_pr);
 #endif
 
-	/* Transfer interpolated cylinder pressures from pr_track strucktures to plotdata
+	/* Transfer interpolated cylinder pressures from pr_track structures to plotdata
 	 * Go down the list of tank pressures in plot_info. Align them with the start &
 	 * end times of each profile segment represented by a pr_track_t structure. Get
 	 * the accumulated pressure_depths from the pr_track_t structures and then
@@ -248,7 +248,7 @@ static void fill_missing_tank_pressures(const struct dive *dive, struct plot_inf
 			last_segment = it;
 		}
 
-		if(dive->get_cylinder(cyl)->cylinder_use == OC_GAS) {
+		if (dive->get_cylinder(cyl)->cylinder_use == OC_GAS) {
 
 			/* if this segment has pressure_time, then calculate a new interpolated pressure */
 			if (interpolate.pressure_time) {
@@ -358,16 +358,15 @@ void populate_pressure_information(const struct dive *dive, const struct divecom
 		int pressure = get_plot_sensor_pressure(pi, i, sensor);
 		int time = entry.sec;
 
+		[[maybe_unused]] auto [divemode, cylinder_index, _gasmix] = get_dive_status_at(*dive, *dc, time, &loop_mode, &loop_gas);
 		if (has_gaschange) {
-			cyl = loop_gas.cylinder_index_at(time).first;
+			cyl = cylinder_index;
 			if (cyl < 0)
 				cyl = sensor;
 		}
 
-		divemode_t dmode = loop_mode.at(time);
-
 		if (current != std::string::npos) { // calculate pressure-time, taking into account the dive mode for this specific segment.
-			entry.pressure_time = (int)(calc_pressure_time(dive, pi.entry[i - 1], entry) * gasfactor[dmode] + 0.5);
+			entry.pressure_time = (int)(calc_pressure_time(dive, pi.entry[i - 1], entry) * gasfactor[divemode] + 0.5);
 			track[current].pressure_time += entry.pressure_time;
 			track[current].t_end = entry.sec;
 			if (pressure)

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -197,6 +197,17 @@ static void update_cylinder_pressure(struct dive *d, int old_depth, int new_dept
 	}
 }
 
+static struct sample *create_sample(struct divecomputer &dc, int time, depth_t depth, bool entered)
+{
+	struct sample *sample = prepare_sample(&dc);
+	sample->time.seconds = time;
+	sample->depth = depth;
+	sample->manually_entered = entered;
+	sample->sac.mliter = entered ? prefs.bottomsac : prefs.decosac;
+
+	return sample;
+}
+
 /* overwrite the data in dive
  * return false if something goes wrong */
 static void create_dive_from_plan(struct diveplan &diveplan, struct dive *dive, struct divecomputer *dc, bool track_gas)
@@ -263,34 +274,36 @@ static void create_dive_from_plan(struct diveplan &diveplan, struct dive *dive, 
 				report_error("Invalid cylinder in create_dive_from_plan(): %d", dp.cylinderid);
 				continue;
 			}
-			sample = prepare_sample(dc);
-			sample[-1].setpoint.mbar = po2;
+
+			sample->setpoint.mbar = po2;
 			if (po2)
-				sample[-1].o2sensor[0].mbar = po2;
-			sample->time.seconds = lasttime + 1;
-			sample->depth = lastdepth;
-			sample->manually_entered = dp.entered;
-			sample->sac.mliter = dp.entered ? prefs.bottomsac : prefs.decosac;
+				sample->o2sensor[0].mbar = po2;
+			type = get_effective_divemode(*dc, *cyl);
+
+			sample = create_sample(*dc, lasttime + 1, lastdepth, dp.entered);
+
 			lastcylid = dp.cylinderid;
 		}
 		if (dp.divemode != type) {
 			type = dp.divemode;
-			add_event(dc, lasttime, SAMPLE_EVENT_BOOKMARK, 0, type, "modechange");
+			if ((dc->divemode == CCR && prefs.allowOcGasAsDiluent && cyl->cylinder_use == OC_GAS) || dc->divemode == PSCR)
+				add_event(dc, lasttime, SAMPLE_EVENT_BOOKMARK, 0, type, "modechange");
 		}
 
-		/* Create sample */
-		sample = prepare_sample(dc);
 		/* set po2 at beginning of this segment */
 		/* and keep it valid for last sample - where it likely doesn't matter */
-		sample[-1].setpoint.mbar = po2;
 		sample->setpoint.mbar = po2;
-		sample->time.seconds = lasttime = time;
-		if (dp.entered) last_manual_point = dp.time;
-		sample->depth = lastdepth = depth;
-		sample->manually_entered = dp.entered;
-		sample->sac.mliter = dp.entered ? prefs.bottomsac : prefs.decosac;
-		if (track_gas && !sample[-1].setpoint.mbar) {    /* Don't track gas usage for CCR legs of dive */
-			update_cylinder_pressure(dive, sample[-1].depth.mm, depth.mm, time - sample[-1].time.seconds,
+
+		sample = create_sample(*dc, time, depth, dp.entered);
+		sample->setpoint.mbar = po2;
+		if (dp.entered)
+			last_manual_point = time;
+		lastdepth = depth;
+		lasttime = time;
+
+		if (track_gas) {
+			if (!sample[-1].setpoint.mbar)    /* Don't track gas usage for CCR legs of dive */
+				update_cylinder_pressure(dive, sample[-1].depth.mm, depth.mm, time - sample[-1].time.seconds,
 					dp.entered ? diveplan.bottomsac : diveplan.decosac, cyl, !dp.entered, type);
 			if (cyl->type.workingpressure.mbar)
 				sample->pressure[0].mbar = cyl->end.mbar;

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -588,7 +588,7 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 					std::string temp;
 					struct gasmix gasmix = dive.get_cylinder(dp.cylinderid)->gasmix;
 
-					divemode_t current_divemode = loop.at(dp.time);
+					divemode_t current_divemode = loop.at(dp.time).first;
 					amb = dive.depth_to_atm(dp.depth);
 					gas_pressures pressures = fill_pressures(amb, gasmix, (current_divemode == OC) ? 0.0 : amb * gasmix.o2.permille / 1000.0, current_divemode);
 

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -373,7 +373,7 @@ static void save_samples(struct membuffer *b, const struct dive &dive, const str
 		save_sample(b, s, dummy, o2sensor);
 }
 
-static void save_one_event(struct membuffer *b, const struct dive &dive, const struct event &ev)
+static void save_one_event(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc, const struct event &ev)
 {
 	put_format(b, "event %d:%02d", FRACTION_TUPLE(ev.time.seconds, 60));
 	show_index(b, ev.type, "type=", "");
@@ -385,7 +385,7 @@ static void save_one_event(struct membuffer *b, const struct dive &dive, const s
 		show_index(b, ev.value, "value=", "");
 	show_utf8(b, " name=", ev.name.c_str(), "");
 	if (ev.is_gaschange()) {
-		struct gasmix mix = dive.get_gasmix_from_event(ev);
+		struct gasmix mix = dive.get_gasmix_from_event(ev, dc).first;
 		if (ev.gas.index >= 0)
 			show_integer(b, ev.gas.index, "cylinder=", "");
 		put_gasmix(b, mix);
@@ -396,7 +396,7 @@ static void save_one_event(struct membuffer *b, const struct dive &dive, const s
 static void save_events(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc)
 {
 	for (auto &ev: dc.events)
-		save_one_event(b, dive, ev);
+		save_one_event(b, dive, dc, ev);
 }
 
 static void save_dc(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc)

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -342,7 +342,7 @@ static void save_sample(struct membuffer *b, const struct sample &sample, struct
 	put_format(b, " />\n");
 }
 
-static void save_one_event(struct membuffer *b, const struct dive &dive, const struct event &ev)
+static void save_one_event(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc, const struct event &ev)
 {
 	put_format(b, "  <event time='%d:%02d min'", FRACTION_TUPLE(ev.time.seconds, 60));
 	show_index(b, ev.type, "type='", "'");
@@ -353,7 +353,7 @@ static void save_one_event(struct membuffer *b, const struct dive &dive, const s
 		show_index(b, ev.value, "value='", "'");
 	show_utf8(b, ev.name.c_str(), " name='", "'", 1);
 	if (ev.is_gaschange()) {
-		struct gasmix mix = dive.get_gasmix_from_event(ev);
+		struct gasmix mix = dive.get_gasmix_from_event(ev, dc).first;
 		if (ev.gas.index >= 0)
 			show_integer(b, ev.gas.index, "cylinder='", "'");
 		put_gasmix(b, mix);
@@ -365,7 +365,7 @@ static void save_one_event(struct membuffer *b, const struct dive &dive, const s
 static void save_events(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc)
 {
 	for (auto &ev: dc.events)
-		save_one_event(b, dive, ev);
+		save_one_event(b, dive, dc, ev);
 }
 
 static void save_tags(struct membuffer *b, const tag_list &tags)

--- a/desktop-widgets/preferences/preferences_graph.ui
+++ b/desktop-widgets/preferences/preferences_graph.ui
@@ -178,21 +178,28 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="3" column="1" colspan="2">
+       <widget class="QCheckBox" name="allowOcGasAsDiluent">
+        <property name="text">
+         <string>Allow open circuit gas to be used as diluent for CCR</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
        <widget class="QLabel" name="pSCR">
         <property name="text">
          <string>pSCR options:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="5" column="1">
        <widget class="QLabel" name="MetabolicRate">
         <property name="text">
          <string>pSCR metabolic rate O₂</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
+      <item row="5" column="2">
        <widget class="QDoubleSpinBox" name="psro2rate">
         <property name="suffix">
          <string>ℓ/min</string>
@@ -202,7 +209,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
+      <item row="5" column="3">
        <widget class="QLabel" name="label_28">
         <property name="text">
          <string>Dilution ratio</string>
@@ -212,7 +219,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="4">
+      <item row="5" column="4">
        <widget class="QSpinBox" name="pscrfactor">
         <property name="suffix">
          <string/>
@@ -222,7 +229,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="6" column="1">
        <widget class="QCheckBox" name="show_scr_ocpo2">
         <property name="text">
          <string>Show equivalent OC pO₂ with pSCR pO₂</string>
@@ -242,13 +249,6 @@
        <widget class="QCheckBox" name="show_icd">
         <property name="text">
          <string>Show warnings for isobaric counterdiffusion</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="allowOcGasAsDiluent">
-        <property name="text">
-         <string>Allow open circuit gas to be used as diluent for CCR</string>
         </property>
        </widget>
       </item>

--- a/profile-widget/diveeventitem.h
+++ b/profile-widget/diveeventitem.h
@@ -13,7 +13,7 @@ struct plot_info;
 class DiveEventItem : public DivePixmapItem {
 	Q_OBJECT
 public:
-	DiveEventItem(const struct dive *d, int idx, const struct event &ev, struct gasmix lastgasmix,
+	DiveEventItem(const struct dive *d, const struct divecomputer *dc, int idx, const struct event &ev, const struct gasmix lastgasmix, divemode_t lastdivemode,
 		      const struct plot_info &pi, DiveCartesianAxis *hAxis, DiveCartesianAxis *vAxis,
 		      int speed, const DivePixmaps &pixmaps, QGraphicsItem *parent = nullptr);
 	~DiveEventItem();
@@ -25,8 +25,8 @@ public:
 				  int firstSecond, int lastSecond);
 
 private:
-	void setupToolTipString(struct gasmix lastgasmix);
-	void setupPixmap(struct gasmix lastgasmix, const DivePixmaps &pixmaps);
+	void setupToolTipString(struct gasmix lastgasmix, divemode_t lastdivemode, const struct divecomputer &dc);
+	void setupPixmap(struct gasmix lastgasmix, divemode_t lastdivemode, const struct divecomputer &dc, const DivePixmaps &pixmaps);
 	void recalculatePos();
 	DiveCartesianAxis *vAxis;
 	DiveCartesianAxis *hAxis;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
For dives in CCR mode, show 'bailout' and 'on loop' events whenever a
gas switch from a diluent gas to a bailout gas and vice versa happens.

![image](https://github.com/user-attachments/assets/45953c50-62f7-458a-86a0-fde1c1a22309)

This matches how CCR dives are imported from dive computers.

![image](https://github.com/user-attachments/assets/60a2d71c-3cac-446d-b842-495471a7a1eb)

Also don't show context menu actions in the profile to add dive mode changes unless the mode of the dive supports this.
And reshuffle the CCR preferences to match this change.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Improve Display of Bailout / Loop Events;
- Fix the Diveplan Creation;
- Fixup gaschange events;
- Reshuffle the CCR Preference to Keep the Context Correct.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
