### PR TITLE
Desktop: Show Warning for Dives with No Viable Cylinders.

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1042,24 +1042,24 @@ static void fixup_dc_sample_sensors(struct dive &dive, struct divecomputer &dc)
 	}
 }
 
-static void fixup_dc_cylinder_use(struct dive &dive, struct divecomputer &dc)
+int check_dc_cylinder_use(struct dive &dive, struct divecomputer &dc)
 {
 
 	if (dc.divemode != OC && dc.divemode != CCR && dc.divemode != PSCR)
-		return;
+		return 1;
 
 	// Check that we have at least one cylinder that is suitable for the dive
 
 	// For OC we default to air if we don't have any cylinders
 
 	if (dc.divemode == OC && dive.cylinders.empty())
-		return;
+		return 1;
 
 	for (auto &cylinder: dive.cylinders)
 		if ((dc.divemode == CCR && cylinder.cylinder_use == DILUENT) || ((dc.divemode == PSCR || dc.divemode == OC) && cylinder.cylinder_use == OC_GAS))
-			return;
+			return 1;
 
-	report_error("Dive: %u, dive computer: %s: %s dive, but no %s cylinder found. Please add or select the correct cylinder use.", dive.number, dc.model.c_str(), dc.divemode == OC ? "open circuit" : dc.divemode == CCR ? "CCR" : "PSCR", dc.divemode == OC ? "open circuit" : dc.divemode == CCR ? "diluent" : "drive gas");
+	return report_error("Dive: %u, dive computer: %s: %s dive, but no %s cylinder found. Please add or select the correct cylinder use.", dive.number, dc.model.c_str(), dc.divemode == OC ? "open circuit" : dc.divemode == CCR ? "CCR" : "PSCR", dc.divemode == OC ? "open circuit" : dc.divemode == CCR ? "diluent" : "drive gas");
 }
 
 
@@ -1091,8 +1091,8 @@ static void fixup_dive_dc(struct dive &dive, struct divecomputer &dc)
 	/* Fixup CCR / PSCR dives with o2sensor values, but without no_o2sensors */
 	fixup_no_o2sensors(dc);
 
-	/* Fixup cylinder use */
-	fixup_dc_cylinder_use(dive, dc);
+	/* Check cylinder use */
+	check_dc_cylinder_use(dive, dc);
 
 	/* If there are no samples, generate a fake profile based on depth and time */
 	if (dc.samples.empty())

--- a/core/dive.h
+++ b/core/dive.h
@@ -206,6 +206,8 @@ extern bool cylinder_with_sensor_sample(const struct dive *dive, int cylinder_id
 
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 
+extern int check_dc_cylinder_use(struct dive &dive, struct divecomputer &dc);
+
 /* Make pointers to dive and dive_trip "Qt metatypes" so that they can be passed through
  * QVariants and through QML.
  */

--- a/core/gas.cpp
+++ b/core/gas.cpp
@@ -62,8 +62,9 @@ void sanitize_gasmix(struct gasmix &mix)
 	/* Sane mix? */
 	if (o2 <= 1000 && he <= 1000 && o2 + he <= 1000)
 		return;
-	report_info("Odd gasmix: %u O2 %u He", o2, he);
+
 	mix = gasmix_air;
+	report_error("Odd gasmix: %u O2 %u He, switched to air.", o2, he);
 }
 
 int gasmix_distance(struct gasmix a, struct gasmix b)

--- a/desktop-widgets/divelistview.h
+++ b/desktop-widgets/divelistview.h
@@ -54,6 +54,8 @@ slots:
 	void shiftTimes();
 	void divesSelectedSlot(const QVector<QModelIndex> &indices, QModelIndex currentDive, int currentDC);
 	void tripSelected(QModelIndex trip, QModelIndex currentDive);
+	void divesChanged(const QVector<dive *> &dives, DiveField field);
+	void cylinderEdited(dive *dive, int);
 private:
 	void rowsInserted(const QModelIndex &parent, int start, int end) override;
 	void reset() override;


### PR DESCRIPTION

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Show a warning when a dive is opened / edited and doesn't have any
usable cylinders for the selected dive mode (i.e. no open circuit gas
for open circuit / PSCR, or no diluent for CCR).

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4413.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
![image](https://github.com/user-attachments/assets/1b7229fc-30ce-463d-b9b3-a491b299bf9c)

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
Reported-by: @kruegerha
