### PR TITLE
Add support for Cressi BLE serial service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+core: add support for Cressi Bluetooth interfaces #4460
 desktop: add support to import .asd and .script files from Scubapro's LogTrak and SmartTrak
 desktop: update "Save dive data as subtitles" feature to make it more configurable.
 bluetooth: fix crash on MacOS when doing first download from a new BLE device

--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -154,17 +154,17 @@ static const char *match_uuid_list(const QBluetoothUuid &match, const struct uui
 // Oh. It did, didn't it?
 //
 static const struct uuid_match serial_service_uuids[] = {
-	{ "6e400001-b5a3-f393-e0a9-e50e24dc10b8", "Cressi"},
 	{ "0000fefb-0000-1000-8000-00805f9b34fb", "Heinrichs-Weikamp (Telit/Stollmann)" },
 	{ "2456e1b9-26e2-8f83-e744-f34f01e9d701", "Heinrichs-Weikamp (U-Blox)" },
 	{ "544e326b-5b72-c6b0-1c46-41c1bc448118", "Mares BlueLink Pro" },
-	{ "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic Semi UART" },
 	{ "98ae7120-e62e-11e3-badd-0002a5d5c51b", "Suunto (EON Steel/Core, G5)" },
 	{ "cb3c4555-d670-4670-bc20-b61dbc851e9a", "Pelagic (i770R, i200C, Pro Plus X, Geo 4.0)" },
 	{ "ca7b0001-f785-4c38-b599-c7c5fbadb034", "Pelagic (i330R, DSX)" },
 	{ "fdcdeaaa-295d-470e-bf15-04217b7aa0a0", "ScubaPro (G2, G3)"},
 	{ "fe25c237-0ece-443c-b0aa-e02033e7029d", "Shearwater (Perdix/Teric/Peregrine/Tern)" },
 	{ "0000fcef-0000-1000-8000-00805f9b34fb", "Divesoft" },
+        { "6e400001-b5a3-f393-e0a9-e50e24dc10b8", "Cressi"}, // Must have higher priority than Nordic UART
+        { "6e400001-b5a3-f393-e0a9-e50e24dcca9e", "Nordic Semi UART" },
 	{ NULL, }
 };
 


### PR DESCRIPTION
Add known Bluetooth LE serial service for the Cressi Bluetooth interfaces.

Unfortunately, the Cressi BT offers two known BLE serial services: the service I just added and a Nordic Semi UART (which I am assuming is somehow used by the BT interface itself).

The pre-existing code chose the service based on the discovery ordering (`BLEObject::addService()` cleared any prior services when finding a known one), which led to prioritizing the wrong service (the Nordic UART).

Now instead, all known services are kept until service discovery is completed and only then we choose a single known service based on its priority (determined by it's ordering in the `serial_service_uuids` array).

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes part of #4460 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Yes, added:

> core: add support for Cressi Bluetooth interfaces #4460

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@mikeller @jefdriesen 
