### PR TITLE
Desktop: Improve Management of Tank Sensors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ translations/*.qm
 *.exe
 *.dmg
 *.patch
-*.xml
+*.bak
 ssrf-version.h
 !dives/*.xml
 *~
@@ -46,3 +46,4 @@ gh_release_notes.md
 release_content_title.txt
 /output/
 /Documentation/output/
+/metainfo/subsurface.metainfo.xml

--- a/commands/command_edit.cpp
+++ b/commands/command_edit.cpp
@@ -1311,7 +1311,7 @@ void EditSensors::mapSensors(int toCyl, int fromCyl)
 				sample.sensor[s] = fromCyl;
 		}
 	}
-	emit diveListNotifier.diveComputerEdited(dc);
+	emit diveListNotifier.diveComputerEdited(*d, *dc);
 	d->invalidate_cache(); // Ensure that dive is written in git_save()
 }
 

--- a/commands/command_edit.h
+++ b/commands/command_edit.h
@@ -445,14 +445,14 @@ private:
 class EditSensors : public Base
 {
 public:
-	EditSensors(int cylIndex, int fromCylinder, int dcNr);
+	EditSensors(unsigned int cylIndex, int16_t fromCylinder, int dcNr);
 
 private:
 	struct dive *d;
 	struct divecomputer *dc;
-	int toCylinder;
-	int fromCylinder;
-	void mapSensors(int toCyl, int fromCyl);
+	unsigned int cylinderIndex;
+	int16_t	sensorId;
+	std::vector<struct tank_sensor_mapping> oldTankSensorMappings;
 	void undo() override;
 	void redo() override;
 	bool workToBeDone() override;

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -181,6 +181,7 @@ set(SUBSURFACE_CORE_LIB_SRCS
 	subsurfacesysinfo.h
 	tag.cpp
 	tag.h
+	tanksensormapping.h
 	taxonomy.cpp
 	taxonomy.h
 	time.cpp

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -850,8 +850,8 @@ static void fixup_dc_temp(struct dive &dive, struct divecomputer &dc)
 /* Remove redundant pressure information */
 static void simplify_dc_pressures(struct divecomputer &dc)
 {
-	int lastindex[2] = { -1, -1 };
-	int lastpressure[2] = { 0 };
+	int lastindex[MAX_SENSORS] = { NO_SENSOR };
+	int lastpressure[MAX_SENSORS] = { 0 };
 
 	for (auto &sample: dc.samples) {
 		int j;
@@ -1015,7 +1015,7 @@ static void fixup_dc_sample_sensors(struct dive &dive, struct divecomputer &dc)
 			int sensor = sample.sensor[j];
 
 			// No invalid sensor ID's, please
-			if (sensor < 0 || sensor > MAX_SENSORS) {
+			if (sensor < 0) {
 				sample.sensor[j] = NO_SENSOR;
 				sample.pressure[j] = 0_bar;
 				continue;

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -26,6 +26,7 @@
 #include "range.h"
 #include "sample.h"
 #include "tag.h"
+#include "tanksensormapping.h"
 #include "trip.h"
 
 // For user visible text but still not translated
@@ -1304,6 +1305,19 @@ static void merge_extra_data(struct divecomputer &res,
 	}
 }
 
+static void merge_tank_sensor_mappings(struct divecomputer &res,
+			  const struct divecomputer &a, const struct divecomputer &b)
+{
+	for (auto &tank_sensor_mapping: b.tank_sensor_mappings) {
+		if (std::find_if(a.tank_sensor_mappings.begin(), a.tank_sensor_mappings.end(), [&tank_sensor_mapping](const struct tank_sensor_mapping &a) {
+			return a.sensor_index == tank_sensor_mapping.sensor_index;
+		}) != a.tank_sensor_mappings.end())
+			continue;
+
+		res.tank_sensor_mappings.push_back(tank_sensor_mapping);
+	}
+}
+
 static std::string merge_text(const std::string &a, const std::string &b, const char *sep)
 {
 	if (a.empty())
@@ -2176,6 +2190,7 @@ static void interleave_dive_computers(struct dive &res,
 			merge_events(res, newdc, dc1, *match, cylinders_map_a, cylinders_map_b, offset);
 			merge_samples(newdc, dc1, *match, cylinders_map_a, cylinders_map_b, offset);
 			merge_extra_data(newdc, dc1, *match);
+			merge_tank_sensor_mappings(newdc, dc1, *match);
 			/* Use the diveid of the later dive! */
 			if (offset > 0)
 				newdc.diveid = match->diveid;

--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1063,43 +1063,43 @@ int check_dc_cylinder_use(struct dive &dive, struct divecomputer &dc)
 }
 
 
-static void fixup_dive_dc(struct dive &dive, struct divecomputer &dc)
+void dive::fixup_dive_dc(struct divecomputer &dc)
 {
 	/* Fixup duration and mean depth */
 	fixup_dc_duration(dc);
 
 	/* Fix up sample depth data */
-	fixup_dc_depths(dive, dc);
+	fixup_dc_depths(*this, dc);
 
 	/* Fix up first sample ndl data */
 	fixup_dc_ndl(dc);
 
 	/* Fix up dive temperatures based on dive computer samples */
-	fixup_dc_temp(dive, dc);
+	fixup_dc_temp(*this, dc);
 
 	/* Fix up gas switch events */
-	fixup_dc_gasswitch(dive, dc);
+	fixup_dc_gasswitch(*this, dc);
 
 	/* Fix up cylinder ids in pressure sensors */
-	fixup_dc_sample_sensors(dive, dc);
+	fixup_dc_sample_sensors(*this, dc);
 
 	/* Fix up cylinder pressures based on DC info */
-	fixup_dive_pressures(dive, dc);
+	fixup_dive_pressures(*this, dc);
 
-	fixup_dc_events(dive, dc);
+	fixup_dc_events(*this, dc);
 
 	/* Fixup CCR / PSCR dives with o2sensor values, but without no_o2sensors */
 	fixup_no_o2sensors(dc);
 
 	/* Check cylinder use */
-	check_dc_cylinder_use(dive, dc);
+	check_dc_cylinder_use(*this, dc);
 
 	/* If there are no samples, generate a fake profile based on depth and time */
 	if (dc.samples.empty())
 		fake_dc(&dc);
 }
 
-void dive::fixup_no_cylinder()
+void dive::fixup_dive()
 {
 	sanitize_cylinder_info(*this);
 	maxcns = cns;
@@ -1112,7 +1112,7 @@ void dive::fixup_no_cylinder()
 	update_min_max_temperatures(*this, watertemp);
 
 	for (auto &dc: dcs)
-		fixup_dive_dc(*this, dc);
+		fixup_dive_dc(dc);
 
 	fixup_water_salinity(*this);
 	if (!surface_pressure.mbar)

--- a/core/dive.h
+++ b/core/dive.h
@@ -204,7 +204,6 @@ extern void copy_events_until(const struct dive *sd, struct dive *dd, int dcNr, 
 extern void copy_used_cylinders(const struct dive *s, struct dive *d, bool used_only);
 extern void add_gas_switch_event(struct dive *dive, struct divecomputer *dc, int time, int idx);
 extern struct event create_gas_switch_event(struct dive *dive, struct divecomputer *dc, int seconds, int idx);
-extern bool cylinder_with_sensor_sample(const struct dive *dive, int cylinder_id);
 
 extern void update_setpoint_events(const struct dive *dive, struct divecomputer *dc);
 

--- a/core/dive.h
+++ b/core/dive.h
@@ -156,6 +156,7 @@ extern int same_gasmix_cylinder(const cylinder_t &cyl, int cylid, const struct d
 extern bool is_cylinder_use_appropriate(const struct divecomputer &dc, const cylinder_t &cyl, bool allowNonUsable);
 extern divemode_t get_effective_divemode(const struct divecomputer &dc, const struct cylinder_t &cylinder);
 extern std::tuple<divemode_t, int, const struct gasmix *> get_dive_status_at(const struct dive &dive, const struct divecomputer &dc, int seconds, divemode_loop *loop_mode = nullptr, gasmix_loop *loop_gas = nullptr);
+extern const std::vector<struct tank_sensor_mapping> get_tank_sensor_mappings_for_storage(const struct dive &dive, const struct divecomputer &dc);
 
 /* Data stored when copying a dive */
 struct dive_paste_data {

--- a/core/dive.h
+++ b/core/dive.h
@@ -89,7 +89,8 @@ struct dive {
 
 	void clear();
 	int number_of_computers() const;
-	void fixup_no_cylinder();		/* to fix cylinders, we need the divelist (to calculate cns) */
+	void fixup_dive();
+	void fixup_dive_dc(struct divecomputer &dc);
 	timestamp_t endtime() const;		/* maximum over divecomputers (with samples) */
 	duration_t totaltime() const;		/* maximum over divecomputers (with samples) */
 	temperature_t dc_airtemp() const;	/* average over divecomputers */

--- a/core/divecomputer.cpp
+++ b/core/divecomputer.cpp
@@ -5,6 +5,7 @@
 #include "event.h"
 #include "extradata.h"
 #include "pref.h"
+#include "tanksensormapping.h"
 #include "sample.h"
 #include "subsurface-string.h"
 

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -4,6 +4,7 @@
 
 #include "divemode.h"
 #include "units.h"
+#include <set>
 #include <string>
 #include <vector>
 
@@ -58,6 +59,8 @@ extern void free_dc_contents(struct divecomputer *dc);
 extern int get_depth_at_time(const struct divecomputer *dc, unsigned int time);
 extern struct sample *prepare_sample(struct divecomputer *dc);
 extern void append_sample(const struct sample &sample, struct divecomputer *dc);
+extern std::set<int16_t> get_tank_sensor_ids(const struct divecomputer &dc);
+extern void fixup_dc_sample_sensors(struct divecomputer &dc);
 extern void fixup_dc_duration(struct divecomputer &dc);
 extern int add_event_to_dc(struct divecomputer *dc, struct event ev); // event structure is consumed, returns index of inserted event
 extern struct event *add_event(struct divecomputer *dc, unsigned int time, int type, int flags, int value, const std::string &name);

--- a/core/divecomputer.h
+++ b/core/divecomputer.h
@@ -10,6 +10,7 @@
 struct extra_data;
 struct event;
 struct sample;
+struct tank_sensor_mapping;
 
 /* Is this header the correct place? */
 #define SURFACE_THRESHOLD 750 /* somewhat arbitrary: only below 75cm is it really diving */
@@ -43,6 +44,7 @@ struct divecomputer {
 	std::vector<struct sample> samples;
 	std::vector<struct event> events;
 	std::vector<struct extra_data> extra_data;
+	std::vector<struct tank_sensor_mapping> tank_sensor_mappings;
 
 	divecomputer();
 	~divecomputer();

--- a/core/divelist.cpp
+++ b/core/divelist.cpp
@@ -33,7 +33,7 @@ void dive_table::record_dive(std::unique_ptr<dive> d)
 
 void dive_table::fixup_dive(struct dive &dive) const
 {
-	dive.fixup_no_cylinder();
+	dive.fixup_dive();
 	update_cylinder_related_info(dive);
 }
 

--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -29,6 +29,7 @@
 #include "subsurface-string.h"
 #include "subsurface-time.h"
 #include "tag.h"
+#include "tanksensormapping.h"
 #include "trip.h"
 #include "version.h"
 
@@ -824,6 +825,15 @@ static void parse_dc_keyvalue(char *line, struct git_parser_state *state)
 	add_extra_data(state->active_dc, state->converted_strings[0], state->converted_strings[1]);
 }
 
+static void parse_dc_tanksensormapping(char *line, struct git_parser_state *state)
+{
+	// Let's make sure we have two strings...
+	if (state->converted_strings.size() != 2)
+		return;
+
+	state->active_dc->tank_sensor_mappings.push_back(tank_sensor_mapping { (int16_t)atoi(state->converted_strings[0].c_str()), (unsigned int)atoi(state->converted_strings[1].c_str()) });
+}
+
 static void parse_dc_event(char *line, struct git_parser_state *state)
 {
 	int m, s = 0;
@@ -1058,7 +1068,7 @@ static const std::array dc_action {
 #define D(x) keyword_action { #x, parse_dc_ ## x }
 	D(airtemp), D(date), D(dctype), D(deviceid), D(diveid), D(duration),
 	D(event), D(keyvalue), D(lastmanualtime), D(maxdepth), D(meandepth), D(model), D(numberofoxygensensors),
-	D(salinity), D(surfacepressure), D(surfacetime), D(time), D(watertemp)
+	D(salinity), D(surfacepressure), D(surfacetime), D(tanksensormapping), D(time), D(watertemp)
 };
 
 /* Sample lines start with a space or a number */

--- a/core/parse.h
+++ b/core/parse.h
@@ -82,6 +82,7 @@ struct parser_state {
 	int o2pressure_sensor = 0;
 	int sample_rate = 0;
 	struct { std::string key; std::string value; } cur_extra_data;
+	struct { int16_t sensor_id; unsigned int cylinder_index; } cur_tank_sensor_mapping;
 	struct units xml_parsing_units;
 	struct divelog *log = nullptr;				/* non-owning */
 	std::vector<fingerprint_record> *fingerprints = nullptr;

--- a/core/qthelper.h
+++ b/core/qthelper.h
@@ -15,6 +15,7 @@ struct picture;
 struct dive_trip;
 struct xml_params;
 struct git_info;
+struct divecomputer;
 class QImage;
 
 enum watertypes {FRESHWATER, BRACKISHWATER, EN13319WATER, SALTWATER, DC_WATERTYPE};
@@ -30,6 +31,7 @@ bool gpsHasChanged(struct dive *dive, struct dive *master, const QString &gps_te
 QString get_gas_string(struct gasmix gas);
 QString get_dive_gas(const struct dive *d, int dcNr, int cylinderId);
 std::vector<std::pair<int, QString>> get_dive_gas_list(const struct dive *d, int dcNr, bool showOnlyAppropriate);
+std::vector<std::pair<int, QString>> get_tank_sensor_list(const divecomputer &dc);
 QStringList stringToList(const QString &s);
 void read_hashes();
 void write_hashes();

--- a/core/sample.cpp
+++ b/core/sample.cpp
@@ -25,21 +25,19 @@ void add_sample_pressure(struct sample *sample, int sensor, int mbar)
 		return;
 
 	/* Do we already have a slot for this sensor */
-	for (idx = 0; idx < MAX_SENSORS; idx++) {
-		if (sensor != sample->sensor[idx])
-			continue;
-		sample->pressure[idx].mbar = mbar;
-		return;
-	}
+	for (idx = 0; idx < MAX_SENSORS; idx++)
+		if (sensor == sample->sensor[idx]) {
+			sample->pressure[idx].mbar = mbar;
+			return;
+		}
 
 	/* Pick the first unused index if we couldn't reuse one */
-	for (idx = 0; idx < MAX_SENSORS; idx++) {
-		if (sample->pressure[idx].mbar)
-			continue;
-		sample->sensor[idx] = sensor;
-		sample->pressure[idx].mbar = mbar;
-		return;
-	}
+	for (idx = 0; idx < MAX_SENSORS; idx++)
+		if (!sample->pressure[idx].mbar) {
+			sample->sensor[idx] = sensor;
+			sample->pressure[idx].mbar = mbar;
+			return;
+		}
 
 	/* We do not have enough slots for the pressure samples. */
 	/* Should we warn the user about dropping pressure data? */

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -36,6 +36,7 @@
 #include "range.h"
 #include "gettext.h"
 #include "tag.h"
+#include "tanksensormapping.h"
 #include "subsurface-time.h"
 
 #define VA_BUF(b, fmt) do { va_list args; va_start(args, fmt); put_vformat(b, fmt, args); va_end(args); } while (0)
@@ -124,6 +125,13 @@ static void save_extra_data(struct membuffer *b, const struct divecomputer &dc)
 	for (const auto &ed: dc.extra_data) {
 		if (!ed.key.empty() && !ed.value.empty())
 			put_format(b, "keyvalue \"%s\" \"%s\"\n", ed.key.c_str(), ed.value.c_str());
+	}
+}
+
+static void save_tank_sensor_mappings(struct membuffer *b, const struct divecomputer &dc)
+{
+	for (const auto &tank_sensor_mapping: dc.tank_sensor_mappings) {
+		put_format(b, "tanksensormapping \"%d\" \"%d\"\n", tank_sensor_mapping.sensor_id, tank_sensor_mapping.cylinder_index);
 	}
 }
 
@@ -429,6 +437,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 	put_duration(b, dc.surfacetime, "surfacetime ", "min\n");
 
 	save_extra_data(b, dc);
+	save_tank_sensor_mappings(b, dc);
 	save_events(b, dive, dc);
 	save_samples(b, dive, dc);
 }

--- a/core/save-git.cpp
+++ b/core/save-git.cpp
@@ -128,11 +128,11 @@ static void save_extra_data(struct membuffer *b, const struct divecomputer &dc)
 	}
 }
 
-static void save_tank_sensor_mappings(struct membuffer *b, const struct divecomputer &dc)
+static void save_tank_sensor_mappings(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc)
 {
-	for (const auto &tank_sensor_mapping: dc.tank_sensor_mappings) {
-		put_format(b, "tanksensormapping \"%d\" \"%d\"\n", tank_sensor_mapping.sensor_id, tank_sensor_mapping.cylinder_index);
-	}
+	const auto mappings = get_tank_sensor_mappings_for_storage(dive, dc);
+	for (const auto &mapping: mappings)
+		put_format(b, "tanksensormapping \"%d\" \"%d\"\n", mapping.sensor_id, mapping.cylinder_index);
 }
 
 static void put_gasmix(struct membuffer *b, struct gasmix mix)
@@ -437,7 +437,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 	put_duration(b, dc.surfacetime, "surfacetime ", "min\n");
 
 	save_extra_data(b, dc);
-	save_tank_sensor_mappings(b, dc);
+	save_tank_sensor_mappings(b, dive, dc);
 	save_events(b, dive, dc);
 	save_samples(b, dive, dc);
 }

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -24,6 +24,7 @@
 #include "sample.h"
 #include "subsurface-string.h"
 #include "subsurface-time.h"
+#include "tanksensormapping.h"
 #include "trip.h"
 #include "file.h"
 #include "membuffer.h"
@@ -399,6 +400,16 @@ static void save_extra_data(struct membuffer *b, const struct divecomputer &dc)
 	}
 }
 
+static void save_tank_sensor_mappings(struct membuffer *b, const struct divecomputer &dc)
+{
+	for (const auto &tank_sensor_mapping: dc.tank_sensor_mappings) {
+		put_string(b, "  <tanksensormapping");
+		show_integer(b, tank_sensor_mapping.sensor_id, "sensorid='", "'");
+		show_integer(b, tank_sensor_mapping.cylinder_index, "cylinderindex='", "'");
+		put_string(b, " />\n");
+	}
+}
+
 static void show_date(struct membuffer *b, timestamp_t when)
 {
 	struct tm tm;
@@ -455,6 +466,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 	save_salinity(b, dc);
 	put_duration(b, dc.surfacetime, "  <surfacetime>", " min</surfacetime>\n");
 	save_extra_data(b, dc);
+	save_tank_sensor_mappings(b, dc);
 	save_events(b, dive, dc);
 	save_samples(b, dive, dc);
 

--- a/core/save-xml.cpp
+++ b/core/save-xml.cpp
@@ -400,12 +400,13 @@ static void save_extra_data(struct membuffer *b, const struct divecomputer &dc)
 	}
 }
 
-static void save_tank_sensor_mappings(struct membuffer *b, const struct divecomputer &dc)
+static void save_tank_sensor_mappings(struct membuffer *b, const struct dive &dive, const struct divecomputer &dc)
 {
-	for (const auto &tank_sensor_mapping: dc.tank_sensor_mappings) {
+	const auto mappings = get_tank_sensor_mappings_for_storage(dive, dc);
+	for (const auto &mapping: mappings) {
 		put_string(b, "  <tanksensormapping");
-		show_integer(b, tank_sensor_mapping.sensor_id, "sensorid='", "'");
-		show_integer(b, tank_sensor_mapping.cylinder_index, "cylinderindex='", "'");
+		show_integer(b, mapping.sensor_id, "sensorid='", "'");
+		show_integer(b, mapping.cylinder_index, "cylinderindex='", "'");
 		put_string(b, " />\n");
 	}
 }
@@ -466,7 +467,7 @@ static void save_dc(struct membuffer *b, const struct dive &dive, const struct d
 	save_salinity(b, dc);
 	put_duration(b, dc.surfacetime, "  <surfacetime>", " min</surfacetime>\n");
 	save_extra_data(b, dc);
-	save_tank_sensor_mappings(b, dc);
+	save_tank_sensor_mappings(b, dive, dc);
 	save_events(b, dive, dc);
 	save_samples(b, dive, dc);
 

--- a/core/subsurface-qt/divelistnotifier.h
+++ b/core/subsurface-qt/divelistnotifier.h
@@ -95,7 +95,7 @@ signals:
 	void divesTimeChanged(timestamp_t delta, const QVector<dive *> &dives);
 	void divesImported(); // A general signal when multiple dives have been imported.
 
-	void diveComputerEdited(divecomputer *dc);
+	void diveComputerEdited(dive &dive, divecomputer &dc);
 
 	void cylindersReset(const QVector<dive *> &dives);
 	void cylinderAdded(dive *d, int pos);

--- a/core/tanksensormapping.h
+++ b/core/tanksensormapping.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TANKSENSORMAPPING_H
+#define TANKSENSORMAPPING_H
+
+struct tank_sensor_mapping {
+	int16_t sensor_id;
+	unsigned int cylinder_index;
+};
+
+#endif

--- a/desktop-widgets/divelistview.cpp
+++ b/desktop-widgets/divelistview.cpp
@@ -397,7 +397,6 @@ static void check_cylinder_use(struct dive &dive)
 	for (auto &divecomputer: dive.dcs)
 		check_dc_cylinder_use(dive, divecomputer);
 }
-	
 
 void DiveListView::divesChanged(const QVector<dive *> &dives, DiveField field)
 {

--- a/desktop-widgets/modeldelegates.cpp
+++ b/desktop-widgets/modeldelegates.cpp
@@ -289,46 +289,31 @@ void TankUseDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, c
 	model->setData(index, cylinderuse_from_text(qPrintable(comboBox->currentText())));
 }
 
-SensorDelegate::SensorDelegate(QObject *parent) : QStyledItemDelegate(parent), currentdc(nullptr)
+SensorDelegate::SensorDelegate(QObject *parent) :
+	ComboBoxDelegate([this] (QWidget *parent) { return new SensorSelectionModel(*this->getCurrentDc(), parent); }, parent, false), currentdc(nullptr)
 {
 }
 
-void SensorDelegate::setCurrentDC(divecomputer *dc)
+void SensorDelegate::setCurrentDc(divecomputer *dc)
 {
 	currentdc = dc;
 }
 
-QWidget *SensorDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &index) const
+const divecomputer *SensorDelegate::getCurrentDc() const
 {
-	QComboBox *comboBox = new QComboBox(parent);
+	return currentdc;
+}
 
-	if (!currentdc)
-		return comboBox;
-
-	std::vector<int16_t> sensors;
-	for (const auto &sample: currentdc->samples) {
-		for (int s = 0; s < MAX_SENSORS; ++s) {
-			if (sample.pressure[s].mbar) {
-				if (std::find(sensors.begin(), sensors.end(), sample.sensor[s]) == sensors.end())
-					sensors.push_back(sample.sensor[s]);
-			}
-		}
-	}
-	std::sort(sensors.begin(), sensors.end());
-	for (auto s : sensors)
-		comboBox->addItem(QString::number(s));
-
-	comboBox->setCurrentIndex(-1);
-	QString indexString = index.data().toString();
-	if (!indexString.isEmpty())
-		comboBox->setCurrentText(indexString);
-	return comboBox;
+void SensorDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint)
+{
 }
 
 void SensorDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
-	QComboBox *comboBox = qobject_cast<QComboBox *>(editor);
-	model->setData(index, comboBox->currentText());
+	if (!index.isValid())
+		return;
+	QComboBox *combo = qobject_cast<QComboBox *>(editor);
+	model->setData(index, combo->currentData(Qt::UserRole));
 }
 
 void WSInfoDelegate::editorClosed(QWidget *, QAbstractItemDelegate::EndEditHint hint)

--- a/desktop-widgets/modeldelegates.h
+++ b/desktop-widgets/modeldelegates.h
@@ -84,14 +84,15 @@ private:
 	int *currentDcNr;
 };
 
-class SensorDelegate : public QStyledItemDelegate {
+class SensorDelegate : public ComboBoxDelegate {
 	Q_OBJECT
 public:
 	explicit SensorDelegate(QObject *parent = 0);
-	void setCurrentDC(divecomputer *dc);
+	void setCurrentDc(divecomputer *dc);
 private:
 	void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
-	QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+	const divecomputer *getCurrentDc() const;
+	void editorClosed(QWidget *widget, QAbstractItemDelegate::EndEditHint hint) override;
 	divecomputer *currentdc;
 };
 

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -49,6 +49,7 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	connect(ui.weights, &TableView::itemClicked, this, &TabDiveEquipment::editWeightWidget);
 	connect(cylindersModel, &CylindersModel::divesEdited, this, &TabDiveEquipment::divesEdited);
 	connect(weightModel, &WeightModel::divesEdited, this, &TabDiveEquipment::divesEdited);
+	connect(&diveListNotifier, &DiveListNotifier::diveComputerEdited, this, &TabDiveEquipment::diveComputerEdited);
 
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::TYPE, &tankInfoDelegate);
 	ui.cylinders->view()->setItemDelegateForColumn(CylindersModel::USE, &tankUseDelegate);
@@ -242,6 +243,11 @@ void TabDiveEquipment::divesEdited(int i)
 	ui.multiDiveWarningMessage->setCloseButtonVisible(false);
 	ui.multiDiveWarningMessage->setText(tr("Warning: edited %1 dives").arg(i));
 	ui.multiDiveWarningMessage->show();
+}
+
+void TabDiveEquipment::diveComputerEdited(dive &dive, divecomputer &dc)
+{
+	dive.fixup_dive_dc(dc);
 }
 
 void TabDiveEquipment::on_suit_editingFinished()

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -19,15 +19,6 @@ static bool ignoreHiddenFlag(int i)
 	       i == CylindersModel::WORKINGPRESS_INT || i == CylindersModel::SIZE_INT;
 }
 
