### PR TITLE
Add discovery support for Cressi BT interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-core: add support for Cressi Bluetooth interfaces #4460
+core: add support for Cressi Bluetooth interfaces #4460 #4469
 desktop: add support to import .asd and .script files from Scubapro's LogTrak and SmartTrak
 desktop: update "Save dive data as subtitles" feature to make it more configurable.
 bluetooth: fix crash on MacOS when doing first download from a new BLE device

--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -40,6 +40,20 @@ static struct modelPattern model[] = {
 	{ 0x4744, "Aqualung", "i330R" },
 };
 
+// The Cressi BT interfaces for Goa-style computers advertise names with pattern:
+//  <model number>_<4 digit lowercase hex serial number>
+// The source of truth for model numbers is in libdivecomputer/src/descriptor.c
+static QRegularExpression cressiBTNamePattern("^([1-9][0-9]?)_[0-9a-f]{4}$");
+static QMap<int, QString> cressiModelNumToProduct{
+	{ 1, "Cartesio"},
+	{ 2, "Goa"},
+	{ 3, "Leonardo 2.0"},
+	{ 4, "Donatello"},
+        { 5, "Michelangelo"},
+	{ 9, "Neon"},
+	{10, "Nepto"}
+};
+
 struct namePattern {
 	const char *prefix;
 	const char *vendor;
@@ -136,6 +150,12 @@ static dc_descriptor_t *getDeviceType(QString btName)
 				product = model[i].product;
 				break;
 			}
+		}
+	} else if (auto m = cressiBTNamePattern.match(btName); m.hasMatch()) {
+		auto num = m.captured(1);
+		product = cressiModelNumToProduct.value(num.toInt());
+		if (!product.isEmpty()) {
+			vendor = "Cressi";
 		}
 	} else { // finally try all the string prefix based ones
 		for (uint16_t i = 0; i < sizeof(name) / sizeof(struct namePattern); i++) {


### PR DESCRIPTION
Based on a very limited sample count [1,2], the Cressi Bluetooth LE interfaces seem to advertise their computers with the following pattern: `<model number>_<4 digit lowercase hex serial number>`. We can use that pattern to identify Cressi computers.

[1] I own two Donatellos which advertise as 4_254d and 4_1e52.
[2] There is a Goa adverising as 2_466a https://github.com/deepsealabs/libdc-swift/issues/8#issuecomment-2571343354

It's worth noting that that the Goa and Donatello require different BT interface devices, so they seem to implement a consistent naming scheme.

A more reliable way would be to check for service UUID 6e400001-b5a3-f393-e0a9-e50e24dc10b8 on discovery and then read the device identification values. But this is a big deviation from the name-based matching btdiscovery.cpp is doing today.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

Fixes #4460 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

> core: add support for Cressi Bluetooth interfaces

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->

@mikeller @jefdriesen  