### PR TITLE
Fix the CNS Calculation.

### DIFF
--- a/dives/test40-42.xml
+++ b/dives/test40-42.xml
@@ -32,7 +32,7 @@
   <sample time='41:00 min' depth='0.0 m' />
   </divecomputer>
 </dive>
-<dive number='1' otu='97' cns='34%' date='2014-04-01' time='10:00:00' duration='77:54 min'>
+<dive number='1' otu='95' cns='34%' date='2014-04-01' time='10:00:00' duration='77:54 min'>
   <notes>CCR dive</notes>
   <cylinder size='2.0 l' workpressure='232.0 bar' description='Oxy2' o2='100.0%' start='190.0 bar' end='130.0 bar' use='oxygen' />
   <cylinder size='2.0 l' workpressure='232.0 bar' description='Dil2' start='185.0 bar' end='130.0 bar' use='diluent' />
@@ -2529,7 +2529,7 @@
   <sample time='82:50 min' depth='0.235 m' ndl='0:00 min' stoptime='0:00 min' cns='0%' po2='0.0 bar' />
   </divecomputer>
 </dive>
-<dive number='1' otu='97' cns='34%' date='2014-04-02' time='10:00:00' duration='77:54 min'>
+<dive number='1' otu='95' cns='34%' date='2014-04-02' time='10:00:00' duration='77:54 min'>
   <notes>CCR dive</notes>
   <cylinder size='2.0 l' workpressure='232.0 bar' description='Oxy2' o2='100.0%' start='190.0 bar' end='130.0 bar' use='oxygen' />
   <cylinder size='2.0 l' workpressure='232.0 bar' description='Dil2' start='185.0 bar' end='130.0 bar' use='diluent' />


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Fix the calculation of CNS and OTU for CCR dives. This was broken by the
introduction cylinder use based distinction between CCR and OC segments
in #4245.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. fix the calculation of CNS and OTU for CCR dives;
2. check for missing O2 sensor readings;
3. treat setpoint changes as discrete and happening when a sample is recorded;
4. improve the performance of the decompression obligation calculation.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4466.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
