### PR TITLE
Statistics: Add month-of-year binning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+statistics: add month-of-year binning
 core: add support for Cressi Bluetooth interfaces #4460 #4469
 desktop: add support to import .asd and .script files from Scubapro's LogTrak and SmartTrak
 desktop: update "Save dive data as subtitles" feature to make it more configurable.

--- a/core/subsurface-time.h
+++ b/core/subsurface-time.h
@@ -10,6 +10,7 @@ extern timestamp_t utc_mktime(const struct tm *tm);
 extern void utc_mkdate(timestamp_t, struct tm *tm);
 extern int utc_year(timestamp_t timestamp);
 extern int utc_weekday(timestamp_t timestamp);
+extern int utc_month(timestamp_t timestamp);
 extern int gettimezoneoffset();
 
 /* parse and format date times of the form YYYY-MM-DD hh:mm:ss */

--- a/core/time.cpp
+++ b/core/time.cpp
@@ -170,6 +170,21 @@ int utc_weekday(timestamp_t timestamp)
 }
 
 /*
+ * Extract month of the year from 64-bit timestamp.
+ * Returns 0-11 where 0 is Jan and 11 is Dec.
+ *
+ * Same comment as for utc_year(): Modern compilers are good
+ * at throwing out unused calculations, so this is more efficient
+ * than it looks.
+ */
+int utc_month(timestamp_t timestamp)
+{
+	struct tm tm;
+	utc_mkdate(timestamp, &tm);
+	return tm.tm_mon;
+}
+
+/*
  * Try to parse datetime of the form "YYYY-MM-DD hh:mm:ss" or as
  * an 64-bit decimal and return 64-bit timestamp. On failure or
  * if passed an empty string, return 0.

--- a/stats/statsvariables.cpp
+++ b/stats/statsvariables.cpp
@@ -1899,6 +1899,29 @@ struct DayOfWeekVariable : public StatsVariableTemplate<StatsVariable::Type::Dis
 	}
 };
 
+// ============ Month of the year ============
+struct MonthOfYearBinner : public SimpleBinner<MonthOfYearBinner, IntBin> {
+	QString format(const StatsBin &bin) const override {
+		return QString(monthname(derived_bin(bin).value));
+	}
+	int to_bin_value(const dive *d) const {
+		return utc_month(d->when);
+	}
+};
+
+static MonthOfYearBinner month_of_year_binner;
+struct MonthOfYearVariable : public StatsVariableTemplate<StatsVariable::Type::Discrete> {
+	QString name() const override {
+		return StatsTranslations::tr("Month of year");
+	}
+	QString diveCategories(const dive *d) const override {
+		return QString(monthname(utc_month(d->when)));
+	}
+	std::vector<const StatsBinner *> binners() const override {
+		return { &month_of_year_binner };
+	}
+};
+
 // ============ Rating ============
 struct RatingBinner : public SimpleBinner<RatingBinner, IntBin> {
 	QString format(const StatsBin &bin) const override {
@@ -1975,6 +1998,7 @@ static CylinderTypeVariable cylinder_type_variable;
 static LocationVariable location_variable;
 static TripVariable trip_variable;
 static DayOfWeekVariable day_of_week_variable;
+static MonthOfYearVariable month_of_year_variable;
 static RatingVariable rating_variable;
 static VisibilityVariable visibility_variable;
 
@@ -1985,5 +2009,5 @@ const std::vector<const StatsVariable *> stats_variables = {
 	&dive_mode_variable, &people_variable, &buddy_variable, &dive_guide_variable, &tag_variable,
 	&gas_type_variable, &suit_variable,
 	&weightsystem_variable, &cylinder_type_variable, &location_variable, &trip_variable, &day_of_week_variable,
-	&rating_variable, &visibility_variable
+	&month_of_year_variable, &rating_variable, &visibility_variable
 };


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This commit adds a "month of year" to the statistics base data selection. It enables the user to see statistics data aggregated through the year, for example seeing the water temperatures during winter/summer etc. This is useful if a diver dives in the same locations for several years.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4438

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->
I added the new functionality to the CHANGELOG.md

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
