### PR TITLE
Use thread safe version of libraw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(NOT ANDROID)
 	endif()
 	pkg_config_library(LIBUSB libusb-1.0 QUIET)
 	pkg_config_library(LIBMTP libmtp QUIET)
-	pkg_config_library(LIBRAW libraw )
+	pkg_config_library(LIBRAW libraw_r )
 endif()
 
 include_directories(.

--- a/core/metadata.cpp
+++ b/core/metadata.cpp
@@ -544,21 +544,21 @@ degrees_t degminsec_to_udeg(float a[3])
 #ifdef LIBRAW_SUPPORT
 static bool parseRaw(const char *fn, metadata *metadata)
 {
-	LibRaw raw; // Might think about reusing that
+	// Might think about reusing that
+	auto raw = std::make_unique<LibRaw>();
 
 	// TODO: Convert filename to UTF-16 for windows
-	if (raw.open_file(fn) != LIBRAW_SUCCESS)
+	if (raw->open_file(fn) != LIBRAW_SUCCESS)
 		return false;
 
-	metadata->timestamp = raw.imgdata.other.timestamp;
-	metadata->location.lat = degminsec_to_udeg(raw.imgdata.other.parsed_gps.latitude);
+	metadata->timestamp = raw->imgdata.other.timestamp;
+	metadata->location.lat = degminsec_to_udeg(raw->imgdata.other.parsed_gps.latitude);
 #if LIBRAW_MINOR_VERSION < 20
 	// what a funny typo in the structure...
-	metadata->location.lon = degminsec_to_udeg(raw.imgdata.other.parsed_gps.longtitude);
+	metadata->location.lon = degminsec_to_udeg(raw->imgdata.other.parsed_gps.longtitude);
 #else
-	metadata->location.lon = degminsec_to_udeg(raw.imgdata.other.parsed_gps.longitude);
+	metadata->location.lon = degminsec_to_udeg(raw->imgdata.other.parsed_gps.longitude);
 #endif
-
 	return true;
 }
 #endif


### PR DESCRIPTION
We should use the thread safe version libraw_r since we are processing thumbnails in the background.

Fixes #4377 and thus supersedes PR #4424.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
