### PR TITLE
Fix cmake include/lib search path for libdivecomputer

### DIFF
--- a/cmake/Modules/FindLibdivecomputer.cmake
+++ b/cmake/Modules/FindLibdivecomputer.cmake
@@ -19,7 +19,7 @@ NAMES
     libdivecomputer/descriptor.h
 HINTS
     ${CMAKE_CURRENT_SOURCE_DIR}/../install-root/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libdivecomputer/include/
+    ${CMAKE_CURRENT_SOURCE_DIR}/libdivecomputer/include/
 PATHS
     /opt/out/include
 )
@@ -27,10 +27,9 @@ PATHS
 FIND_LIBRARY( LIBDIVECOMPUTER_LIBRARIES
 NAMES
     libdivecomputer.a
-    divecomputer
 HINTS
     ${CMAKE_CURRENT_SOURCE_DIR}/../install-root/lib
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libdivecomputer/src/.libs/
+    ${CMAKE_CURRENT_SOURCE_DIR}/libdivecomputer/src/.libs/
 PATHS
     /opt/out/lib
 )


### PR DESCRIPTION
Fixes https://github.com/subsurface/subsurface/issues/4521.

This makes the procedure described in the INSTALL.md file works strait out of the box.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The cmake search path for the submodule (libdivecomputer) assumes the lib has been cloned separately and not using the git submodule update command. This fixes it by changing the HINT path for cmake.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
Fixes #4521.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