-static bool hiddenByDefault(int i)
-{
-	switch (i) {
-	case CylindersModel::SENSORS:
-		return true;
-	}
-	return false;
-}
-
 TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 	cylindersModel(new CylindersModel(false, this)),
 	weightModel(new WeightModel(this))
@@ -87,11 +78,11 @@ TabDiveEquipment::TabDiveEquipment(MainTab *parent) : TabBase(parent),
 		if (ignoreHiddenFlag(i))
 			continue;
 		auto setting = s.value(QString("column%1_hidden").arg(i));
-		bool checked = setting.isValid() ? setting.toBool() : hiddenByDefault(i) ;
+		bool hidden = setting.isValid() ? setting.toBool() : false;
 		QAction *action = new QAction(cylindersModel->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString(), ui.cylinders->view());
 		action->setCheckable(true);
 		action->setData(i);
-		action->setChecked(!checked);
+		action->setChecked(!hidden);
 		connect(action, &QAction::triggered, this, &TabDiveEquipment::toggleTriggeredColumn);
 		ui.cylinders->view()->setColumnHidden(i, checked);
 		ui.cylinders->view()->horizontalHeader()->addAction(action);

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.cpp
@@ -146,7 +146,7 @@ void TabDiveEquipment::updateData(const std::vector<dive *> &, dive *currentDive
 
 	cylindersModel->updateDive(currentDive, currentDC);
 	weightModel->updateDive(currentDive);
-	sensorDelegate.setCurrentDC(dc);
+	sensorDelegate.setCurrentDc(dc);
 	tankUseDelegate.setDiveDc(*currentDive, currentDC);
 
 	if (currentDive && !currentDive->suit.empty())

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -34,6 +34,7 @@ private slots:
 	void on_suit_editingFinished();
 	void divesEdited(int count);
 	void diveComputerEdited(dive &dive, divecomputer &dc);
+	void cylinderRemoved(struct dive *dive, int);
 
 private:
 	Ui::TabDiveEquipment ui;

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -33,6 +33,7 @@ private slots:
 	void editWeightWidget(const QModelIndex &index);
 	void on_suit_editingFinished();
 	void divesEdited(int count);
+	void diveComputerEdited(dive &dive, divecomputer &dc);
 
 private:
 	Ui::TabDiveEquipment ui;

--- a/desktop-widgets/tab-widgets/TabDiveEquipment.h
+++ b/desktop-widgets/tab-widgets/TabDiveEquipment.h
@@ -44,6 +44,7 @@ private:
 	TankUseDelegate tankUseDelegate;
 	SensorDelegate sensorDelegate;
 	WSInfoDelegate wsInfoDelegate;
+	void setCylinderColumnVisibility();
 };
 
 #endif // TAB_DIVE_EQUIPMENT_H

