### PR TITLE
profile: fix for temperature items

### DIFF
--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -404,7 +404,12 @@ void DiveTemperatureItem::replot(const dive *, int fromIn, int toIn, bool)
 
 	for (size_t i = 0; i < textItems.size(); ++i) {
 		auto [sec, mkelvin] = textItems[i];
-		createTextItem(sec, mkelvin, i == textItems.size() - 1);
+		// never treat the first item as the last one (different text alignmet)
+		// even if there is only one. // Fixes bug #4407
+		if ( i == 0 )
+			createTextItem(sec, mkelvin, false);
+		else
+			createTextItem(sec, mkelvin, i == textItems.size() - 1);
 	}
 }
 
@@ -413,6 +418,7 @@ void DiveTemperatureItem::createTextItem(int sec, int mkelvin, bool last)
 	temperature_t temp;
 	temp.mkelvin = mkelvin;
 
+	// the last item should aligned to the right to fit in the plot
 	int flags = last ? Qt::AlignLeft | Qt::AlignBottom :
 			   Qt::AlignRight | Qt::AlignBottom;
 	auto text = std::make_unique<DiveTextItem>(dpr, 0.8, flags, this);

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -406,10 +406,10 @@ void DiveTemperatureItem::replot(const dive *, int fromIn, int toIn, bool)
 		auto [sec, mkelvin] = textItems[i];
 		// never treat the first item as the last one (different text alignmet)
 		// even if there is only one. // Fixes bug #4407
-		if ( i == 0 )
-			createTextItem(sec, mkelvin, false);
+		if ( i != 0 && i == textItems.size() - 1 )
+			createTextItem(sec, mkelvin, true);
 		else
-			createTextItem(sec, mkelvin, i == textItems.size() - 1);
+			createTextItem(sec, mkelvin, false);
 	}
 }
 


### PR DESCRIPTION
The last of the textItems in DiveTemperatureItem::replot is aligned to the right. This causes a problem, if there is only one item. Make the first item alway aligned to the left.

Fixes #4407

Reported-by: @KimDelmar

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
