### PR TITLE
desktop: option to change display of decimals of depth in dive table

### DIFF
--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -93,9 +93,9 @@ static void exportHTMLstatistics(const QString filename, struct htmlExportSettin
 			out << "\"AVERAGE_TIME\":\"" << formatMinutes(s.total_time.seconds / s.selection_size) << "\",";
 			out << "\"SHORTEST_TIME\":\"" << formatMinutes(s.shortest_time.seconds) << "\",";
 			out << "\"LONGEST_TIME\":\"" << formatMinutes(s.longest_time.seconds) << "\",";
-			out << "\"AVG_DEPTH\":\"" << get_depth_string(s.avg_depth) << "\",";
-			out << "\"MIN_DEPTH\":\"" << get_depth_string(s.min_depth) << "\",";
-			out << "\"MAX_DEPTH\":\"" << get_depth_string(s.max_depth) << "\",";
+			out << "\"AVG_DEPTH\":\"" << get_depth_string(s.avg_depth,false, true) << "\","; // on export we should not truncate decimals
+			out << "\"MIN_DEPTH\":\"" << get_depth_string(s.min_depth,false, true) << "\",";
+			out << "\"MAX_DEPTH\":\"" << get_depth_string(s.max_depth,false, true) << "\",";
 			out << "\"AVG_SAC\":\"" << get_volume_string(s.avg_sac) << "\",";
 			out << "\"MIN_SAC\":\"" << get_volume_string(s.min_sac) << "\",";
 			out << "\"MAX_SAC\":\"" << get_volume_string(s.max_sac) << "\",";

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -494,7 +494,7 @@ QString get_depth_string(int mm, bool showunit, bool showdecimal)
 {
 	if (prefs.units.length == units::METERS) {
 		double meters = mm / 1000.0;
-		return QString("%L1%2").arg(meters, 0, 'f', showdecimal ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
+		return QString("%L1%2").arg(meters, 0, 'f', showdecimal  ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
 	} else {
 		double feet = mm_to_feet(mm);
 		return QString("%L1%2").arg(feet, 0, 'f', 0).arg(showunit ? gettextFromC::tr("ft") : QString());

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -494,7 +494,7 @@ QString get_depth_string(int mm, bool showunit, bool showdecimal)
 {
 	if (prefs.units.length == units::METERS) {
 		double meters = mm / 1000.0;
-		return QString("%L1%2").arg(meters, 0, 'f', (showdecimal && meters < 20.0) ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
+		return QString("%L1%2").arg(meters, 0, 'f', showdecimal ? 1 : 0).arg(showunit ? gettextFromC::tr("m") : QString());
 	} else {
 		double feet = mm_to_feet(mm);
 		return QString("%L1%2").arg(feet, 0, 'f', 0).arg(showunit ? gettextFromC::tr("ft") : QString());

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -19,7 +19,7 @@ void qPrefUnits::loadSync(bool doSync)
 	disk_length(doSync);
 	disk_pressure(doSync);
 	disk_show_units_table(doSync);
-	disk_show_mdecimal_table(doSync);
+	disk_show_mdecimal(doSync);
 	disk_temperature(doSync);
 	disk_unit_system(doSync);
 	disk_vertical_speed_time(doSync);
@@ -40,7 +40,7 @@ DISK_LOADSYNC_ENUM_EXT(Units, "pressure", units::PRESSURE, pressure, units.);
 
 HANDLE_PREFERENCE_BOOL_EXT(Units, "show_units_table", show_units_table, units.);
 
-HANDLE_PREFERENCE_BOOL_EXT(Units, "show_mdecimal_table", show_mdecimal_table, units.);
+HANDLE_PREFERENCE_BOOL_EXT(Units, "show_mdecimal", show_mdecimal, units.);
 
 SET_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, temperature, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "temperature", units::TEMPERATURE, temperature, units.);

--- a/core/settings/qPrefUnit.cpp
+++ b/core/settings/qPrefUnit.cpp
@@ -19,6 +19,7 @@ void qPrefUnits::loadSync(bool doSync)
 	disk_length(doSync);
 	disk_pressure(doSync);
 	disk_show_units_table(doSync);
+	disk_show_mdecimal_table(doSync);
 	disk_temperature(doSync);
 	disk_unit_system(doSync);
 	disk_vertical_speed_time(doSync);
@@ -38,6 +39,8 @@ SET_PREFERENCE_ENUM_EXT(Units, units::PRESSURE, pressure, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "pressure", units::PRESSURE, pressure, units.);
 
 HANDLE_PREFERENCE_BOOL_EXT(Units, "show_units_table", show_units_table, units.);
+
+HANDLE_PREFERENCE_BOOL_EXT(Units, "show_mdecimal_table", show_mdecimal_table, units.);
 
 SET_PREFERENCE_ENUM_EXT(Units, units::TEMPERATURE, temperature, units.);
 DISK_LOADSYNC_ENUM_EXT(Units, "temperature", units::TEMPERATURE, temperature, units.);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -10,6 +10,7 @@ class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
+	Q_PROPERTY(bool show_mdecimal_table READ show_mdecimal_table WRITE set_show_mdecimal_table NOTIFY show_mdecimal_tableChanged)
 
 public:
 	static qPrefUnits *instance();
@@ -25,6 +26,7 @@ public:
 	static units::LENGTH length() { return prefs.units.length; }
 	static units::PRESSURE pressure() { return prefs.units.pressure; }
 	static bool show_units_table() { return prefs.units.show_units_table; }
+	static bool show_mdecimal_table() { return prefs.units.show_mdecimal_table; }
 	static unit_system_values unit_system() { return prefs.unit_system; }
 	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
 	static units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
@@ -37,6 +39,7 @@ public slots:
 	static void set_length(units::LENGTH value);
 	static void set_pressure(units::PRESSURE value);
 	static void set_show_units_table(bool value);
+	static void set_show_mdecimal_table(bool value);
 	static void set_temperature(units::TEMPERATURE value);
 	static void set_unit_system(unit_system_values value);
 	static void set_vertical_speed_time(units::TIME value);
@@ -49,6 +52,7 @@ signals:
 	void lengthChanged(units::LENGTH value);
 	void pressureChanged(units::PRESSURE value);
 	void show_units_tableChanged(bool value);
+	void show_mdecimal_tableChanged(bool value);
 	void temperatureChanged(units::TEMPERATURE value);
 	void unit_systemChanged(unit_system_values value);
 	void vertical_speed_timeChanged(units::TIME value);
@@ -63,6 +67,7 @@ private:
 	static void disk_length(bool doSync);
 	static void disk_pressure(bool doSync);
 	static void disk_show_units_table(bool doSync);
+	static void disk_show_mdecimal_table(bool doSync);
 	static void disk_temperature(bool doSync);
 	static void disk_unit_system(bool doSync);
 	static void disk_vertical_speed_time(bool doSync);

--- a/core/settings/qPrefUnit.h
+++ b/core/settings/qPrefUnit.h
@@ -10,7 +10,7 @@ class qPrefUnits : public QObject {
 	Q_OBJECT
 	Q_PROPERTY(bool coordinates_traditional READ coordinates_traditional WRITE set_coordinates_traditional NOTIFY coordinates_traditionalChanged)
 	Q_PROPERTY(bool show_units_table READ show_units_table WRITE set_show_units_table NOTIFY show_units_tableChanged)
-	Q_PROPERTY(bool show_mdecimal_table READ show_mdecimal_table WRITE set_show_mdecimal_table NOTIFY show_mdecimal_tableChanged)
+	Q_PROPERTY(bool show_mdecimal READ show_mdecimal WRITE set_show_mdecimal NOTIFY show_mdecimalChanged)
 
 public:
 	static qPrefUnits *instance();
@@ -26,7 +26,7 @@ public:
 	static units::LENGTH length() { return prefs.units.length; }
 	static units::PRESSURE pressure() { return prefs.units.pressure; }
 	static bool show_units_table() { return prefs.units.show_units_table; }
-	static bool show_mdecimal_table() { return prefs.units.show_mdecimal_table; }
+	static bool show_mdecimal() { return prefs.units.show_mdecimal; }
 	static unit_system_values unit_system() { return prefs.unit_system; }
 	static units::TEMPERATURE temperature() { return prefs.units.temperature; }
 	static units::TIME vertical_speed_time() { return prefs.units.vertical_speed_time; }
@@ -39,7 +39,7 @@ public slots:
 	static void set_length(units::LENGTH value);
 	static void set_pressure(units::PRESSURE value);
 	static void set_show_units_table(bool value);
-	static void set_show_mdecimal_table(bool value);
+	static void set_show_mdecimal(bool value);
 	static void set_temperature(units::TEMPERATURE value);
 	static void set_unit_system(unit_system_values value);
 	static void set_vertical_speed_time(units::TIME value);
@@ -52,7 +52,7 @@ signals:
 	void lengthChanged(units::LENGTH value);
 	void pressureChanged(units::PRESSURE value);
 	void show_units_tableChanged(bool value);
-	void show_mdecimal_tableChanged(bool value);
+	void show_mdecimalChanged(bool value);
 	void temperatureChanged(units::TEMPERATURE value);
 	void unit_systemChanged(unit_system_values value);
 	void vertical_speed_timeChanged(units::TIME value);
@@ -67,7 +67,7 @@ private:
 	static void disk_length(bool doSync);
 	static void disk_pressure(bool doSync);
 	static void disk_show_units_table(bool doSync);
-	static void disk_show_mdecimal_table(bool doSync);
+	static void disk_show_mdecimal(bool doSync);
 	static void disk_temperature(bool doSync);
 	static void disk_unit_system(bool doSync);
 	static void disk_vertical_speed_time(bool doSync);

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -6,7 +6,7 @@
 const struct units SI_units = SI_UNITS;
 const struct units IMPERIAL_units = {
         .length = units::FEET, .volume = units::CUFT, .pressure = units::PSI, .temperature = units::FAHRENHEIT, .weight = units::LBS,
-	.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal_table = false
+	.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal = false
 };
 
 int get_pressure_units(int mb, const char **units)

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -6,7 +6,7 @@
 const struct units SI_units = SI_UNITS;
 const struct units IMPERIAL_units = {
         .length = units::FEET, .volume = units::CUFT, .pressure = units::PSI, .temperature = units::FAHRENHEIT, .weight = units::LBS,
-	.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false
+	.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal_table = false
 };
 
 int get_pressure_units(int mb, const char **units)

--- a/core/units.h
+++ b/core/units.h
@@ -478,7 +478,7 @@ struct units {
 		ALWAYS_HOURS
 	} duration_units;
 	bool show_units_table;
-	bool show_mdecimal_table;
+	bool show_mdecimal;
 };
 
 /*
@@ -491,7 +491,7 @@ struct units {
 #define SI_UNITS 																\
         { \
 	        .length = units::METERS, .volume = units::LITER, .pressure = units::BAR, .temperature = units::CELSIUS, .weight = units::KG, \
-		.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal_table = false \
+		.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal = false \
         }
 
 extern const struct units SI_units, IMPERIAL_units;

--- a/core/units.h
+++ b/core/units.h
@@ -478,6 +478,7 @@ struct units {
 		ALWAYS_HOURS
 	} duration_units;
 	bool show_units_table;
+	bool show_mdecimal_table;
 };
 
 /*
@@ -490,7 +491,7 @@ struct units {
 #define SI_UNITS 																\
         { \
 	        .length = units::METERS, .volume = units::LITER, .pressure = units::BAR, .temperature = units::CELSIUS, .weight = units::KG, \
-		.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false \
+		.vertical_speed_time = units::MINUTES, .duration_units = units::MIXED, .show_units_table = false, .show_mdecimal_table = false \
         }
 
 extern const struct units SI_units, IMPERIAL_units;

--- a/desktop-widgets/preferences/preferences_units.cpp
+++ b/desktop-widgets/preferences/preferences_units.cpp
@@ -43,7 +43,7 @@ void PreferencesUnits::refreshSettings()
 	ui->duration_no_hours->setChecked(prefs.units.duration_units == units::MINUTES_ONLY);
 	ui->duration_show_hours->setChecked(prefs.units.duration_units == units::ALWAYS_HOURS);
 	ui->show_units_table->setChecked(prefs.units.show_units_table);
-	ui->show_mdecimal_table->setChecked(prefs.units.show_mdecimal_table);
+	ui->show_mdecimal->setChecked(prefs.units.show_mdecimal);
 }
 
 void PreferencesUnits::syncSettings()
@@ -61,5 +61,5 @@ void PreferencesUnits::syncSettings()
 	qPrefUnits::set_coordinates_traditional(ui->gpsTraditional->isChecked());
 	qPrefUnits::set_duration_units(ui->duration_mixed->isChecked() ? units::MIXED : (ui->duration_no_hours->isChecked() ? units::MINUTES_ONLY : units::ALWAYS_HOURS));
 	qPrefUnits::set_show_units_table(ui->show_units_table->isChecked());
-	qPrefUnits::set_show_mdecimal_table(ui->show_mdecimal_table->isChecked());
+	qPrefUnits::set_show_mdecimal(ui->show_mdecimal->isChecked());
 }

--- a/desktop-widgets/preferences/preferences_units.cpp
+++ b/desktop-widgets/preferences/preferences_units.cpp
@@ -43,6 +43,7 @@ void PreferencesUnits::refreshSettings()
 	ui->duration_no_hours->setChecked(prefs.units.duration_units == units::MINUTES_ONLY);
 	ui->duration_show_hours->setChecked(prefs.units.duration_units == units::ALWAYS_HOURS);
 	ui->show_units_table->setChecked(prefs.units.show_units_table);
+	ui->show_mdecimal_table->setChecked(prefs.units.show_mdecimal_table);
 }
 
 void PreferencesUnits::syncSettings()
@@ -60,4 +61,5 @@ void PreferencesUnits::syncSettings()
 	qPrefUnits::set_coordinates_traditional(ui->gpsTraditional->isChecked());
 	qPrefUnits::set_duration_units(ui->duration_mixed->isChecked() ? units::MIXED : (ui->duration_no_hours->isChecked() ? units::MINUTES_ONLY : units::ALWAYS_HOURS));
 	qPrefUnits::set_show_units_table(ui->show_units_table->isChecked());
+	qPrefUnits::set_show_mdecimal_table(ui->show_mdecimal_table->isChecked());
 }

--- a/desktop-widgets/preferences/preferences_units.ui
+++ b/desktop-widgets/preferences/preferences_units.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>455</width>
-    <height>515</height>
+    <width>511</width>
+    <height>568</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -281,6 +281,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="show_mdecimal_table">
+        <property name="text">
+         <string>metric depth decimals</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -348,7 +355,6 @@
   <tabstop>duration_show_hours</tabstop>
   <tabstop>duration_no_hours</tabstop>
   <tabstop>duration_mixed</tabstop>
-  <tabstop>show_units_table</tabstop>
   <tabstop>gpsTraditional</tabstop>
   <tabstop>gpsDecimal</tabstop>
  </tabstops>
@@ -532,10 +538,10 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_5"/>
   <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup_3"/>
+  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_4"/>
-  <buttongroup name="buttonGroup_5"/>
  </buttongroups>
 </ui>

--- a/desktop-widgets/preferences/preferences_units.ui
+++ b/desktop-widgets/preferences/preferences_units.ui
@@ -282,7 +282,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="show_mdecimal_table">
+       <widget class="QCheckBox" name="show_mdecimal">
         <property name="text">
          <string>metric depth decimals</string>
         </property>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -121,8 +121,8 @@ void TabDiveInformation::updateProfile()
 	dive *currentDive = parent.currentDive;
 	ui->maxcnsText->setText(QString("%L1\%").arg(currentDive->maxcns));
 	ui->otuText->setText(QString("%L1").arg(currentDive->otu));
-	ui->maximumDepthText->setText(get_depth_string(currentDive->maxdepth, true));
-	ui->averageDepthText->setText(get_depth_string(currentDive->meandepth, true));
+	ui->maximumDepthText->setText(get_depth_string(currentDive->maxdepth, true, true)); // always show decimals
+	ui->averageDepthText->setText(get_depth_string(currentDive->meandepth, true, true));
 
 	std::vector<volume_t> gases = get_gas_used(currentDive);
 	QString volumes;

--- a/desktop-widgets/tab-widgets/TabDiveNotes.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveNotes.cpp
@@ -106,7 +106,7 @@ void TabDiveNotes::divesChanged(const QVector<dive *> &dives, DiveField field)
 	if (field.duration)
 		ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
 	if (field.depth)
-		ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
+		ui.depth->setText(get_depth_string(currentDive->maxdepth, true, prefs.units.show_mdecimal));
 	if (field.rating)
 		ui.rating->setCurrentStars(currentDive->rating);
 	if (field.notes)
@@ -267,7 +267,7 @@ void TabDiveNotes::updateData(const std::vector<dive *> &, dive *currentDive, in
 		ui.buddy->setText(QString::fromStdString(currentDive->buddy));
 	}
 	ui.duration->setText(render_seconds_to_string(currentDive->duration.seconds));
-	ui.depth->setText(get_depth_string(currentDive->maxdepth, true));
+	ui.depth->setText(get_depth_string(currentDive->maxdepth, true, prefs.units.show_mdecimal));
 
 	ui.editDiveSiteButton->setEnabled(!ui.location->text().isEmpty());
 	/* unset the special value text for date and time, just in case someone dove at midnight */

--- a/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveStatistics.cpp
@@ -75,13 +75,13 @@ void TabDiveStatistics::updateData(const std::vector<dive *> &, dive *currentDiv
 	stats_t stats_selection = calculate_stats_selected();
 	clear();
 	if (amount_selected > 1 && stats_selection.selection_size >= 1) {
-		ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true));
-		ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true));
-		ui->depthLimits->setAverage(get_depth_string(stats_selection.combined_max_depth.mm / stats_selection.selection_size, true));
+		ui->depthLimits->setMaximum(get_depth_string(stats_selection.max_depth, true, true));  // for the statistics we should always use a decimal!
+		ui->depthLimits->setMinimum(get_depth_string(stats_selection.min_depth, true, true));
+		ui->depthLimits->setAverage(get_depth_string(stats_selection.combined_max_depth.mm / stats_selection.selection_size, true, true));
 	} else {
 		ui->depthLimits->setMaximum("");
 		ui->depthLimits->setMinimum("");
-		ui->depthLimits->setAverage(get_depth_string(stats_selection.max_depth, true));
+		ui->depthLimits->setAverage(get_depth_string(stats_selection.max_depth, true, true));
 	}
 
 	if (stats_selection.max_sac.mliter && (stats_selection.max_sac.mliter != stats_selection.avg_sac.mliter))

--- a/desktop-widgets/templatelayout.cpp
+++ b/desktop-widgets/templatelayout.cpp
@@ -460,11 +460,11 @@ QVariant TemplateLayout::getValue(QString list, QString property, const State &s
 		} else if (property == "longest_time") {
 			return formatMinutes(object->longest_time.seconds);
 		} else if (property == "avg_depth") {
-			return get_depth_string(object->avg_depth);
+			return get_depth_string(object->avg_depth, false, true);
 		} else if (property == "min_depth") {
-			return get_depth_string(object->min_depth);
+			return get_depth_string(object->min_depth, false, prefs.units.show_mdecimal);
 		} else if (property == "max_depth") {
-			return get_depth_string(object->max_depth);
+			return get_depth_string(object->max_depth, false, prefs.units.show_mdecimal);
 		} else if (property == "avg_sac") {
 			return get_volume_string(object->avg_sac);
 		} else if (property == "min_sac") {
@@ -536,7 +536,7 @@ QVariant TemplateLayout::getValue(QString list, QString property, const State &s
 		} else if (property == "noDive") {
 			return d->duration.seconds == 0 && d->dcs[0].duration.seconds == 0;
 		} else if (property == "depth") {
-			return get_depth_string(d->dcs[0].maxdepth.mm, true, true);
+			return get_depth_string(d->dcs[0].maxdepth.mm, true, prefs.units.show_mdecimal);
 		} else if (property == "meandepth") {
 			return get_depth_string(d->dcs[0].meandepth.mm, true, true);
 		} else if (property == "divemaster") {

--- a/mobile-widgets/qmlmanager.cpp
+++ b/mobile-widgets/qmlmanager.cpp
@@ -1145,7 +1145,7 @@ bool QMLManager::checkDuration(struct dive *d, QString duration)
 
 bool QMLManager::checkDepth(dive *d, QString depth)
 {
-	if (get_depth_string(d->dcs[0].maxdepth.mm, true, true) != depth) {
+	if (get_depth_string(d->dcs[0].maxdepth.mm, true, prefs.units.show_mdecimal) != depth) {
 		int depthValue = parseLengthToMm(depth);
 		// the QML code should stop negative depth, but massively huge depth can make
 		// the profile extremely slow or even run out of memory and crash, so keep

--- a/profile-widget/diveprofileitem.cpp
+++ b/profile-widget/diveprofileitem.cpp
@@ -254,7 +254,7 @@ void DiveProfileItem::replot(const dive *d, int from, int to, bool in_planner)
 void DiveProfileItem::plot_depth_sample(const struct plot_data &entry, QFlags<Qt::AlignmentFlag> flags, const QColor &color)
 {
 	auto item = std::make_unique<DiveTextItem>(dpr, 1.0, flags, this);
-	item->set(get_depth_string(entry.depth, true), color);
+	item->set(get_depth_string(entry.depth, true, prefs.units.show_mdecimal), color); // decimals, choice of user
 	item->setPos(hAxis.posAtValue(entry.sec), vAxis.posAtValue(entry.depth.mm));
 	texts.push_back(std::move(item));
 }
@@ -522,7 +522,7 @@ void DiveMeanDepthItem::createTextItem(double lastSec, double lastMeanDepth)
 {
 	texts.clear();
 	auto text = std::make_unique<DiveTextItem>(dpr, diveMeanDepthItemLabelScale, Qt::AlignRight | Qt::AlignVCenter, this);
-	text->set(get_depth_string(lrint(lastMeanDepth), true), getColor(TEMP_TEXT));
+	text->set(get_depth_string(lrint(lastMeanDepth), true, true), getColor(TEMP_TEXT));
 	text->setPos(QPointF(hAxis.posAtValue(lastSec) + dpr, vAxis.posAtValue(lastMeanDepth)));
 	texts.push_back(std::move(text));
 }

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -230,20 +230,20 @@ QVariant CylindersModel::data(const QModelIndex &index, int role) const
 		case HE:
 			return percent_string(cyl->gasmix.he);
 		case DEPTH:
-			return get_depth_string(cyl->depth, true);
+			return get_depth_string(cyl->depth, true, false);
 		case MOD:
 			if (cyl->bestmix_o2) {
 				return QStringLiteral("*");
 			} else {
 				pressure_t modpO2;
 				modpO2.mbar = inPlanner ? prefs.bottompo2 : (int)(prefs.modpO2 * 1000.0);
-				return get_depth_string(d->gas_mod(cyl->gasmix, modpO2, m_or_ft(1, 1)), true);
+				return get_depth_string(d->gas_mod(cyl->gasmix, modpO2, m_or_ft(1, 1)), true, false);
 			}
 		case MND:
 			if (cyl->bestmix_he)
 				return QStringLiteral("*");
 			else
-				return get_depth_string(d->gas_mnd(cyl->gasmix, prefs.bestmixend, m_or_ft(1, 1)), true);
+				return get_depth_string(d->gas_mnd(cyl->gasmix, prefs.bestmixend, m_or_ft(1, 1)), true, false);
 			break;
 		case USE:
 			return gettextFromC::tr(cylinderuse_text[cyl->cylinder_use]);

--- a/qt-models/diveimportedmodel.cpp
+++ b/qt-models/diveimportedmodel.cpp
@@ -65,7 +65,7 @@ QVariant DiveImportedModel::data(const QModelIndex &index, int role) const
 		case 1:
 			return QVariant(get_dive_duration_string(d.duration.seconds, tr("h"), tr("min")));
 		case 2:
-			return QVariant(get_depth_string(d.maxdepth.mm, true, false));
+			return QVariant(get_depth_string(d.maxdepth.mm, true, prefs.units.show_mdecimal)); // screen output single dive: user choice
 		case 3:
 			return checkStates[index.row()];
 		}

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -280,9 +280,9 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 	case MobileListModel::IdRole: return d->id;
 	case MobileListModel::NumberRole: return d->number;
 	case MobileListModel::LocationRole: return QString::fromStdString(d->get_location());
-	case MobileListModel::DepthRole: return get_depth_string(d->dcs[0].maxdepth.mm, true, true);
+	case MobileListModel::DepthRole: return get_depth_string(d->dcs[0].maxdepth.mm, true, prefs.units.show_mdecimal); //maybe later via show_mdecimal?
 	case MobileListModel::DurationRole: return formatDiveDuration(d);
-	case MobileListModel::DepthDurationRole: return QStringLiteral("%1 / %2").arg(get_depth_string(d->dcs[0].maxdepth.mm, true, true),
+	case MobileListModel::DepthDurationRole: return QStringLiteral("%1 / %2").arg(get_depth_string(d->dcs[0].maxdepth.mm, true, prefs.units.show_mdecimal),
 										      formatDiveDuration(d));
 	case MobileListModel::RatingRole: return d->rating;
 	case MobileListModel::VizRole: return d->visibility;
@@ -325,7 +325,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		case DATE:
 			return get_dive_date_string(d->when);
 		case DEPTH:
-			return get_depth_string(d->maxdepth, prefs.units.show_units_table, prefs.units.show_mdecimal_table);
+			return get_depth_string(d->maxdepth, prefs.units.show_units_table, prefs.units.show_mdecimal);
 		case DURATION:
 			return displayDuration(d);
 		case TEMPERATURE:

--- a/qt-models/divetripmodel.cpp
+++ b/qt-models/divetripmodel.cpp
@@ -325,7 +325,7 @@ QVariant DiveTripModelBase::diveData(const struct dive *d, int column, int role)
 		case DATE:
 			return get_dive_date_string(d->when);
 		case DEPTH:
-			return get_depth_string(d->maxdepth, prefs.units.show_units_table);
+			return get_depth_string(d->maxdepth, prefs.units.show_units_table, prefs.units.show_mdecimal_table);
 		case DURATION:
 			return displayDuration(d);
 		case TEMPERATURE:

--- a/qt-models/yearlystatisticsmodel.cpp
+++ b/qt-models/yearlystatisticsmodel.cpp
@@ -67,15 +67,15 @@ QVariant YearStatisticsItem::data(int column, int role) const
 	case LONGEST_TIME:
 		return formatMinutes(stats_interval.longest_time.seconds);
 	case AVG_DEPTH:
-		return get_depth_string(stats_interval.avg_depth);
+		return get_depth_string(stats_interval.avg_depth,false,true); // stats/average: decimals should be present
 	case AVG_MAX_DEPTH:
 		if (stats_interval.selection_size)
-			return get_depth_string(stats_interval.combined_max_depth.mm / stats_interval.selection_size);
+			return get_depth_string((stats_interval.combined_max_depth.mm / stats_interval.selection_size) ,false,true);
 		break;
 	case MIN_DEPTH:
-		return get_depth_string(stats_interval.min_depth);
+		return get_depth_string(stats_interval.min_depth,false,true); // stats/average: decimals should be present
 	case MAX_DEPTH:
-		return get_depth_string(stats_interval.max_depth);
+		return get_depth_string(stats_interval.max_depth,false,true); // stats/average: decimals should be present
 	case AVG_SAC:
 		return get_volume_string(stats_interval.avg_sac);
 	case MIN_SAC:
@@ -220,8 +220,8 @@ void YearlyStatisticsModel::update_yearly_stats()
 		int i = 0;
 		for (auto it = std::next(stats.stats_by_depth.begin()); it != stats.stats_by_depth.end(); ++it) {
 			if (it->selection_size) {
-				QString label = QString(tr("%1 - %2")).arg(get_depth_string(i * (STATS_DEPTH_BUCKET * 1000), true, false),
-						get_depth_string((i + 1) * (STATS_DEPTH_BUCKET * 1000), true, false));
+				QString label = QString(tr("%1 - %2")).arg(get_depth_string(i * (STATS_DEPTH_BUCKET * 1000), true, true),
+						get_depth_string((i + 1) * (STATS_DEPTH_BUCKET * 1000), true, true));  // stats/average: decimals should be present
 				it->location = label.toStdString();
 				YearStatisticsItem *iChild = new YearStatisticsItem(*it);
 				item->children.append(iChild);

--- a/translations/subsurface_de_DE.ts
+++ b/translations/subsurface_de_DE.ts
@@ -7481,6 +7481,11 @@ Siehe https://doc.qt.io/archives/qt-4.8/qdatetime.html#fromString</translation>
         <translation>Einheiten in der Tauchgangsliste anzeigen</translation>
     </message>
     <message>
+        <location filename="../desktop-widgets/preferences/preferences_units.ui" line="287"/>
+        <source>metric depth decimals</source>
+        <translation>Meter mit Nachkommastelle</translation>
+    </message>
+    <message>
         <location filename="../desktop-widgets/preferences/preferences_units.ui" line="290"/>
         <source>GPS coordinates</source>
         <translation>GPS-Koordinaten</translation>

--- a/translations/subsurface_de_DE.ts
+++ b/translations/subsurface_de_DE.ts
@@ -7481,11 +7481,6 @@ Siehe https://doc.qt.io/archives/qt-4.8/qdatetime.html#fromString</translation>
         <translation>Einheiten in der Tauchgangsliste anzeigen</translation>
     </message>
     <message>
-        <location filename="../desktop-widgets/preferences/preferences_units.ui" line="287"/>
-        <source>metric depth decimals</source>
-        <translation>Meter mit Nachkommastelle</translation>
-    </message>
-    <message>
         <location filename="../desktop-widgets/preferences/preferences_units.ui" line="290"/>
         <source>GPS coordinates</source>
         <translation>GPS-Koordinaten</translation>


### PR DESCRIPTION
The qthelper get_depth_string does now what is expected, depending on the given bool showdecimal (<20m exception removed). A preference (units.show_mdecimal_table) was introduced to change whether decimals are displayed for (metric) max depth values in the dive list. The setting can be change via UI at preferences/units.

This is a more general approach to #4431.


<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
