### PR TITLE
Desktop: Fix Automatic Firmware Upgrade for Heinrichs Weikamp.

### DIFF
--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -129,11 +129,14 @@ slots:
 	void parseOstcFwVersion(QNetworkReply *reply);
 	void saveOstcFirmware(QNetworkReply *reply);
 
+signals:
+	void checkCompleted();
+
 private:
 	void upgradeFirmware(const QString &filename);
 	device_data_t devData;
 	QString latestFirmwareAvailable;
-	QString latestFirmwareHexFile;
+	QUrl latestFirmwareHexFile;
 	QString storeFirmware;
 	QWidget *parent;
 	QNetworkAccessManager manager;

--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -573,9 +573,12 @@ void DownloadFromDCWidget::on_ok_clicked()
 
 	diveImportedModel->recordDives(flags);
 
-	if (ostcFirmwareCheck && currentState == DONE)
+	if (ostcFirmwareCheck && currentState == DONE) {
+		connect(ostcFirmwareCheck.get(), &OstcFirmwareCheck::checkCompleted, this, &DownloadFromDCWidget::accept);
 		ostcFirmwareCheck->checkLatest(this, diveImportedModel->thread.data()->internalData(), filename);
-	accept();
+	} else {
+		accept();
+	}
 }
 
 void DownloadFromDCWidget::updateDeviceEnabled()


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the automatic firmware upgrade after downloading dives by not
closing the download dialog until the firmware download is complete.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix the automatic firmware upgrade after downloading dives by not
   closing the download dialog until the firmware download is complete;
2. change Heinrichs Weikamp download links to https;
3. amend the firmware upgrade dialog to point out that Bluetooth has
   to be re-enabled for the upgrade.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

![Screenshot From 2025-02-18 00-14-30](https://github.com/user-attachments/assets/71dd403a-da9f-418e-817e-e94919f37edf)

![image](https://github.com/user-attachments/assets/7dea0f74-7139-486c-9dc5-48d3ce0275d6)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