--- a/dives/merged-tank-sensors.xml
+++ b/dives/merged-tank-sensors.xml
@@ -1,0 +1,197 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive number='2' otu='38' cns='4%' date='2025-03-11' time='20:46:51' duration='27:22 min'>
+  <notes>no sensors mapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <cylinder description='first_2' o2='40.0%' depth='22.086 m' />
+  <cylinder description='second_2' o2='25.0%' depth='66.249 m' />
+  <cylinder description='third_2' o2='16.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth_2' o2='15.0%' he='46.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='11.968 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:22 min' depth='0.0 m' />
+  </divecomputer>
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='11.968 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='0:00 min' type='11' value='40' name='gaschange' cylinder='4' o2='40.0%' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='6' o2='16.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:22 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='3' otu='42' cns='4%' date='2025-03-11' time='20:47:03' duration='29:58 min'>
+  <notes>default mapping, single tank</notes>
+  <cylinder description='first' o2='50.0%' use='diluent' depth='22.086 m' />
+  <cylinder description='first_2' o2='45.0%' use='diluent' depth='22.086 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='9.564 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='0' o2='50.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='10.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:00 min' depth='3.0 m' />
+  <sample time='29:58 min' depth='0.0 m' />
+  </divecomputer>
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='9.564 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='1' />
+  <event time='0:00 min' type='11' value='45' name='gaschange' cylinder='1' o2='45.0%' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='0' o2='50.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='10.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:00 min' depth='3.0 m' />
+  <sample time='29:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='4' otu='62' cns='4%' date='2025-03-11' time='20:47:27' duration='41:58 min'>
+  <notes>sensors swapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <cylinder description='first_2' o2='40.0%' depth='22.086 m' />
+  <cylinder description='second_2' o2='25.0%' depth='66.249 m' />
+  <cylinder description='third_2' o2='16.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth_2' o2='15.0%' he='46.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='8.829 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='1' />
+  <tanksensormapping sensorid='1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='39:00 min' depth='3.0 m' />
+  <sample time='41:58 min' depth='0.0 m' />
+  </divecomputer>
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='8.829 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='5' />
+  <tanksensormapping sensorid='1' cylinderindex='4' />
+  <event time='0:00 min' type='11' value='40' name='gaschange' cylinder='4' o2='40.0%' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='6' o2='16.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='39:00 min' depth='3.0 m' />
+  <sample time='41:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='5' otu='84' cns='4%' date='2025-03-11' time='20:47:33' duration='54:58 min'>
+  <notes>default mapping</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='7.45 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure2='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='52:00 min' depth='3.0 m' />
+  <sample time='54:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/dives/test-tank-sensor-mapping-merge.xml
+++ b/dives/test-tank-sensor-mapping-merge.xml
@@ -1,0 +1,120 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive number='2' otu='38' cns='4%' date='2025-03-11' time='20:46:51' duration='27:22 min'>
+  <notes>no sensors mapped</notes>
+  <cylinder description='first_2' o2='40.0%' depth='22.086 m' />
+  <cylinder description='second_2' o2='25.0 %' depth='66.249 m' />
+  <cylinder description='third_2' o2='16.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth_2' o2='15.0%' he='46.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='11.968 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='-1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:22 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='3' otu='42' cns='4%' date='2025-03-11' time='20:47:03' duration='29:58 min'>
+  <notes>default mapping, single tank</notes>
+  <cylinder description='first_2' o2='45.0%' use='diluent' depth='22.086 m' />
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='9.564 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='10.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:00 min' depth='3.0 m' />
+  <sample time='29:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='4' otu='62' cns='4%' date='2025-03-11' time='20:47:27' duration='41:58 min'>
+  <notes>sensors swapped</notes>
+  <cylinder description='first_2' o2='40.0%' depth='22.086 m' />
+  <cylinder description='second_2' o2='25.0%' depth='66.249 m' />
+  <cylinder description='third_2' o2='16.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth_2' o2='15.0%' he='46.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='8.829 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='1' />
+  <tanksensormapping sensorid='1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='39:00 min' depth='3.0 m' />
+  <sample time='41:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='5' otu='84' cns='4%' date='2025-03-11' time='20:47:33' duration='54:58 min'>
+  <notes>default mapping</notes>
+  <cylinder description='first_2' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second_2' depth='66.249 m' />
+  <cylinder description='third_2' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth_2' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 2' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='7.45 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure2='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='52:00 min' depth='3.0 m' />
+  <sample time='54:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/dives/test-tank-sensor-mapping.xml
+++ b/dives/test-tank-sensor-mapping.xml
@@ -1,0 +1,120 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive number='2' otu='38' cns='4%' date='2025-03-11' time='20:46:51' duration='27:22 min'>
+  <notes>no sensors mapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='11.968 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='-1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:22 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='3' otu='42' cns='4%' date='2025-03-11' time='20:47:03' duration='29:58 min'>
+  <notes>default mapping, single tank</notes>
+  <cylinder description='first' o2='50.0%' use='diluent' depth='22.086 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='9.564 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='10.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:00 min' depth='3.0 m' />
+  <sample time='29:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='4' otu='62' cns='4%' date='2025-03-11' time='20:47:27' duration='41:58 min'>
+  <notes>sensors swapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='8.829 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='1' />
+  <tanksensormapping sensorid='1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='39:00 min' depth='3.0 m' />
+  <sample time='41:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='5' otu='84' cns='4%' date='2025-03-11' time='20:47:33' duration='54:58 min'>
+  <notes>default mapping</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='7.45 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure2='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='52:00 min' depth='3.0 m' />
+  <sample time='54:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/dives/test-tank-sensors.xml
+++ b/dives/test-tank-sensors.xml
@@ -1,0 +1,120 @@
+<divelog program='subsurface' version='3'>
+<settings>
+</settings>
+<divesites>
+</divesites>
+<dives>
+<dive number='2' otu='38' cns='4%' date='2025-03-11' time='20:46:51' duration='27:22 min'>
+  <notes>no sensors mapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='11.968 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='-1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:22 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='3' otu='42' cns='4%' date='2025-03-11' time='20:47:03' duration='29:58 min'>
+  <notes>default mapping, single tank</notes>
+  <cylinder description='first' o2='50.0%' use='diluent' depth='22.086 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='9.564 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='10.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='27:00 min' depth='3.0 m' />
+  <sample time='29:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='4' otu='62' cns='4%' date='2025-03-11' time='20:47:27' duration='41:58 min'>
+  <notes>sensors swapped</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='8.829 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <tanksensormapping sensorid='0' cylinderindex='1' />
+  <tanksensormapping sensorid='1' cylinderindex='0' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure1='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='39:00 min' depth='3.0 m' />
+  <sample time='41:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+<dive number='5' otu='84' cns='4%' date='2025-03-11' time='20:47:33' duration='54:58 min'>
+  <notes>default mapping</notes>
+  <cylinder description='first' o2='50.0%' depth='22.086 m' />
+  <cylinder description='second' depth='66.249 m' />
+  <cylinder description='third' o2='15.0%' he='45.0%' depth='96.7 m' />
+  <cylinder description='fourth' o2='15.0%' he='45.0%' use='diluent' depth='96.7 m' />
+  <divecomputer model='Divecomputer 1' last-manual-time='20:00 min' dctype='CCR' no_o2sensors='3'>
+  <depth max='40.965 m' mean='7.45 m' />
+  <temperature water='26.667 C' />
+  <surface pressure='1.013 bar' />
+  <water salinity='1020 g/l' />
+  <event time='20:01 min' type='25' value='2949135' name='gaschange' cylinder='2' o2='15.0%' he='45.0%' />
+  <sample time='0:00 min' depth='0.0 m' />
+  <sample time='0:10 min' depth='1.067 m' temp='26.667 C' pressure0='109.213 bar' pressure2='159.407 bar' tts='1:00 min' cns='4%' sensor1='0.777 bar' sensor2='0.777 bar' sensor3='0.756 bar' dc_supplied_ppo2='0.66 bar' po2='0.7 bar' />
+  <sample time='0:50 min' depth='15.0 m' />
+  <sample time='10:00 min' depth='15.0 m' pressure0='63.57 bar' pressure1='158.855 bar' sensor1='1.323 bar' sensor2='1.323 bar' sensor3='1.344 bar' dc_supplied_ppo2='1.15 bar' />
+  <sample time='20:00 min' depth='15.0 m' />
+  <sample time='20:01 min' depth='15.0 m' />
+  <sample time='20:42 min' depth='11.0 m' />
+  <sample time='21:10 min' depth='10.0 m' pressure0='52.676 bar' pressure1='153.615 bar' tts='9:00 min' sensor1='1.344 bar' sensor2='1.344 bar' sensor3='1.365 bar' dc_supplied_ppo2='1.17 bar' />
+  <sample time='21:16 min' depth='7.128 m' />
+  <sample time='21:26 min' depth='6.0 m' />
+  <sample time='24:24 min' depth='3.0 m' />
+  <sample time='24:40 min' depth='3.0 m' pressure0='40.541 bar' tts='14:00 min' sensor1='1.47 bar' sensor2='1.449 bar' sensor3='1.47 bar' dc_supplied_ppo2='1.26 bar' />
+  <sample time='38:40 min' depth='3.0 m' pressure0='31.578 bar' pressure1='147.548 bar' tts='19:00 min' sensor1='1.428 bar' sensor2='1.407 bar' sensor3='1.428 bar' dc_supplied_ppo2='1.23 bar' />
+  <sample time='52:00 min' depth='3.0 m' />
+  <sample time='54:58 min' depth='0.0 m' />
+  </divecomputer>
+</dive>
+</dives>
+</divelog>

