### PR TITLE
Import: Improve the Selection of bluetooth Transport.

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -71,7 +71,7 @@ slots:
 private:
 	void markChildrenAsDisabled();
 	void markChildrenAsEnabled();
-	void updateDeviceEnabled();
+	void updateTransportSelection();
 	void showRememberedDCs();
 	void checkShowError(states state);
 

--- a/desktop-widgets/downloadfromdivecomputer.h
+++ b/desktop-widgets/downloadfromdivecomputer.h
@@ -71,7 +71,7 @@ slots:
 private:
 	void markChildrenAsDisabled();
 	void markChildrenAsEnabled();
-	void updateTransportSelection();
+	void updateTransportSelection(bool changeSelection);
 	void showRememberedDCs();
 	void checkShowError(states state);
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
In the 'Import from dive computer' dialog, only enable selection of
bluetooth as the transport if bluetooth is a supported transport for the
selected dive computer model.
If bluetooth is _the only_ option, pre-select bluetooth and make it
impossible to deselect.
This should reduce user confusion around the correct transport mode to
choose.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. in the 'Import from dive computer' dialog, only enable selection of bluetooth as the transport if bluetooth is a supported transport for the selected dive computer model;
2. if bluetooth is _the only_ option, pre-select bluetooth and make it impossible to deselect.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
bluetooth not supported:
(@jefdriesen not quite sure about this one - is it possible for users to use a 'serial to bluetooth' adaptor with a dive computer with a built in serial connection, and then connect to the dive computer directly in Subsurface, without setting up a serial port device in the operating system first?)

![image](https://github.com/user-attachments/assets/62169fe8-7917-4ba4-8519-4a8b95cc506a)

bluetooth and others supported:

![image](https://github.com/user-attachments/assets/9ece40fa-70ae-4a7f-a59f-4f3946e70e3a)

Only bluetooth supported:

![image](https://github.com/user-attachments/assets/5b840d2a-4a21-49b8-a1bd-1f02ae4c62ba)


### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
