### PR TITLE
Remove the broken Divesoft model detection

### DIFF
--- a/core/divesoft.cpp
+++ b/core/divesoft.cpp
@@ -26,7 +26,7 @@ int divesoft_import(const std::string &buffer, struct divelog *log)
 		return report_error("%s", translate("gettextFromC", "Unknown DC"));
 
 	auto d = std::make_unique<dive>();
-	d->dcs[0].model = devdata.vendor + " " + devdata.model + " (Imported from file)";
+	d->dcs[0].model = devdata.vendor + " (Imported from file)";
 
 	// Parse the dive data
 	dc_status_t rc = libdc_buffer_parser(d.get(), &devdata, (const unsigned char *)buffer.data(), buffer.size());

--- a/core/divesoft.cpp
+++ b/core/divesoft.cpp
@@ -13,27 +13,15 @@
 #include "format.h"
 #include "libdivecomputer.h"
 
-// As supplied by Divesoft
-static constexpr std::string_view divesoft_liberty_serial_prefix = "7026";
-static constexpr std::string_view divesoft_freedom_serial_prefix = "7044";
-static constexpr std::string_view divesoft_freedom_plus_serial_prefix = "7273";
-
 // From libdivecomputer
 static constexpr int divesoft_liberty_model = 10;
 static constexpr int divesoft_freedom_model = 19;
 
 int divesoft_import(const std::string &buffer, struct divelog *log)
 {
-	std::string model_identifier = buffer.substr(52, 4);
-	int model = 0;
-	if (model_identifier == divesoft_liberty_serial_prefix)
-		model = divesoft_liberty_model;
-	else if (model_identifier == divesoft_freedom_serial_prefix || model_identifier == divesoft_freedom_plus_serial_prefix)
-		model = divesoft_freedom_model;
-
 	device_data_t devdata;
 	devdata.log = log;
-	int ret = prepare_device_descriptor(model, DC_FAMILY_DIVESOFT_FREEDOM, devdata);
+	int ret = prepare_device_descriptor(divesoft_freedom_model, DC_FAMILY_DIVESOFT_FREEDOM, devdata);
 	if (ret == 0)
 		return report_error("%s", translate("gettextFromC", "Unknown DC"));
 


### PR DESCRIPTION
Only the V2 header contains a serial number, and there are also cases where the serial number hasn't been filled in correctly.

Libdivecomputer doesn't use the actual model number for parsing the Divesoft dives, so hardcoding the Freedom works fine. The main disadvantage is that all imported dives will show the Divesoft Freedom as their dive computer model.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
