### PR TITLE
Fix Bug Causing the Application to Terminate when an Error Is Reported.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -258,5 +258,9 @@ set(SUBSURFACE_CORE_LIB_SRCS
 )
 source_group("Subsurface Core" FILES ${SUBSURFACE_CORE_LIB_SRCS})
 
-add_library(subsurface_corelib STATIC ${SUBSURFACE_CORE_LIB_SRCS} )
+add_library(subsurface_corelib STATIC ${SUBSURFACE_CORE_LIB_SRCS})
 target_link_libraries(subsurface_corelib ${QT_LIBRARIES})
+
+add_library(subsurface_corelib_testing STATIC ${SUBSURFACE_CORE_LIB_SRCS})
+target_link_libraries(subsurface_corelib_testing ${QT_LIBRARIES})
+target_compile_definitions(subsurface_corelib_testing PRIVATE -DSUBSURFACE_TESTING)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,7 +63,7 @@ function(TEST NAME FILE)
 		${NAME}
 		subsurface_backend_shared
 		${TEST_SPECIFIC_LIBRARIES}
-		subsurface_corelib
+		subsurface_corelib_testing
 		RESOURCE_LIBRARY
 		${QT_TEST_LIBRARIES}
 		${SUBSURFACE_LINK_LIBRARIES}
@@ -94,13 +94,11 @@ endfunction()
 add_definitions(-g)
 add_definitions(-DSUBSURFACE_TEST_DATA="${SUBSURFACE_TEST_DATA}")
 
-target_compile_definitions(subsurface_corelib PRIVATE -DSUBSURFACE_TESTING)
-
 # Build QML test runner
 add_executable(TestQML testqml.cpp)
 target_link_libraries(
 	TestQML
-	subsurface_corelib
+	subsurface_corelib_testing
 	RESOURCE_LIBRARY
 	${QT_TEST_LIBRARIES}
 	${SUBSURFACE_LINK_LIBRARIES}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This was caused by me adding the throwing of a `runtime_error()` into
`report_error()` and thinking I made this conditional to test builds
only.
Unfortunately the define leaked into the application build, resulting in
unwanted application terminations.
The fix introduces significant overhead to the build by duplicating the
'subsurface_corelib' build. I think the way to mitigate this will be to
stop building the tests for application builds - this seems to be
overhead for little value anyway, as the tests aren't run for
application builds.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
