### PR TITLE
Add support for libdivecomputer's DC_IOCTL_BLE_CHARACTERISTIC_READ

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -796,16 +796,15 @@ dc_status_t BLEObject::read_characteristic(const QBluetoothUuid &uuid, char *res
 dc_status_t qt_ble_ioctl(void *io, unsigned int request, void *data, size_t size)
 {
 	BLEObject *ble = (BLEObject *) io;
-	struct quint128 uuid;
-	size_t readsize;
-	char *p;
-
 	switch (request) {
 	case DC_IOCTL_BLE_GET_NAME:
 		return ble->get_name((char *) data, size);
 	case DC_IOCTL_BLE_CHARACTERISTIC_READ:
+		struct quint128 uuid;
 		memcpy(uuid.data, data, sizeof(uuid.data));
+		size_t readsize;
 		readsize = size - sizeof(uuid.data);
+		char *p;
 		p = ((char*)data) +  sizeof(uuid.data);
 		return ble->read_characteristic(QBluetoothUuid(uuid), p, readsize);
 	default:

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -205,6 +205,9 @@ void BLEObject::addService(const QBluetoothUuid &newService)
 		return;
 	}
 
+	auto service = controller->createServiceObject(newService, this);
+	allSafeServices.append(service);
+
 	//
 	// If it's a known serial service, clear any other previous
 	// services we've found - we'll use this one.
@@ -224,7 +227,7 @@ void BLEObject::addService(const QBluetoothUuid &newService)
 	details = is_known_serial_service(newService);
 	if (details) {
 		report_info(" .. recognized service %s", details);
-		services.clear();
+		serialCandidateServices.clear();
 	} else {
 		bool isStandardUuid = false;
 
@@ -235,7 +238,7 @@ void BLEObject::addService(const QBluetoothUuid &newService)
 		}
 	}
 
-	auto service = controller->createServiceObject(newService, this);
+
 	if (service) {
 		// provide some visibility into what's happening in the log
 		service->connect(service, &QLowEnergyService::stateChanged,[=](QLowEnergyService::ServiceState newState) {
@@ -249,7 +252,7 @@ void BLEObject::addService(const QBluetoothUuid &newService)
 				 [=](QLowEnergyService::ServiceError newError) {
 			report_info("error discovering service details %d", static_cast<int>(newError));
 		});
-		services.append(service);
+		serialCandidateServices.append(service);
 		report_info("starting service characteristics discovery");
 		service->discoverDetails();
 	}
@@ -268,7 +271,7 @@ BLEObject::~BLEObject()
 {
 	report_info("Deleting BLE object");
 
-	qDeleteAll(services);
+	qDeleteAll(allSafeServices);
 
 	delete controller;
 }
@@ -417,7 +420,7 @@ dc_status_t BLEObject::read(void *data, size_t size, size_t *actual)
 dc_status_t BLEObject::select_preferred_service()
 {
 	// Wait for each service to finish discovering
-	for (const QLowEnergyService *s: services) {
+	for (const QLowEnergyService *s: serialCandidateServices) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		WAITFOR(s->state() != QLowEnergyService::RemoteServiceDiscovering, BLE_TIMEOUT);
 		if (s->state() == QLowEnergyService::RemoteServiceDiscovering)
@@ -429,7 +432,7 @@ dc_status_t BLEObject::select_preferred_service()
 	}
 
 	// Print out the services for debugging
-	for (const QLowEnergyService *s: services) {
+	for (const QLowEnergyService *s: serialCandidateServices) {
 		report_info("Found service %s %s", to_str(s->serviceUuid()).c_str(), qPrintable(s->serviceName()));
 
 		for (const QLowEnergyCharacteristic &c: s->characteristics()) {
@@ -441,7 +444,7 @@ dc_status_t BLEObject::select_preferred_service()
 	}
 
 	// Pick the preferred one
-	for (QLowEnergyService *s: services) {
+	for (QLowEnergyService *s: serialCandidateServices) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		if (s->state() != QLowEnergyService::RemoteServiceDiscovered)
 #else
@@ -764,13 +767,47 @@ dc_status_t BLEObject::get_name(char *data, size_t size)
 	return DC_STATUS_SUCCESS;
 }
 
+dc_status_t BLEObject::read_characteristic(const QBluetoothUuid &uuid, char *res, size_t size)
+{
+	for (QLowEnergyService *s: allSafeServices) {
+		const QList<QLowEnergyCharacteristic> chars = s->characteristics();
+		for (const QLowEnergyCharacteristic& ch : chars) {
+			if (ch.uuid() == uuid) {
+				report_info("Reading BLE characteristic %s from service %s",
+					to_str(uuid).c_str(),
+					to_str(s->serviceUuid()).c_str());
+				s->readCharacteristic(ch);
+				QByteArray val = ch.value();
+				if ((size_t)val.size() != size) {
+					report_error("unexpected read characteristic size (%lld): expected %lld", (long long)val.size(), (long long)size);
+					return DC_STATUS_DATAFORMAT;
+				}
+				report_info("Obtained characteristic value: %s", val.toHex().toStdString().c_str());
+				memcpy(res, val.data(), size);
+				return DC_STATUS_SUCCESS;
+			}
+		}
+	}
+	// Not found
+	report_error("characteristic %s not found in any of the services", to_str(uuid).c_str());
+	return DC_STATUS_NOACCESS;
+}
+
 dc_status_t qt_ble_ioctl(void *io, unsigned int request, void *data, size_t size)
 {
 	BLEObject *ble = (BLEObject *) io;
+	struct quint128 uuid;
+	size_t readsize;
+	char *p;
 
 	switch (request) {
 	case DC_IOCTL_BLE_GET_NAME:
 		return ble->get_name((char *) data, size);
+	case DC_IOCTL_BLE_CHARACTERISTIC_READ:
+		memcpy(uuid.data, data, sizeof(uuid.data));
+		readsize = size - sizeof(uuid.data);
+		p = ((char*)data) +  sizeof(uuid.data);
+		return ble->read_characteristic(QBluetoothUuid(uuid), p, readsize);
 	default:
 		return DC_STATUS_UNSUPPORTED;
 	}

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -44,8 +44,7 @@ public slots:
 	dc_status_t setupHwTerminalIo(const QList<QLowEnergyCharacteristic> &allC);
 	dc_status_t setHwCredit(unsigned int c);
 private:
-	QVector<QLowEnergyService *> serialCandidateServices;
-	QVector<QLowEnergyService *> allSafeServices;
+	QVector<QLowEnergyService *> services;
 
 	QLowEnergyController *controller;
 	QLowEnergyService *preferred = nullptr;

--- a/core/qt-ble.h
+++ b/core/qt-ble.h
@@ -28,6 +28,7 @@ public:
 	dc_status_t write(const void* data, size_t size, size_t *actual);
 	dc_status_t read(void* data, size_t size, size_t *actual);
 	dc_status_t get_name(char *res, size_t size);
+	dc_status_t read_characteristic(const QBluetoothUuid &uuid, char *res, size_t size);
 	dc_status_t poll(int timeout);
 
 	inline QLowEnergyService *preferredService() { return preferred; }
@@ -43,7 +44,8 @@ public slots:
 	dc_status_t setupHwTerminalIo(const QList<QLowEnergyCharacteristic> &allC);
 	dc_status_t setHwCredit(unsigned int c);
 private:
-	QVector<QLowEnergyService *> services;
+	QVector<QLowEnergyService *> serialCandidateServices;
+	QVector<QLowEnergyService *> allSafeServices;
 
 	QLowEnergyController *controller;
 	QLowEnergyService *preferred = nullptr;


### PR DESCRIPTION
Most BLE enabled dive computers use a communication protocol which simply emulates UART communication over the BLE link. There is a BLE service containing two characteristics: one for sending and one for receiving. The high level communication is done by sending commands and receiving the response over this virtual UART, just like with plain serial (or usb-serial) communication.

The Cressi dive computers are a bit different in this regard because they do have a UART service and characteristics, but they also have a few extra characteristics for information like the model number, firmware version and serial number. In their serial communication protocol, this information could be read by sending a command, but for the BLE communication they removed this command and we now have to read the info from those extra characteristics instead. Unfortunately this information is crucial, so we can't proceed without it.

The new ioctl's were added to libdivecomputer to support reading/writing such secondary characteristics.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
Implements support for libdivecomputer's `DC_IOCTL_BLE_CHARACTERISTIC_READ`.

In order to do so it keeps a list with all the BLE services of the device.

### Related issues:

Addresses part of #4460

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
None

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@jefdriesen 