--- a/profile-widget/profilewidget2.cpp
+++ b/profile-widget/profilewidget2.cpp
@@ -83,7 +83,7 @@ ProfileWidget2::ProfileWidget2(DivePlannerPointsModel *plannerModelIn, double dp
 	connect(&diveListNotifier, &DiveListNotifier::pictureOffsetChanged, this, &ProfileWidget2::pictureOffsetChanged);
 	connect(&diveListNotifier, &DiveListNotifier::divesChanged, this, &ProfileWidget2::divesChanged);
 	connect(&diveListNotifier, &DiveListNotifier::deviceEdited, this, &ProfileWidget2::replot);
-	connect(&diveListNotifier, &DiveListNotifier::diveComputerEdited, this, &ProfileWidget2::replot);
+	connect(&diveListNotifier, &DiveListNotifier::diveComputerEdited, this, &ProfileWidget2::diveComputerEdited);
 #endif // SUBSURFACE_MOBILE
 
 #if !defined(QT_NO_DEBUG) && defined(SHOW_PLOT_INFO_TABLE)
@@ -164,6 +164,12 @@ void ProfileWidget2::setupItemOnScene()
 	mouseFollowerHorizontal->setZValue(9996);
 	mouseFollowerVertical->setZValue(9995);
 #endif
+}
+
+void ProfileWidget2::diveComputerEdited(dive &dive, divecomputer &dc)
+{
+	if (d == &dive && d->get_dc(this->dc) == &dc)
+		replot();
 }
 
 void ProfileWidget2::replot()

