### PR TITLE
Desktop: Add Consistent Loading of Media with Invalid Extensions.

### DIFF
--- a/core/imagedownloader.cpp
+++ b/core/imagedownloader.cpp
@@ -206,7 +206,7 @@ Thumbnailer::Thumbnailer() : failImage(QPixmap(":filter-close").scaled(maxThumbn
 	connect(ImageDownloader::instance(), &ImageDownloader::failed, this, &Thumbnailer::imageDownloadFailed);
 	connect(VideoFrameExtractor::instance(), &VideoFrameExtractor::extracted, this, &Thumbnailer::frameExtracted);
 	connect(VideoFrameExtractor::instance(), &VideoFrameExtractor::failed, this, &Thumbnailer::frameExtractionFailed);
-	connect(VideoFrameExtractor::instance(), &VideoFrameExtractor::failed, this, &Thumbnailer::frameExtractionInvalid);
+	connect(VideoFrameExtractor::instance(), &VideoFrameExtractor::invalid, this, &Thumbnailer::frameExtractionInvalid);
 }
 
 Thumbnailer *Thumbnailer::instance()

--- a/core/imagedownloader.h
+++ b/core/imagedownloader.h
@@ -63,7 +63,7 @@ private:
 	};
 
 	Thumbnailer();
-	Thumbnail fetchVideoThumbnail(const QString &filename, const QString &originalFilename, duration_t duration);
+	Thumbnail fetchVideoThumbnail(const QString &filename, const QString &originalFilename, duration_t duration, bool unknownFiletype = false);
 	Thumbnail extractVideoThumbnail(const QString &picture_filename, duration_t duration);
 	Thumbnail addPictureThumbnailToCache(const QString &picture_filename, const QImage &thumbnail);
 	Thumbnail addVideoThumbnailToCache(const QString &picture_filename, duration_t duration, const QImage &thumbnail, duration_t position);

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -1088,7 +1088,7 @@ QString localFilePath(const QString &originalFilename)
 // TODO: Apparently Qt has no simple way of listing the supported video
 // codecs? Do we have to query them by hand using QMediaPlayer::hasSupport()?
 const QStringList videoExtensionsList = {
-	".avi", ".mp4", ".mov", ".mpeg", ".mpg", ".wmv"
+	"*.avi", "*.mp4", "*.mov", "*.mpeg", "*.mpg", "*.wmv"
 };
 
 // Raw extensions according to https://en.wikipedia.org/wiki/Raw_image_format
@@ -1104,7 +1104,7 @@ static const QStringList rawExtensionsList = {
 
 QStringList mediaExtensionFilters()
 {
-	return imageExtensionFilters() + videoExtensionFilters();
+	return imageExtensionFilters() + videoExtensionsList;
 }
 
 QStringList imageExtensionFilters()
@@ -1113,14 +1113,6 @@ QStringList imageExtensionFilters()
 	for (QString format: QImageReader::supportedImageFormats())
 		filters.append("*." + format);
 	return filters + rawExtensionsList;
-}
-
-QStringList videoExtensionFilters()
-{
-	QStringList filters;
-	for (const QString &format: videoExtensionsList)
-		filters.append("*" + format);
-	return filters;
 }
 
 std::string local_file_path(const struct picture &picture)

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -40,10 +40,8 @@ std::optional<std::string> getCloudURL(); // move to prefs.h, probably.
 bool parseGpsText(const QString &gps_text, double *latitude, double *longitude);
 void init_proxy();
 QStringList getWaterTypesAsString();
-extern const QStringList videoExtensionsList;
 QStringList mediaExtensionFilters();
 QStringList imageExtensionFilters();
-QStringList videoExtensionFilters();
 QString get_depth_string(depth_t depth, bool showunit = false, bool showdecimal = true);
 QString get_depth_string(int mm, bool showunit = false, bool showdecimal = true);
 QString get_depth_unit(bool metric);

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -68,8 +68,8 @@ DiveListView::DiveListView(QWidget *parent) : QTreeView(parent),
 	QSettings s;
 	s.beginGroup("DiveListColumnState");
 	for (int i = 0; i < model()->columnCount(); i++) {
-		QString title = QString("%1").arg(model()->headerData(i, Qt::Horizontal).toString());
-		QString settingName = QString("showColumn%1").arg(i);
+		QString title = QStringLiteral("%1").arg(model()->headerData(i, Qt::Horizontal).toString());
+		QString settingName = QStringLiteral("showColumn%1").arg(i);
 		QAction *a = new QAction(title, header());
 		bool showHeaderFirstRun = i == DiveTripModelBase::NR ||
 					  i == DiveTripModelBase::DATE ||
@@ -103,11 +103,11 @@ DiveListView::~DiveListView()
 			continue;
 		// we used to hardcode them all to 100 - so that might still be in the settings
 		if (columnWidth(i) == 100 || columnWidth(i) == initialColumnWidths[i])
-			settings.remove(QString("colwidth%1").arg(i));
+			settings.remove(QStringLiteral("colwidth%1").arg(i));
 		else
-			settings.setValue(QString("colwidth%1").arg(i), columnWidth(i));
+			settings.setValue(QStringLiteral("colwidth%1").arg(i), columnWidth(i));
 	}
-	settings.remove(QString("colwidth%1").arg(DiveTripModelBase::COLUMNS - 1));
+	settings.remove(QStringLiteral("colwidth%1").arg(DiveTripModelBase::COLUMNS - 1));
 	settings.endGroup();
 }
 
@@ -176,7 +176,7 @@ void DiveListView::setColumnWidths()
 	for (int i = DiveTripModelBase::NR; i < DiveTripModelBase::COLUMNS; i++) {
 		if (isColumnHidden(i))
 			continue;
-		QVariant width = settings.value(QString("colwidth%1").arg(i));
+		QVariant width = settings.value(QStringLiteral("colwidth%1").arg(i));
 		if (width.isValid())
 			setColumnWidth(i, width.toInt());
 		else
@@ -831,15 +831,11 @@ void DiveListView::shiftTimes()
 void DiveListView::loadImages()
 {
 	QStringList m_filters = mediaExtensionFilters();
-	QStringList i_filters = imageExtensionFilters();
-	QStringList v_filters = videoExtensionFilters();
 	QStringList fileNames = QFileDialog::getOpenFileNames(this,
 							      tr("Open media files"),
 							      lastUsedImageDir(),
-							      QString("%1 (%2);;%3 (%4);;%5 (%6);;%7 (*.*)")
+							      QStringLiteral("%1 (%2);;%3 (*.*)")
 							      .arg(tr("Media files"), m_filters.join(" ")
-							      , tr("Image files"), i_filters.join(" ")
-							      , tr("Video files"), v_filters.join(" ")
 							      , tr("All files")));
 
 	if (fileNames.isEmpty())


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
We are allowing users to add RAW images with ivalid file name
extensions. Make this behaviour consistent by allowing users to add
videos with invalid file name extensions.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Alternative to #4424.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://github.com/user-attachments/assets/72c0433b-eca2-43c8-87dd-bb407be247ec)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
