### PR TITLE
Configuration: Update Settings for OSTC 4/5.

### DIFF
--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -117,12 +117,9 @@ bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, const DeviceD
 
 	//Other Settings
 	writer.writeTextElement("DiveMode", QString::number(details.diveMode));
-	writer.writeTextElement("Saturation", QString::number(details.saturation));
-	writer.writeTextElement("Desaturation", QString::number(details.desaturation));
 	writer.writeTextElement("LastDeco", QString::number(details.lastDeco));
 	writer.writeTextElement("Brightness", QString::number(details.brightness));
 	writer.writeTextElement("Units", QString::number(details.units));
-	writer.writeTextElement("SamplingRate", QString::number(details.samplingRate));
 	writer.writeTextElement("Salinity", QString::number(details.salinity));
 	writer.writeTextElement("DiveModeColor", QString::number(details.diveModeColor));
 	writer.writeTextElement("Language", QString::number(details.language));
@@ -137,22 +134,35 @@ bool ConfigureDiveComputer::saveXMLBackup(const QString &fileName, const DeviceD
 	writer.writeTextElement("FutureTTS", QString::number(details.futureTTS));
 	writer.writeTextElement("CcrMode", QString::number(details.ccrMode));
 	writer.writeTextElement("DecoType", QString::number(details.decoType));
-	writer.writeTextElement("AGFSelectable", QString::number(details.aGFSelectable));
 	writer.writeTextElement("AGFHigh", QString::number(details.aGFHigh));
 	writer.writeTextElement("AGFLow", QString::number(details.aGFLow));
-	writer.writeTextElement("CalibrationGas", QString::number(details.calibrationGas));
 	writer.writeTextElement("FlipScreen", QString::number(details.flipScreen));
 	writer.writeTextElement("SetPointFallback", QString::number(details.setPointFallback));
-	writer.writeTextElement("LeftButtonSensitivity", QString::number(details.leftButtonSensitivity));
-	writer.writeTextElement("RightButtonSensitivity", QString::number(details.rightButtonSensitivity));
-	writer.writeTextElement("BottomGasConsumption", QString::number(details.bottomGasConsumption));
+	writer.writeTextElement("AlwaysShowppO2", QString::number(details.alwaysShowppO2));
 	writer.writeTextElement("DecoGasConsumption", QString::number(details.decoGasConsumption));
+
+	writer.writeComment("Heinrichs Weikamp OSTC4 only:");
+	writer.writeTextElement("TravelGasConsumption", QString::number(details.travelGasConsumption));
+	writer.writeTextElement("VPMConservatism", QString::number(details.vpmConservatism));
+	writer.writeTextElement("ButtonSensitivity", QString::number(details.buttonSensitivity));
+	writer.writeTextElement("ButtonBalance", QString::number(details.buttonBalance));
+
+	writer.writeComment("Not used on Heinrichs Weikamp OSTC4:");
+	writer.writeTextElement("BottomGasConsumption", QString::number(details.bottomGasConsumption));
+	writer.writeTextElement("Saturation", QString::number(details.saturation));
+	writer.writeTextElement("Desaturation", QString::number(details.desaturation));
+	writer.writeTextElement("SamplingRate", QString::number(details.samplingRate));
+	writer.writeTextElement("AGFSelectable", QString::number(details.aGFSelectable));
+	writer.writeTextElement("CalibrationGas", QString::number(details.calibrationGas));
+	writer.writeTextElement("RightButtonSensitivity", QString::number(details.rightButtonSensitivity));
+	writer.writeTextElement("LeftButtonSensitivity", QString::number(details.leftButtonSensitivity));
 	writer.writeTextElement("ModWarning", QString::number(details.modWarning));
 	writer.writeTextElement("DynamicAscendRate", QString::number(details.dynamicAscendRate));
 	writer.writeTextElement("GraphicalSpeedIndicator", QString::number(details.graphicalSpeedIndicator));
-	writer.writeTextElement("AlwaysShowppO2", QString::number(details.alwaysShowppO2));
+	writer.writeTextElement("SafetyStopEndDepth", QString::number(details.safetyStopResetDepth));
+	writer.writeTextElement("SafetyStopEndDepth", QString::number(details.safetyStopResetDepth));
 
-	// Suunto vyper settings.
+	writer.writeComment("Suunto vyper specific settings:");
 	writer.writeTextElement("Altitude", QString::number(details.altitude));
 	writer.writeTextElement("PersonalSafety", QString::number(details.personalSafety));
 	writer.writeTextElement("TimeFormat", QString::number(details.timeFormat));
@@ -414,6 +424,9 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 			if (settingName == "DecoType")
 				details.decoType = keyString.toInt();
 
+			if (settingName == "VPMConservatism")
+				details.vpmConservatism = keyString.toInt();
+
 			if (settingName == "AGFSelectable")
 				details.aGFSelectable = keyString.toInt();
 
@@ -438,17 +451,32 @@ bool ConfigureDiveComputer::restoreXMLBackup(const QString &fileName, DeviceDeta
 			if (settingName == "RightButtonSensitivity")
 				details.rightButtonSensitivity = keyString.toInt();
 
+			if (settingName == "ButtonSensitivity")
+				details.buttonSensitivity = keyString.toInt();
+
+			if (settingName == "ButtonBalance")
+				details.buttonBalance = keyString.toInt();
+
 			if (settingName == "BottomGasConsumption")
 				details.bottomGasConsumption = keyString.toInt();
 
 			if (settingName == "DecoGasConsumption")
 				details.decoGasConsumption = keyString.toInt();
 
+			if (settingName == "TravelGasConsumption")
+				details.travelGasConsumption = keyString.toInt();
+
 			if (settingName == "ModWarning")
 				details.modWarning = keyString.toInt();
 
 			if (settingName == "DynamicAscendRate")
 				details.dynamicAscendRate = keyString.toInt();
+
+			if (settingName == "SafetyStopEndDepth")
+				details.safetyStopEndDepth = keyString.toInt();
+
+			if (settingName == "SafetyStopResetDepth")
+				details.safetyStopResetDepth = keyString.toInt();
 
 			if (settingName == "GraphicalSpeedIndicator")
 				details.graphicalSpeedIndicator = keyString.toInt();

--- a/core/configuredivecomputerthreads.cpp
+++ b/core/configuredivecomputerthreads.cpp
@@ -368,20 +368,6 @@ static dc_status_t write_suunto_vyper_settings(dc_device_t *device, DeviceDetail
 		progress_cb(device_data.device, DC_EVENT_PROGRESS, &progress, userdata); \
 	} while (0)
 
-static dc_status_t ostc3_sync_time(device_data_t &data)
-{
-	dc_status_t rc = DC_STATUS_SUCCESS;
-
-	if (data.sync_time) {
-		dc_datetime_t now;
-		dc_datetime_localtime(&now, dc_datetime_now());
-
-		rc = dc_device_timesync(data.device, &now);
-	}
-
-	return rc;
-}
-
 static dc_status_t read_ostc4_settings(device_data_t &device_data, DeviceDetails &deviceDetails, dc_event_callback_t progress_cb, void *userdata)
 {
 	// This code is really similar to the OSTC3 code, but there are minor
@@ -656,7 +642,7 @@ static dc_status_t read_ostc4_settings(device_data_t &device_data, DeviceDetails
 	deviceDetails.customText = ar.trimmed();
 	EMIT_PROGRESS();
 
-	rc = ostc3_sync_time(device_data);
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 
 	return rc;
@@ -921,8 +907,7 @@ static dc_status_t write_ostc4_settings(device_data_t &device_data, const Device
 		return rc;
 	EMIT_PROGRESS();
 
-	if (rc == DC_STATUS_SUCCESS)
-		rc = ostc3_sync_time(device_data);
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 
 	return rc;
@@ -1203,8 +1188,7 @@ static dc_status_t read_ostc3_settings(device_data_t &device_data, DeviceDetails
 	deviceDetails.customText = ar.trimmed();
 	EMIT_PROGRESS();
 
-	if (rc == DC_STATUS_SUCCESS)
-		rc = ostc3_sync_time(device_data);
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 
 	return rc;
@@ -1462,8 +1446,7 @@ static dc_status_t write_ostc3_settings(device_data_t &device_data, const Device
 		return rc;
 	EMIT_PROGRESS();
 
-	if (rc == DC_STATUS_SUCCESS)
-		rc = ostc3_sync_time(device_data);
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 
 	return rc;
@@ -1789,19 +1772,7 @@ static dc_status_t read_ostc_settings(device_data_t &device_data, DeviceDetails 
 		printf("CF %d: %d\n", cf, read_ostc_cf(data, cf));
 #endif
 
-	//sync date and time
-	if (device_data.sync_time) {
-		QDateTime timeToSet = QDateTime::currentDateTime();
-		dc_datetime_t time = { 0 };
-		time.year = timeToSet.date().year();
-		time.month = timeToSet.date().month();
-		time.day = timeToSet.date().day();
-		time.hour = timeToSet.time().hour();
-		time.minute = timeToSet.time().minute();
-		time.second = timeToSet.time().second();
-		time.timezone = DC_TIMEZONE_NONE;
-		rc = dc_device_timesync(device, &time);
-	}
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 
 	return rc;
@@ -2120,19 +2091,7 @@ static dc_status_t write_ostc_settings(device_data_t &device_data, const DeviceD
 		return rc;
 	EMIT_PROGRESS();
 
-	//sync date and time
-	if (device_data.sync_time) {
-		QDateTime timeToSet = QDateTime::currentDateTime();
-		dc_datetime_t time = { 0 };
-		time.year = timeToSet.date().year();
-		time.month = timeToSet.date().month();
-		time.day = timeToSet.date().day();
-		time.hour = timeToSet.time().hour();
-		time.minute = timeToSet.time().minute();
-		time.second = timeToSet.time().second();
-		time.timezone = DC_TIMEZONE_NONE;
-		rc = dc_device_timesync(device, &time);
-	}
+	rc = divecomputer_sync_time(device_data);
 	EMIT_PROGRESS();
 	return rc;
 }

--- a/core/devicedetails.cpp
+++ b/core/devicedetails.cpp
@@ -12,7 +12,6 @@ setpoint::setpoint(unsigned char sp, unsigned char depth) :
 }
 
 DeviceDetails::DeviceDetails() :
-	syncTime(false),
 	setPointFallback(0),
 	ccrMode(0),
 	calibrationGas(0),
@@ -54,6 +53,7 @@ DeviceDetails::DeviceDetails() :
 	leftButtonSensitivity(0),
 	rightButtonSensitivity(0),
 	buttonSensitivity(0),
+	buttonBalance(0),
 	bottomGasConsumption(0),
 	decoGasConsumption(0),
 	travelGasConsumption(0),

--- a/core/devicedetails.h
+++ b/core/devicedetails.h
@@ -30,7 +30,6 @@ public:
 	QString firmwareVersion;
 	QString customText;
 	QString model;
-	bool syncTime;
 	gas gas1;
 	gas gas2;
 	gas gas3;
@@ -89,6 +88,7 @@ public:
 	int leftButtonSensitivity;
 	int rightButtonSensitivity;
 	int buttonSensitivity;
+	int buttonBalance;
 	int bottomGasConsumption;
 	int decoGasConsumption;
 	int travelGasConsumption;

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -1421,12 +1421,15 @@ dc_status_t divecomputer_device_open(device_data_t *data)
 	return rc;
 }
 
-static dc_status_t sync_divecomputer_time(dc_device_t *device)
+dc_status_t divecomputer_sync_time(const device_data_t &data)
 {
+	if (!data.sync_time)
+		return DC_STATUS_SUCCESS;
+
 	dc_datetime_t now;
 	dc_datetime_localtime(&now, dc_datetime_now());
 
-	return dc_device_timesync(device, &now);
+	return dc_device_timesync(data.device, &now);
 }
 
 dc_loglevel_t get_libdivecomputer_loglevel()
@@ -1500,7 +1503,7 @@ std::string do_libdivecomputer_import(device_data_t *data)
 
 			if (err.empty() && data->sync_time) {
 				dev_info("Syncing dive computer time ...");
-				rc = sync_divecomputer_time(data->device);
+				rc = divecomputer_sync_time(*data);
 
 				switch (rc) {
 				case DC_STATUS_SUCCESS:

--- a/core/libdivecomputer.h
+++ b/core/libdivecomputer.h
@@ -71,6 +71,7 @@ dc_status_t serial_usb_android_open(dc_iostream_t **iostream, dc_context_t *cont
 
 dc_loglevel_t get_libdivecomputer_loglevel();
 dc_status_t divecomputer_device_open(device_data_t *data);
+dc_status_t divecomputer_sync_time(const device_data_t &data);
 
 unsigned int get_supported_transports(device_data_t *data);
 

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -63,6 +63,7 @@ public:
 
 private
 slots:
+	void changeTimeSync(int state);
 	void checkLogFile(int state);
 	void pickLogFile();
 	void readSettings();

--- a/desktop-widgets/configuredivecomputerdialog.ui
+++ b/desktop-widgets/configuredivecomputerdialog.ui
@@ -155,6 +155,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="dateTimeSyncCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Sync dive computer time with PC</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -419,13 +429,6 @@
                 <string>YY/MM/DD</string>
                </property>
               </item>
-             </widget>
-            </item>
-            <item row="3" column="0" colspan="4">
-             <widget class="QCheckBox" name="dateTimeSyncCheckBox_3">
-              <property name="text">
-               <string>Sync dive computer time with PC</string>
-              </property>
              </widget>
             </item>
             <item row="3" column="5">
@@ -1582,13 +1585,6 @@
               </item>
              </widget>
             </item>
-            <item row="6" column="0" colspan="3">
-             <widget class="QCheckBox" name="dateTimeSyncCheckBox">
-              <property name="text">
-               <string>Sync dive computer time with PC</string>
-              </property>
-             </widget>
-            </item>
             <item row="5" column="0">
              <widget class="QLabel">
               <property name="text">
@@ -2541,7 +2537,14 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="4">
+            <item row="8" column="3" colspan="3">
+             <widget class="QCheckBox" name="flipScreenCheckBox_4">
+              <property name="text">
+               <string>Flip screen</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="4">
              <widget class="QComboBox" name="languageComboBox_4">
               <item>
                <property name="text">
@@ -2582,7 +2585,7 @@
             <item row="0" column="0">
              <widget class="QLabel">
               <property name="text">
-               <string>Serial No.</string>
+               <string>Serial no.</string>
               </property>
               <property name="buddy">
                <cstring>serialNoLineEdit_4</cstring>
@@ -2612,7 +2615,7 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="4">
+            <item row="4" column="4">
              <widget class="QComboBox" name="dateFormatComboBox_4">
               <item>
                <property name="text">
@@ -2638,7 +2641,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="3">
+            <item row="3" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>Language</string>
@@ -2648,7 +2651,7 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="3">
+            <item row="4" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>Date format</string>
@@ -2741,6 +2744,9 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="placeholderToStopQtFromCollapsingRow2"/>
+            </item>
             <item row="1" column="4">
              <widget class="QLineEdit" name="modelLineEdit_4">
               <property name="readOnly">
@@ -2748,7 +2754,7 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="3" column="1">
              <widget class="QComboBox" name="diveModeComboBox_4">
               <item>
                <property name="text">
@@ -2772,7 +2778,7 @@
               </item>
              </widget>
             </item>
-            <item row="2" column="0">
+            <item row="3" column="0">
              <widget class="QLabel">
               <property name="text">
                <string>Dive mode</string>
@@ -2782,7 +2788,7 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="4" column="1">
              <widget class="QComboBox" name="diveModeColour_4">
               <item>
                <property name="text">
@@ -2806,14 +2812,7 @@
               </item>
              </widget>
             </item>
-            <item row="6" column="0" colspan="3">
-             <widget class="QCheckBox" name="dateTimeSyncCheckBox_4">
-              <property name="text">
-               <string>Sync dive computer time with PC</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
+            <item row="4" column="0">
              <widget class="QLabel">
               <property name="text">
                <string>Dive mode color</string>
@@ -2823,14 +2822,14 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="0" colspan="3">
+            <item row="5" column="0" colspan="3">
              <widget class="QCheckBox" name="safetyStopCheckBox_4">
               <property name="text">
                <string>Show safety stop</string>
               </property>
              </widget>
             </item>
-            <item row="8" column="1">
+            <item row="6" column="1">
              <widget class="QSpinBox" name="safetyStopLengthSpinBox_4">
               <property name="enabled">
                <bool>false</bool>
@@ -2849,21 +2848,21 @@
               </property>
              </widget>
             </item>
-            <item row="8" column="0">
+            <item row="6" column="0">
              <widget class="QLabel">
               <property name="text">
                <string>Length</string>
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
+            <item row="7" column="0">
              <widget class="QLabel">
               <property name="text">
-               <string>Start Depth</string>
+               <string>Start depth</string>
               </property>
              </widget>
             </item>
-            <item row="9" column="1">
+            <item row="7" column="1">
              <widget class="QDoubleSpinBox" name="safetyStopStartDepthDoubleSpinBox_4">
               <property name="enabled">
                <bool>false</bool>
@@ -2895,14 +2894,7 @@
             <string>Advanced settings</string>
            </attribute>
            <layout class="QGridLayout" name="gridLayout_8">
-            <item row="12" column="3">
-             <widget class="QLabel">
-              <property name="text">
-               <string>Travel gas consumption</string>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="4">
+            <item row="12" column="4">
              <widget class="QSpinBox" name="buttonSensitivity_4">
               <property name="suffix">
                <string>%</string>
@@ -2918,7 +2910,7 @@
               </property>
              </widget>
             </item>
-            <item row="11" column="3">
+            <item row="12" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>Button sensitivity</string>
@@ -2932,6 +2924,13 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="3">
+             <widget class="QLabel">
+              <property name="text">
+               <string>Compass declination</string>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="3">
              <widget class="QLabel">
               <property name="text">
@@ -2939,14 +2938,14 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="3">
+            <item row="3" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>GFLow</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="4">
+            <item row="3" column="4">
              <widget class="QSpinBox" name="gfLowSpinBox_4">
               <property name="suffix">
                <string>%</string>
@@ -2962,14 +2961,14 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="3">
+            <item row="4" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>GFHigh</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="4">
+            <item row="4" column="4">
              <widget class="QSpinBox" name="gfHighSpinBox_4">
               <property name="suffix">
                <string>%</string>
@@ -3005,7 +3004,7 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="4">
+            <item row="5" column="4">
              <widget class="QSpinBox" name="aGFLowSpinBox_4">
               <property name="suffix">
                <string>%</string>
@@ -3018,6 +3017,19 @@
               </property>
               <property name="value">
                <number>60</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="4">
+             <widget class="QSpinBox" name="compassDeclinationSpinBox_4">
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="minimum">
+               <number>-99</number>
+              </property>
+              <property name="maximum">
+               <number>99</number>
               </property>
              </widget>
             </item>
@@ -3076,14 +3088,14 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="3">
+            <item row="5" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>Alt GFLow</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="4">
+            <item row="8" column="4">
              <widget class="QSpinBox" name="aGFHighSpinBox_4">
               <property name="suffix">
                <string>%</string>
@@ -3099,7 +3111,7 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="3">
+            <item row="8" column="3">
              <widget class="QLabel">
               <property name="text">
                <string>Alt GFHigh</string>
@@ -3120,24 +3132,8 @@
               </property>
              </widget>
             </item>
-            <item row="12" column="4">
-             <widget class="QSpinBox" name="travelGasConsumption_4">
-              <property name="suffix">
-               <string>L/min</string>
-              </property>
-              <property name="minimum">
-               <number>5</number>
-              </property>
-              <property name="maximum">
-               <number>50</number>
-              </property>
-              <property name="value">
-               <number>20</number>
-              </property>
-             </widget>
-            </item>
             <item row="13" column="4">
-             <widget class="QSpinBox" name="bottomGasConsumption_4">
+             <widget class="QSpinBox" name="travelGasConsumption_4">
               <property name="suffix">
                <string>L/min</string>
               </property>


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Update the dive computer settings that can be read, edited, and
persisted for the OSTC 4/5.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. update the dive computer settings that can be read, edited, and persisted for the OSTC 4/5;
2. reorganise the arrangement on the settings pages to be a bit more intuitive by separating read-only and read-write parts;
3. pull the 'Sync dive computer time with PC' option out of the settings page to be less confusing, and made it work when writing _and reading_ the settings.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Requires https://github.com/mikeller/ostc4/pull/31 to fully work.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
![image](https://github.com/user-attachments/assets/a6b98144-eac7-40fc-a05d-b118be975282)

![image](https://github.com/user-attachments/assets/dfbef894-8765-4631-995d-f380017a49da)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
