### PR TITLE
Firmware Update: Add bluetooth Disconnect after Firmware Update.

### DIFF
--- a/core/configuredivecomputer.cpp
+++ b/core/configuredivecomputer.cpp
@@ -22,7 +22,7 @@ ConfigureDiveComputer::ConfigureDiveComputer() : readThread(0),
 
 void ConfigureDiveComputer::connectThreadSignals(DeviceThread *thread)
 {
-	connect(thread, &DeviceThread::finished, this, &ConfigureDiveComputer::readThreadFinished, Qt::QueuedConnection);
+	connect(thread, &DeviceThread::finished, this, &ConfigureDiveComputer::threadFinished, Qt::QueuedConnection);
 	connect(thread, &DeviceThread::error, this, &ConfigureDiveComputer::setError);
 	connect(thread, &DeviceThread::progress, this, &ConfigureDiveComputer::progressEvent, Qt::QueuedConnection);
 }
@@ -521,8 +521,10 @@ void ConfigureDiveComputer::progressEvent(int percent)
 
 void ConfigureDiveComputer::setState(ConfigureDiveComputer::states newState)
 {
+	ConfigureDiveComputer::states oldState = currentState;
 	currentState = newState;
-	emit stateChanged(currentState);
+
+	emit stateChanged(oldState, currentState);
 }
 
 void ConfigureDiveComputer::setError(QString err)
@@ -531,40 +533,12 @@ void ConfigureDiveComputer::setError(QString err)
 	emit error(std::move(err));
 }
 
-void ConfigureDiveComputer::readThreadFinished()
+void ConfigureDiveComputer::threadFinished()
 {
 	setState(DONE);
-	if (lastError.isEmpty()) {
-		//No error
-		emit message(tr("Dive computer details read successfully"));
-	}
-}
 
-void ConfigureDiveComputer::writeThreadFinished()
-{
-	setState(DONE);
-	if (lastError.isEmpty()) {
-		//No error
-		emit message(tr("Setting successfully written to device"));
-	}
-}
-
-void ConfigureDiveComputer::firmwareThreadFinished()
-{
-	setState(DONE);
-	if (lastError.isEmpty()) {
-		//No error
-		emit message(tr("Device firmware successfully updated"));
-	}
-}
-
-void ConfigureDiveComputer::resetThreadFinished()
-{
-	setState(DONE);
-	if (lastError.isEmpty()) {
-		//No error
-		emit message(tr("Device settings successfully reset"));
-	}
+	if (lastError.isEmpty())
+		emit message(tr("The operation completed successfully"));
 }
 
 QString ConfigureDiveComputer::dc_open(device_data_t *data)

--- a/core/configuredivecomputer.h
+++ b/core/configuredivecomputer.h
@@ -47,7 +47,7 @@ signals:
 	void progress(int percent);
 	void message(QString msg);
 	void error(QString err);
-	void stateChanged(states newState);
+	void stateChanged(states oldState, states newState);
 	void deviceDetailsChanged(DeviceDetails newDetails);
 
 private:
@@ -60,10 +60,7 @@ private:
 private
 slots:
 	void progressEvent(int percent);
-	void readThreadFinished();
-	void writeThreadFinished();
-	void resetThreadFinished();
-	void firmwareThreadFinished();
+	void threadFinished();
 	void setError(QString err);
 };
 

--- a/desktop-widgets/configuredivecomputerdialog.cpp
+++ b/desktop-widgets/configuredivecomputerdialog.cpp
@@ -131,6 +131,7 @@ ConfigureDiveComputerDialog::ConfigureDiveComputerDialog(const QString &filename
 	connect(config, &ConfigureDiveComputer::error, this, &ConfigureDiveComputerDialog::configError);
 	connect(config, &ConfigureDiveComputer::message, this, &ConfigureDiveComputerDialog::configMessage);
 	connect(config, &ConfigureDiveComputer::deviceDetailsChanged, this, &ConfigureDiveComputerDialog::deviceDetailsReceived);
+	connect(config, &ConfigureDiveComputer::stateChanged, this, &ConfigureDiveComputerDialog::processStateChanged);
 	connect(ui.retrieveDetails, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::readSettings);
 	connect(ui.resetButton, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::resetSettings);
 	connect(ui.resetButton_4, &QPushButton::clicked, this, &ConfigureDiveComputerDialog::resetSettings);
@@ -984,6 +985,15 @@ void ConfigureDiveComputerDialog::deviceDetailsReceived(DeviceDetails newDeviceD
 {
 	deviceDetails = std::move(newDeviceDetails);
 	reloadValues();
+}
+
+void ConfigureDiveComputerDialog::processStateChanged(ConfigureDiveComputer::states oldState, ConfigureDiveComputer::states newState)
+{
+	if (oldState == ConfigureDiveComputer::states::FWUPDATE && newState == ConfigureDiveComputer::states::DONE) {
+		// Close the bluetooth connection to trigger the start of the update on the device
+		// instead of making it wait for a timeout
+		dc_close();
+	}
 }
 
 void ConfigureDiveComputerDialog::reloadValues()

--- a/desktop-widgets/configuredivecomputerdialog.h
+++ b/desktop-widgets/configuredivecomputerdialog.h
@@ -72,6 +72,7 @@ slots:
 	void on_close_clicked();
 	void on_saveSettingsPushButton_clicked();
 	void deviceDetailsReceived(DeviceDetails newDeviceDetails);
+	void processStateChanged(ConfigureDiveComputer::states oldState, ConfigureDiveComputer::states newState);
 	void reloadValues();
 	void on_backupButton_clicked();
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Execute a bluetooth disconnect after the firmware update has completed.
On the Heinrichs Weikamp OSTC 4/5 the firmware update on the device is
waiting for this disconnect, or an eventual timeout before starting to
write the new firmware to EEPROM. This speeds up the process.
Not tested on older Heinrichs Weikamp dive computers.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
