### PR TITLE
Change the Volume Unit Symbol to 'L'.

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -947,7 +947,7 @@ image::images/Newcyl-selection.png["FIGURE: Selecting cylinder name in cylinder 
 This activates the cursor on the cylinder type. Overtype the cylinder type with your new cylinder type (image below).
 *Important:* Overtyping a cylinder type does not affect the name that is being overtyped. The usual convention is that
 double cylinders are prefixed with a "D" to indicate "double". In our case we have a manifolded twinset of two
-7-litre 300 bar cylinders. This could be named "D7ℓ 300 bar" rather than "14ℓ 300 bar". However, use a rule that works for you.
+7-litre 300 bar cylinders. This could be named "D7L 300 bar" rather than "14L 300 bar". However, use a rule that works for you.
 
 image::images/Newcyl-name.png["FIGURE: Typing new cylinder name",align="center"]
 

--- a/backend-shared/exportfuncs.cpp
+++ b/backend-shared/exportfuncs.cpp
@@ -115,8 +115,8 @@ void export_TeX(const char *filename, bool selected_only, bool plain, ExportCall
 	put_format(&buf, "\n%% These fields contain the units used in other fields below. They may be\n");
 	put_format(&buf, "%% referenced as needed in TeX templates.\n");
 	put_format(&buf, "%% \n");
-	put_format(&buf, "%% By default, Subsurface exports units of volume as \"ℓ\" and \"cuft\", which do\n");
-	put_format(&buf, "%% not render well in TeX/LaTeX.  The code below substitutes \"L\" and \"ft$^{3}$\",\n");
+	put_format(&buf, "%% By default, Subsurface exports imperial units of volume as \"cuft\", which does\n");
+	put_format(&buf, "%% not render well in TeX/LaTeX.  The code below substitutes \"ft$^{3}$\",\n");
 	put_format(&buf, "%% respectively.  If you wish to display the original values, you may edit this\n");
 	put_format(&buf, "%% list and all calls to those units will be updated in your document.\n");
 

--- a/core/equipment.cpp
+++ b/core/equipment.cpp
@@ -207,8 +207,8 @@ int find_best_gasmix_match(struct gasmix mix, const struct cylinder_table &cylin
 static void add_default_tank_infos(std::vector<tank_info> &table)
 {
 	/* Size-only metric cylinders */
-	add_tank_info_metric(table, "10.0ℓ", 10000, 0);
-	add_tank_info_metric(table, "11.1ℓ", 11100, 0);
+	add_tank_info_metric(table, "10.0L", 10000, 0);
+	add_tank_info_metric(table, "11.1L", 11100, 0);
 
 	/* Most common AL cylinders */
 	add_tank_info_imperial(table, "AL40", 40, 3000);
@@ -236,16 +236,16 @@ static void add_default_tank_infos(std::vector<tank_info> &table)
 	add_tank_info_imperial(table, "HP130", 130, 3442);
 
 	/* Common European steel cylinders */
-	add_tank_info_metric(table, "3ℓ 232 bar", 3000, 232);
-	add_tank_info_metric(table, "3ℓ 300 bar", 3000, 300);
-	add_tank_info_metric(table, "10ℓ 200 bar", 10000, 200);
-	add_tank_info_metric(table, "10ℓ 232 bar", 10000, 232);
-	add_tank_info_metric(table, "10ℓ 300 bar", 10000, 300);
-	add_tank_info_metric(table, "12ℓ 200 bar", 12000, 200);
-	add_tank_info_metric(table, "12ℓ 232 bar", 12000, 232);
-	add_tank_info_metric(table, "12ℓ 300 bar", 12000, 300);
-	add_tank_info_metric(table, "15ℓ 200 bar", 15000, 200);
-	add_tank_info_metric(table, "15ℓ 232 bar", 15000, 232);
+	add_tank_info_metric(table, "3L 232 bar", 3000, 232);
+	add_tank_info_metric(table, "3L 300 bar", 3000, 300);
+	add_tank_info_metric(table, "10L 200 bar", 10000, 200);
+	add_tank_info_metric(table, "10L 232 bar", 10000, 232);
+	add_tank_info_metric(table, "10L 300 bar", 10000, 300);
+	add_tank_info_metric(table, "12L 200 bar", 12000, 200);
+	add_tank_info_metric(table, "12L 232 bar", 12000, 232);
+	add_tank_info_metric(table, "12L 300 bar", 12000, 300);
+	add_tank_info_metric(table, "15L 200 bar", 15000, 200);
+	add_tank_info_metric(table, "15L 232 bar", 15000, 232);
 	add_tank_info_metric(table, "D7 232 bar", 14000, 232);
 	add_tank_info_metric(table, "D7 300 bar", 14000, 300);
 	add_tank_info_metric(table, "D8.5 232 bar", 17000, 232);

--- a/core/filterconstraint.cpp
+++ b/core/filterconstraint.cpp
@@ -269,7 +269,7 @@ QString filter_constraint_get_unit(enum filter_constraint_type type)
 	case FILTER_CONSTRAINT_VOLUMETRIC_FLOW_UNIT:
 		return get_volume_unit() + "/min";
 	case FILTER_CONSTRAINT_DENSITY_UNIT:
-		return "g/ℓ";
+		return "g/L";
 	case FILTER_CONSTRAINT_PERCENTAGE_UNIT:
 		return "%";
 	}

--- a/core/profile.cpp
+++ b/core/profile.cpp
@@ -1323,19 +1323,19 @@ static std::vector<std::string> plot_string(const struct dive *d, const struct p
 			if (entry.ead.mm > 0) {
 				ead.mm = lrint(get_depth_units(entry.ead, NULL, &depth_unit));
 				res.push_back(casprintf_loc(translate("gettextFromC", "EAD: %d%s"), ead.mm, depth_unit));
-				res.push_back(casprintf_loc(translate("gettextFromC", "EADD: %d%s / %.1fg/ℓ"), eadd.mm, depth_unit, entry.density));
+				res.push_back(casprintf_loc(translate("gettextFromC", "EADD: %d%s / %.1fg/L"), eadd.mm, depth_unit, entry.density));
 				break;
 			}
 		case plot_info::TRIMIX:
 			if (entry.end.mm > 0) {
 				end.mm = lrint(get_depth_units(entry.end, NULL, &depth_unit));
 				res.push_back(casprintf_loc(translate("gettextFromC", "END: %d%s"), end.mm, depth_unit));
-				res.push_back(casprintf_loc(translate("gettextFromC", "EADD: %d%s / %.1fg/ℓ"), eadd.mm, depth_unit, entry.density));
+				res.push_back(casprintf_loc(translate("gettextFromC", "EADD: %d%s / %.1fg/L"), eadd.mm, depth_unit, entry.density));
 				break;
 			}
 		case plot_info::AIR:
 			if (entry.density > 0) {
-				res.push_back(casprintf_loc(translate("gettextFromC", "Density: %.1fg/ℓ"), entry.density));
+				res.push_back(casprintf_loc(translate("gettextFromC", "Density: %.1fg/L"), entry.density));
 			}
 		case plot_info::FREEDIVING:
 			/* nothing */

--- a/core/qthelper.cpp
+++ b/core/qthelper.cpp
@@ -581,7 +581,7 @@ QString get_volume_string(volume_t volume, bool showunit)
 QString get_volume_unit(bool metric)
 {
 	if (metric)
-		return gettextFromC::tr("ℓ");
+		return gettextFromC::tr("L");
 	else
 		return gettextFromC::tr("cuft");
 }
@@ -604,7 +604,7 @@ QString get_pressure_string(pressure_t pressure, bool showunit)
 
 QString get_salinity_string(int salinity)
 {
-	return QStringLiteral("%L1%2").arg(salinity / 10.0).arg(gettextFromC::tr("g/ℓ"));
+	return QStringLiteral("%L1%2").arg(salinity / 10.0).arg(gettextFromC::tr("g/L"));
 }
 
 // the water types need to match the watertypes enum
@@ -1296,7 +1296,7 @@ volume_t string_to_volume(const char *str, pressure_t workp)
 	QString local_cuft = gettextFromC::tr("cuft");
 	volume_t volume;
 
-	if (rest.startsWith("l") || rest.startsWith("ℓ") || rest.startsWith(local_l))
+	if (rest.startsWith("L") || rest.startsWith("l") || rest.startsWith("ℓ") || rest.startsWith(local_l))
 		goto l;
 	if (rest.startsWith("cuft") || rest.startsWith(local_cuft))
 		goto cuft;

--- a/core/save-profiledata.cpp
+++ b/core/save-profiledata.cpp
@@ -380,19 +380,19 @@ static std::string format_st_event(const plot_data &entry, const plot_data &next
 	if (entry.current_gf > 0.0) {
 		replace_all(format_string, "[current_gf]", format_string_std("%.1f%%", entry.current_gf));
 	} else {
-		replace_all(format_string, "[current_gf]", "");	
+		replace_all(format_string, "[current_gf]", "");
 	}
 
 	if (entry.density > 0) {
-		replace_all(format_string, "[density]", format_string_std("%.1fg/ℓ", entry.density));
+		replace_all(format_string, "[density]", format_string_std("%.1fg/L", entry.density));
 	} else {
-		replace_all(format_string, "[density]", "");	
+		replace_all(format_string, "[density]", "");
 	}
 
 	if (entry.icd_warning) {
 		replace_all(format_string, "[icd_warning]", translate("gettextFromC", "ICD in leading tissue"));
 	} else {
-		replace_all(format_string, "[icd_warning]", "");	
+		replace_all(format_string, "[icd_warning]", "");
 	}
 
 	res += format_string;

--- a/core/units.cpp
+++ b/core/units.cpp
@@ -60,7 +60,7 @@ double get_volume_units(unsigned int ml, int *frac, const char **units)
 	case units::LITER:
 	default:
 		vol = ml / 1000.0;
-		unit = translate("gettextFromC", "ℓ");
+		unit = translate("gettextFromC", "L");
 		decimals = 1;
 		break;
 	case units::CUFT:

--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -441,7 +441,7 @@
             <item row="3" column="6">
              <widget class="QDoubleSpinBox" name="salinityDoubleSpinBox_3">
               <property name="suffix">
-               <string>kg/ℓ</string>
+               <string>kg/L</string>
               </property>
               <property name="minimum">
                <double>1.000000000000000</double>
@@ -852,7 +852,7 @@
             <item row="12" column="4">
              <widget class="QSpinBox" name="decoGasConsumption_3">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -868,7 +868,7 @@
             <item row="11" column="4">
              <widget class="QSpinBox" name="bottomGasConsumption_3">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -2081,7 +2081,7 @@
             <item row="12" column="4">
              <widget class="QSpinBox" name="bottomGasConsumption">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -2097,7 +2097,7 @@
             <item row="13" column="4">
              <widget class="QSpinBox" name="decoGasConsumption">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -3123,7 +3123,7 @@
             <item row="12" column="4">
              <widget class="QSpinBox" name="travelGasConsumption_4">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -3139,7 +3139,7 @@
             <item row="13" column="4">
              <widget class="QSpinBox" name="bottomGasConsumption_4">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>
@@ -3155,7 +3155,7 @@
             <item row="14" column="4">
              <widget class="QSpinBox" name="decoGasConsumption_4">
               <property name="suffix">
-               <string>ℓ/min</string>
+               <string>L/min</string>
               </property>
               <property name="minimum">
                <number>5</number>

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -199,7 +199,7 @@ void DivePlannerWidget::waterTypeUpdateTexts()
 		if (ui.waterType->itemData(i) != QVariant::Invalid) {
 			QString densityText = ui.waterType->itemText(i).split("(")[0].trimmed();
 			double density = ui.waterType->itemData(i).toInt() / 10000.0;
-			densityText.append(QStringLiteral(" (%L1%2)").arg(density, 0, 'f', 3).arg(tr("kg/ℓ")));
+			densityText.append(QStringLiteral(" (%L1%2)").arg(density, 0, 'f', 3).arg(tr("kg/L")));
 			ui.waterType->setItemText(i, densityText);
 		}
 	}
@@ -497,8 +497,8 @@ void PlannerSettingsWidget::settingsChanged()
 		ui.bottomSAC->setValue(PlannerShared::bottomsac());
 		ui.decoStopSAC->setValue(PlannerShared::decosac());
 	} else {
-		ui.bottomSAC->setSuffix(tr("ℓ/min"));
-		ui.decoStopSAC->setSuffix(tr("ℓ/min"));
+		ui.bottomSAC->setSuffix(tr("L/min"));
+		ui.decoStopSAC->setSuffix(tr("L/min"));
 		ui.bottomSAC->setDecimals(0);
 		ui.bottomSAC->setSingleStep(1);
 		ui.decoStopSAC->setDecimals(0);

--- a/desktop-widgets/diveplanner.ui
+++ b/desktop-widgets/diveplanner.ui
@@ -241,7 +241,7 @@
           <string extracomment="Custom water density"/>
          </property>
          <property name="suffix">
-          <string>kg/ℓ</string>
+          <string>kg/L</string>
          </property>
          <property name="minimum">
           <double>0.990000000000000</double>

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -624,7 +624,7 @@
           <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="decoStopSAC">
             <property name="suffix">
-             <string>ℓ/min</string>
+             <string>L/min</string>
             </property>
             <property name="decimals">
              <number>0</number>
@@ -686,7 +686,7 @@
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="bottomSAC">
             <property name="suffix">
-             <string>ℓ/min</string>
+             <string>L/min</string>
             </property>
             <property name="decimals">
              <number>0</number>

--- a/desktop-widgets/preferences/preferences_graph.ui
+++ b/desktop-widgets/preferences/preferences_graph.ui
@@ -202,7 +202,7 @@
       <item row="5" column="2">
        <widget class="QDoubleSpinBox" name="psro2rate">
         <property name="suffix">
-         <string>ℓ/min</string>
+         <string>L/min</string>
         </property>
         <property name="decimals">
          <number>3</number>

--- a/desktop-widgets/tab-widgets/TabDiveInformation.cpp
+++ b/desktop-widgets/tab-widgets/TabDiveInformation.cpp
@@ -342,7 +342,7 @@ void TabDiveInformation::divesChanged(const QVector<dive *> &dives, DiveField fi
 		salinity_value = currentDive->salinity;
 	setIndexNoSignal(ui->waterTypeCombo, updateSalinityComboIndex(salinity_value));
 	ui->waterTypeText->setText(get_water_type_string(salinity_value));
-	ui->salinityText->setText(QString("%L1g/ℓ").arg(salinity_value / 10.0));
+	ui->salinityText->setText(QString("%L1g/L").arg(salinity_value / 10.0));
 }
 
 void TabDiveInformation::on_visibility_valueChanged(int value)

--- a/qt-models/cylindermodel.cpp
+++ b/qt-models/cylindermodel.cpp
@@ -60,7 +60,7 @@ static QString get_cylinder_string(const cylinder_t *cyl)
 	} else {
 		value = ml / 1000.0;
 		decimals = 1;
-		unit = CylindersModel::tr("ℓ");
+		unit = CylindersModel::tr("L");
 	}
 
 	return QString("%L1").arg(value, 0, 'f', decimals) + unit;


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Change the currently used `ℓ` symbol for volume to `L`.
The main motivator for this is to make it possible to search for and
filter the pre-defined cylinder types in the dropdown without using a
unicode compser, or being able to remember the unicode value for 'ℓ'.
'L' is also the
[SI-recommended](https://www.bipm.org/documents/20126/41483022/si_brochure_8.pdf)
designator for volume in litres, so most users will be familiar with it.
This change is performed across the code base, in order to achieve
consistency.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
