### PR TITLE
Import: Fix the Handling of ppO2 Sensor IDs.

### DIFF
--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -585,7 +585,7 @@ static void parse_sample_keyvalue(void *_sample, const char *key, const std::str
 		sample->o2sensor[5] = get_o2pressure(value.c_str());
 		return;
 	}
-	if (!strcmp(key, "sensor7")) {
+	if (!strcmp(key, "dc_supplied_ppo2")) {
 		sample->o2sensor[6] = get_o2pressure(value.c_str());
 		return;
 	}

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -585,6 +585,10 @@ static void parse_sample_keyvalue(void *_sample, const char *key, const std::str
 		sample->o2sensor[5] = get_o2pressure(value.c_str());
 		return;
 	}
+	if (!strcmp(key, "sensor7")) {
+		sample->o2sensor[6] = get_o2pressure(value.c_str());
+		return;
+	}
 	if (!strcmp(key, "o2pressure")) {
 		sample->pressure[1] = get_pressure(value.c_str());
 		return;

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -931,6 +931,8 @@ static void try_to_fill_sample(struct sample *sample, const char *name, char *bu
 		return;
 	if (MATCH("sensor6.sample", double_to_o2pressure, &sample->o2sensor[5])) // up to 6 CCR sensors
 		return;
+	if (MATCH("sensor7.sample", double_to_o2pressure, &sample->o2sensor[6])) // the dive computer calculated ppO2
+		return;
 	if (MATCH("po2.sample", double_to_o2pressure, &sample->setpoint))
 		return;
 	if (MATCH("heartbeat", get_uint8, &sample->heartbeat))

--- a/core/parse-xml.cpp
+++ b/core/parse-xml.cpp
@@ -931,7 +931,7 @@ static void try_to_fill_sample(struct sample *sample, const char *name, char *bu
 		return;
 	if (MATCH("sensor6.sample", double_to_o2pressure, &sample->o2sensor[5])) // up to 6 CCR sensors
 		return;
-	if (MATCH("sensor7.sample", double_to_o2pressure, &sample->o2sensor[6])) // the dive computer calculated ppO2
+	if (MATCH("dc_supplied_ppo2.sample", double_to_o2pressure, &sample->o2sensor[6])) // the dive computer calculated ppO2
 		return;
 	if (MATCH("po2.sample", double_to_o2pressure, &sample->setpoint))
 		return;

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1030,7 +1030,7 @@ static void calculate_deco_information(struct deco_state *ds, const struct deco_
 /* Sort the o2 pressure values. There are so few that a simple bubble sort
  * will do */
 
-void sort_o2_pressures(int *sensorn, int np, const struct plot_data &entry)
+static void sort_o2_pressures(int *sensorn, int np, const struct plot_data &entry)
 {
 	int smallest, position, old;
 
@@ -1196,9 +1196,9 @@ static void debug_print_profiledata(struct plot_info &pi)
 		fprintf(f1, "id t1 gas gasint t2 t3 dil dilint t4 t5 setpoint sensor1 sensor2 sensor3 t6 po2 fo2\n");
 		for (i = 0; i < pi.nr; i++) {
 			struct plot_data &entry = pi.entry[i];
-			fprintf(f1, "%d gas=%8d %8d ; dil=%8d %8d ; o2_sp= %d %d %d %d PO2= %f\n", i, get_plot_sensor_pressure(pi, i),
+			fprintf(f1, "%d gas=%8d %8d ; dil=%8d %8d ; o2_sp= %d %d %d %d %d %d %d PO2= %f\n", i, get_plot_sensor_pressure(pi, i),
 				get_plot_interpolated_pressure(pi, i), O2CYLINDER_PRESSURE(entry), INTERPOLATED_O2CYLINDER_PRESSURE(entry),
-				entry.o2pressure.mbar, entry.o2sensor[0].mbar, entry.o2sensor[1].mbar, entry.o2sensor[2].mbar, entry.pressures.o2);
+				entry.o2pressure.mbar, entry.o2sensor[0].mbar, entry.o2sensor[1].mbar, entry.o2sensor[2].mbar, entry.o2sensor[3].mbar, entry.o2sensor[4].mbar, entry.o2sensor[5].mbar, entry.pressures.o2);
 		}
 		fclose(f1);
 	}

--- a/core/sample.h
+++ b/core/sample.h
@@ -6,6 +6,7 @@
 
 #define MAX_SENSORS 2
 #define MAX_O2_SENSORS 6
+#define DC_REPORTED_PPO2 MAX_O2_SENSORS
 #define NO_SENSOR -1
 
 struct sample                         // BASE TYPE BYTES  UNITS    RANGE               DESCRIPTION
@@ -20,7 +21,7 @@ struct sample                         // BASE TYPE BYTES  UNITS    RANGE        
 	temperature_t temperature;        // uint32_t   4    mK     (0-4 MK)               ambient temperature
 	pressure_t pressure[MAX_SENSORS]; // int32_t  2x4    mbar   (0-2 Mbar)             cylinder pressures (main and CCR o2)
 	o2pressure_t setpoint;            // uint16_t   2    mbar   (0-65 bar)             O2 partial pressure (will be setpoint)
-	o2pressure_t o2sensor[MAX_O2_SENSORS];// uint16_t 6x2    mbar   (0-65 bar)             Up to 6 PO2 sensor values (rebreather)
+	o2pressure_t o2sensor[MAX_O2_SENSORS + 1]; // uint16_t 6x2    mbar   (0-65 bar)             Up to 6 PO2 sensor values (rebreather)
 	bearing_t bearing = { .degrees = -1 };// int16_t    2  degrees  (-1 no val, 0-360 deg) compass bearing
 	int16_t sensor[MAX_SENSORS] = {}; // int16_t  2x2  sensorID (0-16k)                ID of cylinder pressure sensor
 	uint16_t cns = 0;                 // uint16_t   2     %     (0-64k %)              cns% accumulated

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -343,7 +343,7 @@ static void save_sample(struct membuffer *b, const struct sample &sample, struct
 	}
 
 	if ((sample.o2sensor[6].mbar) && (sample.o2sensor[6].mbar != old.o2sensor[6].mbar)) {
-		put_milli(b, " sensor7=", sample.o2sensor[6].mbar, "bar");
+		put_milli(b, " dc_supplied_ppo2=", sample.o2sensor[6].mbar, "bar");
 		old.o2sensor[6] = sample.o2sensor[6];
 	}
 

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -342,6 +342,11 @@ static void save_sample(struct membuffer *b, const struct sample &sample, struct
 		old.o2sensor[5] = sample.o2sensor[5];
 	}
 
+	if ((sample.o2sensor[6].mbar) && (sample.o2sensor[6].mbar != old.o2sensor[6].mbar)) {
+		put_milli(b, " sensor7=", sample.o2sensor[6].mbar, "bar");
+		old.o2sensor[6] = sample.o2sensor[6];
+	}
+
 	if (sample.setpoint.mbar != old.setpoint.mbar) {
 		put_milli(b, " po2=", sample.setpoint.mbar, "bar");
 		old.setpoint = sample.setpoint;

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -328,7 +328,7 @@ static void save_sample(struct membuffer *b, const struct sample &sample, struct
 	}
 
 	if ((sample.o2sensor[6].mbar) && (sample.o2sensor[6].mbar != old.o2sensor[6].mbar)) {
-		put_milli(b, " sensor7='", sample.o2sensor[6].mbar, " bar'");
+		put_milli(b, " dc_supplied_ppo2='", sample.o2sensor[6].mbar, " bar'");
 		old.o2sensor[6] = sample.o2sensor[6];
 	}
 

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -327,6 +327,11 @@ static void save_sample(struct membuffer *b, const struct sample &sample, struct
 		old.o2sensor[5] = sample.o2sensor[5];
 	}
 
+	if ((sample.o2sensor[6].mbar) && (sample.o2sensor[6].mbar != old.o2sensor[6].mbar)) {
+		put_milli(b, " sensor7='", sample.o2sensor[6].mbar, " bar'");
+		old.o2sensor[6] = sample.o2sensor[6];
+	}
+
 	if (sample.setpoint.mbar != old.setpoint.mbar) {
 		put_milli(b, " po2='", sample.setpoint.mbar, " bar'");
 		old.setpoint = sample.setpoint;

--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -234,7 +234,7 @@ void ProfileScene::updateVisibility(bool diveHasHeartBeat, bool simplified)
 		o2SetpointGasItem->setVisible(ppGraphs && prefs.show_ccr_setpoint);
 		ccrsensor1GasItem->setVisible(ppGraphs && prefs.show_ccr_sensors);
 		ccrsensor2GasItem->setVisible(ppGraphs && prefs.show_ccr_sensors && (currentdc->no_o2sensors > 1));
-		ccrsensor3GasItem->setVisible(ppGraphs && prefs.show_ccr_sensors && (currentdc->no_o2sensors > 1));
+		ccrsensor3GasItem->setVisible(ppGraphs && prefs.show_ccr_sensors && (currentdc->no_o2sensors > 2));
 		ocpo2GasItem->setVisible((currentdc->divemode == PSCR) && prefs.show_scr_ocpo2);
 		// No point to show the gradient factor if we're not showing the calculated ceiling that is derived from it
 		decoModelParameters->setVisible(prefs.calcceiling);


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Instead of assigning sensor ids in the order that values are reported,
actually use the sensor ids reported by libdivecomputer. This will fix
the problem that for some dive computers (e.g. Shearwater) the dive
computer calculated ppO2 is currently reported first, thus pushing out
all actual sensor values.
A new fixed id (7) outside of the range of currently supported sensor
IDs is used for these dive computer calculated values.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. use the actual sensor ID when reading ppO2 sensor values from the dive computer;
2. use the new position 7 in the sensor array when storing a `DC_SENSOR_NONE` value;
3. persist and read the `DC_SENSOR_NONE` value as 'sensor7' when persisting and reading from XML and git.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
https://groups.google.com/g/subsurface-divelog/c/wTcSp4gvWJY/m/mr19MVk9CgAJ

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Limitiations:
- 'sensor7' is not handled in XSLT transformations
- `DC_SENSOR_NONE` values are not graphed in the profile

For discussion:
I am not sure if exporting / importing this as 'sensor7' is the correct approach, as this:
- makes it appear as if this were a sensor value;
- will create problems if we ever wanted to increase the number of supported sensors.

Possible alternatives (just for import / export, retaining the in-memory representation as it is):
- 'sensor99'
- 'dc_ppo2_value'

@dirkhh thoughts?

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
