### PR TITLE
profile-widget2: enable vertical line with infobox

### DIFF
--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -255,6 +255,17 @@ void ProfileWidget2::divesChanged(const QVector<dive *> &dives, DiveField field)
 
 void ProfileWidget2::actionRequestedReplot(bool)
 {
+	/* this is called vai infoboxChanged, therefore in currentState==PROFILE
+	   we have to set the mouseFollowerVertical to visible (if prefs.infobox)    hk  */
+#ifndef SUBSURFACE_MOBILE
+	if (currentState == PROFILE) {
+		mouseFollowerHorizontal->setVisible(false);
+		if (!prefs.infobox)
+			mouseFollowerVertical->setVisible(false);
+		else
+			mouseFollowerVertical->setVisible(true);
+	}
+#endif
 	settingsChanged();
 }
 
@@ -370,7 +381,7 @@ void ProfileWidget2::mouseMoveEvent(QMouseEvent *event)
 
 	toolTipItem->refresh(d, mapToScene(mapFromGlobal(QCursor::pos())), currentState == PLAN);
 
-	if (currentState == PLAN || currentState == EDIT) {
+	if (currentState == PLAN || currentState == EDIT || prefs.infobox) {
 		QRectF rect = profileScene->profileRegion;
 		auto [miny, maxy] = profileScene->profileYAxis->screenMinMax();
 		double x = std::clamp(pos.x(), rect.left(), rect.right());
@@ -423,11 +434,23 @@ void ProfileWidget2::setProfileState(const dive *dIn, int dcIn)
 
 void ProfileWidget2::setProfileState()
 {
+	/* when infobox is active in currentState==PROFILE
+	   or, when switching to currentState==PROFILE
+	   the mouseFollowers are needed to be set.
+	   However, in currentState==PROFILE on toggling infobox, 
+	   this needs to be set too!   hk */
+#ifndef SUBSURFACE_MOBILE
+	mouseFollowerHorizontal->setVisible(false);
+	if (!prefs.infobox)
+		mouseFollowerVertical->setVisible(false);
+	else
+		mouseFollowerVertical->setVisible(true);
+#endif
+
 	if (currentState == PROFILE)
 		return;
 
 	disconnectPlannerModel();
-
 	currentState = PROFILE;
 	setBackgroundBrush(getColor(::BACKGROUND, profileScene->isGrayscale));
 
@@ -435,8 +458,6 @@ void ProfileWidget2::setProfileState()
 	toolTipItem->readPos();
 	toolTipItem->setVisible(prefs.infobox);
 	rulerItem->setVisible(prefs.rulergraph);
-	mouseFollowerHorizontal->setVisible(false);
-	mouseFollowerVertical->setVisible(false);
 #endif
 
 	handles.clear();

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -255,7 +255,7 @@ void ProfileWidget2::divesChanged(const QVector<dive *> &dives, DiveField field)
 
 void ProfileWidget2::actionRequestedReplot(bool)
 {
-	/* this is called vai infoboxChanged, therefore in currentState==PROFILE
+	/* this is called via infoboxChanged, therefore in currentState==PROFILE
 	   we have to set the mouseFollowerVertical to visible (if prefs.infobox) */
 #ifndef SUBSURFACE_MOBILE
 	if (currentState == PROFILE) {

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -256,7 +256,7 @@ void ProfileWidget2::divesChanged(const QVector<dive *> &dives, DiveField field)
 void ProfileWidget2::actionRequestedReplot(bool)
 {
 	/* this is called vai infoboxChanged, therefore in currentState==PROFILE
-	   we have to set the mouseFollowerVertical to visible (if prefs.infobox)    hk  */
+	   we have to set the mouseFollowerVertical to visible (if prefs.infobox) */
 #ifndef SUBSURFACE_MOBILE
 	if (currentState == PROFILE) {
 		mouseFollowerHorizontal->setVisible(false);
@@ -438,7 +438,7 @@ void ProfileWidget2::setProfileState()
 	   or, when switching to currentState==PROFILE
 	   the mouseFollowers are needed to be set.
 	   However, in currentState==PROFILE on toggling infobox, 
-	   this needs to be set too!   hk */
+	   this needs to be set too!  */
 #ifndef SUBSURFACE_MOBILE
 	mouseFollowerHorizontal->setVisible(false);
 	if (!prefs.infobox)


### PR DESCRIPTION
Enables the vertical mouseFollower in currentState==PROFILE, while prefs.infobox is active.

The values shown in the infobox correspond to a specific data sample. This sample is exactly pointed out by the vertical line of the MouseFollower, enabling a more intuitive analysis

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
When analyzing the dive profile in detail, the Infobox may provide the data of each logged sample.
However, to locate the exact position, the mouse pointer has to be positioned very close to the profile plot.
This change enables the mouseFollowerVertical, to help highlighting the exact position of the cursor for analysis.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
changes in profilewidget2.cpp ensure, that 
mouseFollowerVertical->setVisible(true);
is set, when prefs.infobox == true, and the currentState==PROFILE.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
