### PR TITLE
Desktop: Close Warning when Closing Logbook.

### DIFF
--- a/desktop-widgets/mainwindow.cpp
+++ b/desktop-widgets/mainwindow.cpp
@@ -509,6 +509,8 @@ bool MainWindow::okToClose(QString message)
 
 void MainWindow::closeCurrentFile()
 {
+	ui.mainErrorMessage->hideNotification();
+
 	/* free the dives and trips */
 	clear_git_id();
 	clear_dive_file_data(); // this clears all the core data structures and resets the models


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Close the warning / error notification when the logbook is closed.

These notifications lingering around long after the condition that
caused them has been addressed or has become irrelevant is annoying.
This could probably be done in a better way by 'remembering' when a
notification is posted, and closing it when the context changes and it
has not been superseded.
But at least when closing the logbook we know that whatever the
notification has been about has become stale.

@bstoeger: What would be a good way in C++ to create a unique 'handle' for the notification to be able to close it if and only if it is still showing?

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
