### PR TITLE
Use the libdivecomputer filter function

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -17,175 +17,40 @@ namespace {
 }
 BTDiscovery *BTDiscovery::m_instance = NULL;
 
-struct modelPattern {
-	uint16_t    model;
-	const char *vendor;
-	const char *product;
-};
-static struct modelPattern model[] = {
-	{ 0x4552, "Oceanic", "Pro Plus X" },
-	{ 0x455A, "Aqualung", "i750TC" },
-	{ 0x4647, "Sherwood", "Sage" },
-	{ 0x4648, "Aqualung", "i300C" },
-	{ 0x4649, "Aqualung", "i200C" },
-	{ 0x4749, "Aqualung", "i200Cv2" },
-	{ 0x4651, "Aqualung", "i770R" },
-	{ 0x4652, "Aqualung", "i550C" },
-	{ 0x4653, "Oceanic", "Geo 4.0" },
-	{ 0x4654, "Oceanic", "Veo 4.0" },
-	{ 0x4655, "Sherwood", "Wisdom 4" },
-	{ 0x4656, "Oceanic", "Pro Plus 4" },
-	{ 0x4741, "Apeks", "DSX" },
-	{ 0x4743, "Aqualung", "i470TC" },
-	{ 0x4744, "Aqualung", "i330R" },
-};
-
-// The Cressi BT interfaces for Goa-style computers advertise names with pattern:
-//  <model number>_<4 digit lowercase hex serial number>
-// The source of truth for model numbers is in libdivecomputer/src/descriptor.c
-static QRegularExpression cressiBTNamePattern("^([1-9][0-9]?)_[0-9a-f]{4}$");
-static QMap<int, QString> cressiModelNumToProduct{
-	{ 1, "Cartesio"},
-	{ 2, "Goa"},
-	{ 3, "Leonardo 2.0"},
-	{ 4, "Donatello"},
-        { 5, "Michelangelo"},
-	{ 9, "Neon"},
-	{10, "Nepto"}
-};
-
-struct namePattern {
-	const char *prefix;
-	const char *vendor;
-	const char *product;
-};
-// search is in order of this array, and as a prefix search, so more specific names
-// should be added before less specific names (i.e. "Perdix 2" before "Perdix")
-static struct namePattern name[] = {
-	// Shearwater dive computers
-	{ "Predator", "Shearwater", "Predator" },
-	{ "Perdix 2", "Shearwater", "Perdix 2"},
-	{ "Petrel 3", "Shearwater", "Petrel 3"},
-	// both the Petrel and Petrel 2 identify as "Petrel" as BT/BLE device
-	// but only the Petrel 2 is listed as available dive computer on iOS (which requires BLE support)
-	// so always pick the "Petrel 2" as product when seeing a Petrel
-	{ "Petrel", "Shearwater", "Petrel 2" },
-	{ "Perdix", "Shearwater", "Perdix" },
-	{ "Teric", "Shearwater", "Teric" },
-	{ "Peregrine", "Shearwater", "Peregrine" },
-	{ "NERD 2", "Shearwater", "NERD 2" },
-	{ "NERD", "Shearwater", "NERD" }, // order is important, test for the more specific one first
-	{ "Predator", "Shearwater", "Predator" },
-	{ "Tern", "Shearwater", "Tern" },
-	// Suunto dive computers
-	{ "EON Steel", "Suunto", "EON Steel" },
-	{ "EON Core", "Suunto", "EON Core" },
-	{ "Suunto D5", "Suunto", "D5" },
-	// Scubapro dive computers
-	{ "G2", "Scubapro", "G2" },
-	{ "HUD", "Scubapro", "G2 HUD" },
-	{ "G3", "Scubapro", "G3" },
-	{ "Aladin", "Scubapro", "Aladin Sport Matrix" },
-	{ "A1", "Scubapro", "Aladin A1" },
-	{ "A2", "Scubapro", "Aladin A2" },
-	{ "Luna 2.0 AI", "Scubapro", "Luna 2.0 AI" },
-	{ "Luna 2.0", "Scubapro", "Luna 2.0" },
-	// Mares dive computers
-	{ "Mares Genius", "Mares", "Genius" },
-	{ "Sirius", "Mares", "Sirius" },
-	{ "Mares", "Mares", "Quad" }, // we actually don't know and just pick a common one - user needs to fix in UI
-	// Cress dive computers
-	{ "CARESIO_", "Cressi", "Cartesio" },
-	{ "GOA_", "Cressi", "Goa" },
-	// Deepblu dive computesr
-	{ "COSMIQ", "Deepblu", "Cosmiq+" },
-	// Oceans dive computers
-	{ "S1", "Oceans", "S1" },
-	// McLean dive computers
-	{ "McLean Extreme", "McLean", "Extreme" },
-	// Tecdiving dive computers
-	{ "DiveComputer", "Tecdiving", "DiveComputer.eu" }
-};
-
 static dc_descriptor_t *getDeviceType(QString btName)
 // central function to convert a BT name to a Subsurface known vendor/model pair
 {
-	QString vendor, product;
+	dc_status_t status = DC_STATUS_SUCCESS;
+	dc_descriptor_t *result = NULL;
+	const QByteArray tmp = btName.toLocal8Bit();
+	const char *namestr = tmp.constData();
 
-	if (btName.startsWith("OSTC")) {
-		vendor = "Heinrichs Weikamp";
-		if (btName.mid(4,1) == "3") product = "OSTC Plus";
-		else if (btName.mid(4,2) == "s#") product = "OSTC Sport";
-		else if (btName.mid(4,2) == "s ") product = "OSTC Sport";
-		else if (btName.mid(4,2) == "4-" || btName.mid(4,2) == "5-") product = "OSTC 4/5";
-		else if (btName.mid(4,2) == "2-") product = "OSTC 2N";
-		else if (btName.mid(4,2) == "+ ") product = "OSTC 2";
-		// all BT/BLE enabled OSTCs are HW_FAMILY_OSTC_3, so when we do not know,
-		// just use a default product that allows the code to download from the
-		// user's dive computer
-		else product = "OSTC 2";
-	} else if (btName.contains(QRegularExpression("^DS\\d{6}"))) {
-		// The Ratio bluetooth name looks like the Pelagic ones,
-		// but that seems to be just happenstance.
-		vendor = "Ratio";
-		product = "iX3M 2021 GPS Easy"; // we don't know which of the Bluetooth models, so set one that supports BLE
-	} else if (btName.contains(QRegularExpression("^IX5M\\d{6}")) ||
-		btName.contains(QRegularExpression("^RATIO-\\d{6}"))) {
-		// The 2021 iX3M models (square buttons) report as iX5M,
-		// eventhough the physical model states iX3M.
-		vendor = "Ratio";
-		product = "iX3M 2021 GPS Easy"; // we don't know which of the Bluetooth models, so set one that supports BLE
-	} else if (btName.contains(QRegularExpression("^[A-Z]{2}\\d{6}"))) {
-		// try the Pelagic/Aqualung name patterns
-		// the source of truth for this data is in libdivecomputer/src/descriptor.c
-		// we'd prefer to use the filter functions there but current design makes that really challenging
-		// The Pelagic dive computers (generally branded as Oceanic, Aqualung, or Sherwood)
-		// show up with a two-byte model code followed by six bytes of serial
-		// number. The model code matches the hex model (so "FQ" is 0x4651,
-		// where 'F' is 46h and 'Q' is 51h in ASCII).
-		for (uint16_t i = 0; i < sizeof(model) / sizeof(struct modelPattern); i++) {
-			QString pattern = QString("^%1%2\\d{6}$").arg(QChar(model[i].model >> 8)).arg(QChar(model[i].model & 0xFF));
-			if (btName.contains(QRegularExpression(pattern))) {
-				vendor = model[i].vendor;
-				product = model[i].product;
-				break;
-			}
-		}
-	} else if (auto m = cressiBTNamePattern.match(btName); m.hasMatch()) {
-		auto num = m.captured(1);
-		product = cressiModelNumToProduct.value(num.toInt());
-		if (!product.isEmpty()) {
-			vendor = "Cressi";
-		}
-	} else { // finally try all the string prefix based ones
-		for (uint16_t i = 0; i < sizeof(name) / sizeof(struct namePattern); i++) {
-			if (btName.startsWith(name[i].prefix)) {
-				vendor = name[i].vendor;
-				product = name[i].product;
-				break;
-			}
-		}
+	dc_iterator_t *iterator = NULL;
+	status = dc_descriptor_iterator_new (&iterator, NULL);
+	if (status != DC_STATUS_SUCCESS) {
+		report_error ("Error creating the device descriptor iterator.");
+		return NULL;
 	}
 
-	// check if we found a known dive computer
-	if (!vendor.isEmpty() && !product.isEmpty()) {
-		dc_descriptor_t *lookup = descriptorLookup.value(vendor.toLower() + product.toLower());
-		if (!lookup) {
-			// the Ratio dive computers come in BT only or BLE only and we can't tell
-			// which just from the name; so while this is fairly unlikely, the user
-			// could be on an older computer / device that only supports BT and no BLE
-			// and giving the BLE only name might therefore not work, so try the other
-			// one just in case
-			if (vendor == "Ratio" && product == "iX3M 2021 GPS Easy") {
-				product = "iX3M GPS Easy"; // this one is BT only
-				lookup = descriptorLookup.value(vendor.toLower() + product.toLower());
-			}
-			if (!lookup) // still nothing?
-				qWarning("known dive computer %s not found in descriptorLookup", qPrintable(QString(vendor + product)));
+	dc_descriptor_t *descriptor = NULL;
+	while ((status = dc_iterator_next (iterator, &descriptor)) == DC_STATUS_SUCCESS) {
+		if (dc_descriptor_filter(descriptor, DC_TRANSPORT_BLE, namestr) ||
+			dc_descriptor_filter(descriptor, DC_TRANSPORT_BLUETOOTH, namestr)) {
+			result = descriptor;
+			break;
 		}
-		return lookup;
+
+		dc_descriptor_free (descriptor);
 	}
-	return nullptr;
+
+	dc_iterator_free (iterator);
+
+	if (status != DC_STATUS_SUCCESS && status != DC_STATUS_DONE) {
+		report_error ("Error iterating the device descriptors.");
+		return NULL;
+	}
+
+	return result;
 }
 
 bool matchesKnownDiveComputerNames(QString btName)


### PR DESCRIPTION
Replace the custom bluetooth device name detection code with the libdivecomputer filter function.

This PR is a request for comments because the libdivecomputer filter function isn't a 1:1 replacement for the existing code: 

The current subsurface code tries to identify the exact model where possible, while the libdivecomputer filter is much more broad because the same filter is shared by all models within the same device family. That shouldn't be a problem if the goal is to detect whether a bluetooth name matches a known dive computer. For example as done in the `matchesKnownDiveComputerNames()` function.

The proposed change also doesn't distinguish between BT Classic and LE. Since the BT device names are identical for both, that doesn't make a difference for the underlying matching. But not all devices are dual stack. Some are Classic only or BLE only. The result is that the `getDeviceType()` may select a Classic only or BLE only descriptor. If later on the descriptor is used to open the transport, and it happens to be of the wrong type (e.g. a BT Classic descriptor when trying to open a BLE connection or vice versa), the `divecomputer_device_open()` function will fail with `DC_STATUS_UNSUPPORTED`. The current subsurface code uses some heuristics to work around this problem, but the correct solution would be to pass the desired transport type such that only descriptors supporting the correct transport are selected. That will require some more refactoring.

The main advantage is that subsurface no longer needs to maintain its own logic. Whenever libdivecomputer is updated with support for new devices, the bluetooth discovery will also be updated to recognize those new devices.

Note: this change requires some of the recent commits on libdivecomputer master.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