--- a/profile-widget/profilewidget2.h
+++ b/profile-widget/profilewidget2.h
@@ -111,6 +111,7 @@ private:
 	void dragMoveEvent(QDragMoveEvent *event) override;
 
 	void replot();
+	void diveComputerEdited(dive &dive, divecomputer &dc);
 	void setZoom(int level);
 	void addGasSwitch(int tank, int seconds);
 	void changeGas(int index, int newCylinderId);

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -93,6 +93,34 @@ int DiveTypeSelectionModel::rowCount(const QModelIndex&) const
 	return diveTypes.size();
 }
 
+SensorSelectionModel::SensorSelectionModel(const divecomputer &dc, QObject *parent)
+	: QAbstractListModel(parent)
+{
+	sensorNames = get_tank_sensor_list(dc);
+}
+
+QVariant SensorSelectionModel::data(const QModelIndex &index, int role) const
+{
+	if (!index.isValid())
+		return QVariant();
+
+	switch (role) {
+	case Qt::FontRole:
+		return defaultModelFont();
+	case Qt::DisplayRole:
+		return sensorNames.at(index.row()).second;
+	case Qt::UserRole:
+		return sensorNames.at(index.row()).first;
+	}
+
+	return QVariant();
+}
+
+int SensorSelectionModel::rowCount(const QModelIndex&) const
+{
+	return sensorNames.size();
+}
+
 // Language Model, The Model to populate the list of possible Languages.
 
 LanguageModel *LanguageModel::instance()

