### PR TITLE
Don't "struct" quint128

### DIFF
--- a/core/qt-ble.cpp
+++ b/core/qt-ble.cpp
@@ -819,12 +819,12 @@ dc_status_t qt_ble_ioctl(void *io, unsigned int request, void *data, size_t size
 	case DC_IOCTL_BLE_GET_NAME:
 		return ble->get_name((char *) data, size);
 	case DC_IOCTL_BLE_CHARACTERISTIC_READ:
-		struct quint128 uuid;
-		memcpy(uuid.data, data, sizeof(uuid.data));
+		quint128 uuid;
+		memcpy(&uuid, data, sizeof(uuid));
 		size_t readsize;
-		readsize = size - sizeof(uuid.data);
+		readsize = size - sizeof(uuid);
 		char *p;
-		p = ((char*)data) +  sizeof(uuid.data);
+		p = ((char*)data) +  sizeof(uuid);
 		return ble->read_characteristic(QBluetoothUuid(uuid), p, readsize);
 	default:
 		return DC_STATUS_UNSUPPORTED;


### PR DESCRIPTION
This is a typedef in Qt6 and we can be agnostic about the type without breaking anything between Qt5 and Qt6.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
