### PR TITLE
Ignore infinite deco in backgas breaks

### DIFF
--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -966,7 +966,7 @@ std::vector<decostop> plan(struct deco_state *ds, struct diveplan &diveplan, str
 					bottom_time, dive->get_cylinder(current_cylinder)->gasmix, po2, diveplan.surface_pressure.mbar / 1000.0, divemode);
 				laststoptime = new_clock - clock;
 				/* Finish infinite deco */
-				if (laststoptime >= 48 * 3600 && depth.mm >= 6000) {
+				if (laststoptime >= 48 * 3600 && depth.mm >= 6000 && !o2breaking) {
 					error = PLAN_ERROR_TIMEOUT;
 
 					break;


### PR DESCRIPTION
When doing backgas breaks we might breath a gas that does not advance the decompression. Still a very long or infinite stop time should not abort the deco as we will be switching back to O2.

Fixes #4525

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
