### PR TITLE
Export a json file in addition to the existing JS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 statistics: add month-of-year binning
+htmlexport: export dives as a json file as well
 core: add support for Cressi Bluetooth interfaces #4460 #4469
 desktop: add support to import .asd and .script files from Scubapro's LogTrak and SmartTrak
 desktop: update "Save dive data as subtitles" feature to make it more configurable.

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -129,6 +129,7 @@ void exportHtmlInitLogic(const QString &filename, struct htmlExportSetting &hes)
 	mainDir.mkdir(exportFiles);
 
 	QString js_dive_data = exportFiles + "file.js";
+	QString json_dive_data = exportFiles + "trips.json";
 	QString json_settings = exportFiles + "settings.js";
 	QString translation = exportFiles + "translation.js";
 	QString stat_file = exportFiles + "stat.js";
@@ -143,6 +144,7 @@ void exportHtmlInitLogic(const QString &filename, struct htmlExportSetting &hes)
 	export_translation(qPrintable(translation));
 
 	export_JS(qPrintable(js_dive_data), qPrintable(photosDirectory), hes.selectedOnly, hes.listOnly);
+	export_JSON(qPrintable(json_dive_data), hes.selectedOnly, hes.listOnly);
 
 	QString searchPath = getSubsurfaceDataPath("theme");
 	if (searchPath.isEmpty()) {

--- a/core/divelogexportlogic.cpp
+++ b/core/divelogexportlogic.cpp
@@ -128,7 +128,7 @@ void exportHtmlInitLogic(const QString &filename, struct htmlExportSetting &hes)
 	QString exportFiles = file.fileName() + "_files" + QDir::separator();
 	mainDir.mkdir(exportFiles);
 
-	QString json_dive_data = exportFiles + "file.js";
+	QString js_dive_data = exportFiles + "file.js";
 	QString json_settings = exportFiles + "settings.js";
 	QString translation = exportFiles + "translation.js";
 	QString stat_file = exportFiles + "stat.js";
@@ -142,7 +142,7 @@ void exportHtmlInitLogic(const QString &filename, struct htmlExportSetting &hes)
 	exportHTMLstatistics(stat_file, hes);
 	export_translation(qPrintable(translation));
 
-	export_HTML(qPrintable(json_dive_data), qPrintable(photosDirectory), hes.selectedOnly, hes.listOnly);
+	export_JS(qPrintable(js_dive_data), qPrintable(photosDirectory), hes.selectedOnly, hes.listOnly);
 
 	QString searchPath = getSubsurfaceDataPath("theme");
 	if (searchPath.isEmpty()) {

--- a/core/save-html.cpp
+++ b/core/save-html.cpp
@@ -480,6 +480,27 @@ void export_JS(const char *file_name, const char *photos_dir, const bool selecte
 	}
 }
 
+void export_list_as_JSON(struct membuffer *b, const bool selected_only, const bool list_only)
+{
+	write_trips(b, /* photos_dir */ nullptr, selected_only, list_only);
+}
+
+void export_JSON(const char *file_name, const bool selected_only, const bool list_only)
+{
+	FILE *f;
+
+	membuffer buf;
+	export_list_as_JSON(&buf, selected_only, list_only);
+
+	f = subsurface_fopen(file_name, "w+");
+	if (!f) {
+		report_error(translate("gettextFromC", "Can't open file %s"), file_name);
+	} else {
+		flush_buffer(&buf, f); /*check for writing errors? */
+		fclose(f);
+	}
+}
+
 void export_translation(const char *file_name)
 {
 	FILE *f;

--- a/core/save-html.cpp
+++ b/core/save-html.cpp
@@ -437,6 +437,7 @@ static void write_trips(struct membuffer *b, const char *photos_dir, bool select
 	char sep_ = ' ';
 	char *sep = &sep_;
 
+	put_string(b, "[");
 	for (auto &trip: divelog.trips)
 		trip->saved = 0;
 
@@ -454,21 +455,21 @@ static void write_trips(struct membuffer *b, const char *photos_dir, bool select
 
 	/*Save all remaining trips into Others*/
 	write_no_trip(b, &dive_no, selected_only, photos_dir, list_only, sep);
-}
-
-void export_list(struct membuffer *b, const char *photos_dir, bool selected_only, const bool list_only)
-{
-	put_string(b, "trips=[");
-	write_trips(b, photos_dir, selected_only, list_only);
 	put_string(b, "]");
 }
 
-void export_HTML(const char *file_name, const char *photos_dir, const bool selected_only, const bool list_only)
+void export_list_as_JS(struct membuffer *b, const char *photos_dir, bool selected_only, const bool list_only)
+{
+	put_string(b, "trips=");
+	write_trips(b, photos_dir, selected_only, list_only);
+}
+
+void export_JS(const char *file_name, const char *photos_dir, const bool selected_only, const bool list_only)
 {
 	FILE *f;
 
 	membuffer buf;
-	export_list(&buf, photos_dir, selected_only, list_only);
+	export_list_as_JS(&buf, photos_dir, selected_only, list_only);
 
 	f = subsurface_fopen(file_name, "w+");
 	if (!f) {

--- a/core/save-html.h
+++ b/core/save-html.h
@@ -19,6 +19,8 @@ void put_HTML_volume_units(struct membuffer *b, unsigned int ml, const char *pre
 
 void export_JS(const char *file_name, const char *photos_dir, const bool selected_only, const bool list_only);
 void export_list_as_JS(struct membuffer *b, const char *photos_dir, bool selected_only, const bool list_only);
+void export_JSON(const char *file_name, const bool selected_only, const bool list_only);
+void export_list_as_JSON(struct membuffer *b, const bool selected_only, const bool list_only);
 void export_translation(const char *file_name);
 
 #endif

--- a/core/save-html.h
+++ b/core/save-html.h
@@ -17,8 +17,8 @@ void put_HTML_pressure_units(struct membuffer *b, pressure_t pressure, const cha
 void put_HTML_weight_units(struct membuffer *b, unsigned int grams, const char *pre, const char *post);
 void put_HTML_volume_units(struct membuffer *b, unsigned int ml, const char *pre, const char *post);
 
-void export_HTML(const char *file_name, const char *photos_dir, const bool selected_only, const bool list_only);
-void export_list(struct membuffer *b, const char *photos_dir, bool selected_only, const bool list_only);
+void export_JS(const char *file_name, const char *photos_dir, const bool selected_only, const bool list_only);
+void export_list_as_JS(struct membuffer *b, const char *photos_dir, bool selected_only, const bool list_only);
 void export_translation(const char *file_name);
 
 #endif

--- a/core/uploadDiveShare.cpp
+++ b/core/uploadDiveShare.cpp
@@ -28,7 +28,7 @@ void uploadDiveShare::doUpload(bool selected, const QString &uid, bool noPublic)
 {
 	//generate json
 	membuffer buf;
-	export_list(&buf, NULL, selected, false);
+	export_list_as_JS(&buf, NULL, selected, false);
 	QByteArray json_data(buf.buffer, buf.len);
 
 	//Request to server

--- a/theme/dive_export.html
+++ b/theme/dive_export.html
@@ -5,6 +5,11 @@
 <script>
 //////////////////////////////////
 //advance settings window//
+
+// Because fetching the JSON file is async, we need a way to wait that it's
+// fetched and parsed. This promise will be assigned in load_script below, and
+// awaited in the onload function.
+let waitForTripsLoadPromise;
 load_scripts();
 
 function load_script_sync(name)
@@ -16,8 +21,15 @@ function load_script_sync(name)
 	document.getElementsByTagName("head")[0].appendChild(fileref);
 }
 
+async function loadTrips() {
+	const fetchResponse = await fetch(location.pathname + "_files/trips.json");
+	const trips = await fetchResponse.json();
+	window.trips = trips;
+}
+
 function load_scripts()
 {
+	waitForTripsLoadPromise = loadTrips();
 	var fileref=document.createElement("link");
 	fileref.setAttribute("rel", "stylesheet");
 	fileref.setAttribute("type", "text/css");
@@ -94,7 +106,9 @@ function loadSettings(){
 
 var searchingModules = new Array();
 
-window.onload=function(){
+window.onload = async function(){
+	// Wait that the trips JSON file is loaded before going on.
+	await waitForTripsLoadPromise;
 
 	//initialize settings
 	loadSettings();


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
To make it easier to reuse the data stored in the cloud storage, a JSON file is now generated in addition to all the other files. On purpose all existing behavior has been kept so that this change isn't a breaking change.

We'd still need CORS headers to be added on the cloud server so that web pages could download it. But I'm not sure how to do that.


### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1) Minor refactor
2) Export trips as a JSON file called trips.json

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4471

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
After building the export-html binary with:
```
make -C subsurface/build export-html
```
I'm using this command to generate the export using my own data:
```
./subsurface/build/export-html --source file:///home/julien/.subsurface/cloudstorage/45290a30c2e8dd22/[felash@gmail.com] --output /home/julien/perso/git/subsurface-root/output/dives.html
```

Of course you need to tweak the command with your own data.

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
A changelog entry has been added, it's up to you to decide about adding this as a release note.


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Probably not, but maybe it could be added in https://subsurface-divelog.org/subsurface-user-manual/#S_Cloud_storage

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
