### PR TITLE
get_depth_string: decimals in metric max depth

### DIFF
--- a/core/pref.cpp
+++ b/core/pref.cpp
@@ -96,7 +96,8 @@ preferences::preferences() :
 	allowOcGasAsDiluent(false),
 	coordinates_traditional(true),
 	unit_system(METRIC),
-	units(SI_UNITS)
+	units(SI_UNITS),
+	maxDepth_metric_decimal_limit(20.0)
 {
 }
 

--- a/core/pref.h
+++ b/core/pref.h
@@ -122,6 +122,7 @@ struct preferences {
 	bool        use_default_file;
 	bool        extraEnvironmentalDefault;
 	bool        salinityEditDefault;
+	double      maxDepth_metric_decimal_limit;
 
 	// ********** Geocoding **********
 	geocoding_prefs_t geocoding;

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -494,7 +494,7 @@ QString get_depth_string(int mm, bool showunit, bool showdecimal)
 {
 	if (prefs.units.length == units::METERS) {
 		double meters = mm / 1000.0;
-		return QString("%L1%2").arg(meters, 0, 'f', (showdecimal && meters < 20.0) ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
+		return QString("%L1%2").arg(meters, 0, 'f', (showdecimal && meters < prefs.maxDepth_metric_decimal_limit) ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
 	} else {
 		double feet = mm_to_feet(mm);
 		return QString("%L1%2").arg(feet, 0, 'f', 0).arg(showunit ? gettextFromC::tr("ft") : QString());

--- a/core/settings/qPrefGeneral.cpp
+++ b/core/settings/qPrefGeneral.cpp
@@ -21,6 +21,7 @@ void qPrefGeneral::loadSync(bool doSync)
 	disk_defaultsetpoint(doSync);
 	disk_o2consumption(doSync);
 	disk_pscr_ratio(doSync);
+	disk_maxDepth_metric_decimal_limit(doSync);
 
 	if (!doSync) {
 		load_diveshareExport_uid();
@@ -37,3 +38,5 @@ HANDLE_PREFERENCE_INT(General, "pscr_ratio", pscr_ratio);
 HANDLE_PROP_QSTRING(General, "diveshareExport/uid", diveshareExport_uid);
 
 HANDLE_PROP_BOOL(General, "diveshareExport/private", diveshareExport_private);
+
+HANDLE_PREFERENCE_DOUBLE(General, "maxDepth_metric_decimal_limit", maxDepth_metric_decimal_limit);

--- a/core/settings/qPrefGeneral.h
+++ b/core/settings/qPrefGeneral.h
@@ -12,6 +12,7 @@ class qPrefGeneral : public QObject {
 	Q_PROPERTY(int pscr_ratio READ pscr_ratio WRITE set_pscr_ratio NOTIFY pscr_ratioChanged)
 	Q_PROPERTY(QString diveshareExport_uid READ diveshareExport_uid WRITE set_diveshareExport_uid NOTIFY diveshareExport_uidChanged)
 	Q_PROPERTY(bool diveshareExport_private READ diveshareExport_private WRITE set_diveshareExport_private NOTIFY diveshareExport_privateChanged)
+	Q_PROPERTY(double maxDepth_metric_decimal_limit  READ maxDepth_metric_decimal_limit WRITE set_maxDepth_metric_decimal_limit NOTIFY maxDepth_metric_decimal_limitChanged)
 
 public:
 	static qPrefGeneral *instance();
@@ -27,6 +28,7 @@ public:
 	static int pscr_ratio() { return prefs.pscr_ratio; }
 	static QString diveshareExport_uid() { return st_diveshareExport_uid; }
 	static bool diveshareExport_private() { return st_diveshareExport_private; }
+	static double maxDepth_metric_decimal_limit() { return prefs.maxDepth_metric_decimal_limit; }
 
 public slots:
 	static void set_defaultsetpoint(int value);
@@ -34,6 +36,7 @@ public slots:
 	static void set_pscr_ratio(int value);
 	static void set_diveshareExport_uid(const QString& value);
 	static void set_diveshareExport_private(bool value);
+	static void set_maxDepth_metric_decimal_limit(double value);
 
 signals:
 	void defaultsetpointChanged(int value);
@@ -42,6 +45,7 @@ signals:
 	void diveshareExport_uidChanged(const QString& value);
 	void diveshareExport_privateChanged(bool value);
 	void salinityEditDefaultChanged(bool value);
+	void maxDepth_metric_decimal_limitChanged(double value);
 
 private:
 	qPrefGeneral() {}
@@ -49,6 +53,7 @@ private:
 	static void disk_defaultsetpoint(bool doSync);
 	static void disk_o2consumption(bool doSync);
 	static void disk_pscr_ratio(bool doSync);
+	static void disk_maxDepth_metric_decimal_limit(bool doSync);
 
 	// class variables are load only
 	static void load_diveshareExport_uid();


### PR DESCRIPTION
A hard limit of 20m was coded, above which one decimal, and below no decimal was included in the string.
This somehow arbitrarily chosen limit may now be changed by the knowing user by adding the "maxDepth_metric_decimal_limit" keyword to the [GeneralSettings] section of Subsurface.conf.
The default is still 20, consequently there is no change for the untaught user.

I don't think that this is of interest to many users, therefore it may stay as a 'secret feature'.
However, I know someone to whom this random limit is a major inconvenience ;-)

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