--- a/qt-models/models.cpp
+++ b/qt-models/models.cpp
@@ -9,6 +9,7 @@
 #include "core/qthelper.h"
 #include "core/dive.h"
 #include "core/gettextfromc.h"
+#include "core/sample.h" // for NO_SENSOR
 
 #include <QDir>
 #include <QLocale>
@@ -97,6 +98,7 @@ SensorSelectionModel::SensorSelectionModel(const divecomputer &dc, QObject *pare
 	: QAbstractListModel(parent)
 {
 	sensorNames = get_tank_sensor_list(dc);
+	sensorNames.insert(sensorNames.begin(), std::make_pair(NO_SENSOR, "<" + tr("none") + ">"));
 }
 
 QVariant SensorSelectionModel::data(const QModelIndex &index, int role) const

--- a/qt-models/models.h
+++ b/qt-models/models.h
@@ -20,6 +20,7 @@
 #include "treemodel.h"
 
 struct dive;
+struct divecomputer;
 
 class GasSelectionModel : public QAbstractListModel {
 	Q_OBJECT
@@ -39,6 +40,16 @@ public:
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 private:
 	std::vector<std::pair<int, QString>> diveTypes;
+};
+
+class SensorSelectionModel : public QAbstractListModel {
+	Q_OBJECT
+public:
+	SensorSelectionModel(const divecomputer &dc, QObject *parent);
+	QVariant data(const QModelIndex &index, int role) const override;
+	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+private:
+	std::vector<std::pair<int, QString>> sensorNames;
 };
 
 class LanguageModel : public QAbstractListModel {

--- a/qt-models/weightmodel.cpp
+++ b/qt-models/weightmodel.cpp
@@ -15,7 +15,7 @@ WeightModel::WeightModel(QObject *parent) : CleanerTableModel(parent),
 	tempRow(-1)
 {
 	//enum Column {REMOVE, TYPE, WEIGHT};
-	setHeaderDataStrings(QStringList() << tr("") << tr("Type") << tr("Weight"));
+	setHeaderDataStrings(QStringList() << "" << tr("Type") << tr("Weight"));
 	connect(&diveListNotifier, &DiveListNotifier::weightsystemsReset, this, &WeightModel::weightsystemsReset);
 	connect(&diveListNotifier, &DiveListNotifier::weightAdded, this, &WeightModel::weightAdded);
 	connect(&diveListNotifier, &DiveListNotifier::weightRemoved, this, &WeightModel::weightRemoved);

--- a/tests/testparse.cpp
+++ b/tests/testparse.cpp
@@ -137,6 +137,16 @@ void TestParse::testParse()
 		     SUBSURFACE_TEST_DATA "/dives/test40-42.xml");
 }
 
+void TestParse::testParseTankSensors()
+{
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test-tank-sensor-mapping.xml", &divelog), 0);
+	fprintf(stderr, "number of dives %d \n", static_cast<int>(divelog.dives.size()));
+
+	QCOMPARE(save_dives("./testouttanksensors.ssrf"), 0);
+	FILE_COMPARE("./testouttanksensors.ssrf",
+		     SUBSURFACE_TEST_DATA "/dives/test-tank-sensors.xml");
+}
+
 void TestParse::testParseDM4()
 {
 	QCOMPARE(sqlite3_open(SUBSURFACE_TEST_DATA "/dives/TestDiveDM4.db", &_sqlite3_handle), 0);
@@ -265,6 +275,22 @@ void TestParse::testParseMerge()
 	QCOMPARE(save_dives("./testmerge.ssrf"), 0);
 	FILE_COMPARE("./testmerge.ssrf",
 		     SUBSURFACE_TEST_DATA "/dives/mergedVyperOstc.xml");
+}
+
+void TestParse::testParseMergeTankSensors()
+{
+	/*
+	 * check that we correctly merge mixed cylinder dives with tank sensors
+	 */
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test-tank-sensor-mapping.xml", &divelog), 0);
+
+	struct divelog divelogToMerge;
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/test-tank-sensor-mapping-merge.xml", &divelogToMerge), 0);
+	divelog.add_imported_dives(divelogToMerge, import_flags::merge_all_trips);
+
+	QCOMPARE(save_dives("./testmergetanksensors.ssrf"), 0);
+	FILE_COMPARE("./testmergetanksensors.ssrf",
+		     SUBSURFACE_TEST_DATA "/dives/merged-tank-sensors.xml");
 }
 
 int TestParse::parseCSVmanual(int units, std::string file)

--- a/tests/testparse.h
+++ b/tests/testparse.h
@@ -17,6 +17,7 @@ private slots:
 	int parseV2NoQuestion();
 	int parseV3();
 	void testParse();
+	void testParseTankSensors();
 
 	void testParseDM4();
 	void testParseDM5();
@@ -24,6 +25,7 @@ private slots:
 	void testParseNewFormat();
 	void testParseDLD();
 	void testParseMerge();
+	void testParseMergeTankSensors();
 
 	int parseCSVmanual(int, std::string);
 	void exportSubsurfaceCSV();


### PR DESCRIPTION

<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Improve the UI for the assignment of tank pressure sensors to cylinders, in particular in the case of multiple tank sensors.

@dirkhh: I know we have talked about this before, but I still think the current implementation of this functionality is not ideal:
When it is used, tank pressure sensor ids (`pressure<X>=Y`) are modified in the actual dive data samples. This irreversibly modifies the data that was downloaded from the dive computer, making it impossible for the user to ever go back to the original dive data. Furthermore, the user will not be able at a later stage to figure out which sensor was which, and map them to metadata like the sensor's serial number or battery level that is often supplied by the dive computer as extra data. In addition to this, this approach also doesn't allow the user to have an 'unused' sensor that isn't assigned to a cylinder.
For this reason I think it will better to add extra syntax to our formats to encode this mapping without having to modify the data downloaded from the dive computer. What I propose are zero to many occurrences of an extra child element for `<divecomputer>`:

```
<tank_sensor id='<id from samples>' cylinder='<cylinder id>'>
```

The absence of any of these mappings will be interpreted as a 1:1 mapping (i.e. the existing behaviour).
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix bugs preventing sensors for tanks other than the first three from being shown;
2. remove the hiding of the 'Sensor' column by default;
3. only show the 'Sensor' column if the dive has tank sensors;
4. add start / end pressure to the tank sensor selection in the drop-down;
5. replace the misleading dynamic sensor index with 'X' in the table;
6. update the cylinder table after a sensor has been reassigned.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
https://groups.google.com/g/subsurface-divelog/c/K9u2SBEyUlw

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![Screenshot From 2025-03-06 17-14-42](https://github.com/user-attachments/assets/8b118e3c-dada-4576-8051-eaf4014e6eef)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
