### PR TITLE
Match any horizontal whitespace in the time format test

### DIFF
--- a/desktop-widgets/preferences/preferences_language.cpp
+++ b/desktop-widgets/preferences/preferences_language.cpp
@@ -98,7 +98,7 @@ void PreferencesLanguage::syncSettings()
 	refreshSettings();
 
 	QString qDateTimeWeb = tr("These will be used as is. This might not be what you intended. To avoid this warning wrap the literal parts in quotes (').\nSee https://doc.qt.io/archives/qt-4.8/qdatetime.html#fromString");
-	QRegularExpression timeStandardFormat("^([hHmszaApP\\s:\\.]|'[^']*')*$");
+	QRegularExpression timeStandardFormat("^([hHmszaApP\\h:\\.]|'[^']*')*$");
 	if (!timeStandardFormat.match(ui->timeFormatEntry->currentText()).hasMatch())
 		QMessageBox::warning(this, tr("Literal characters"),
 			tr("Non-standard character(s) in time format.\n") + qDateTimeWeb);


### PR DESCRIPTION
The default time format for KDE Plasma on Debian Trixie is "h:mm Ap" where the space character is U+202F (Narrow No-Break Space), but what \s matches in pcre is locale dependent, so use \h instead.

  $ echo "h:mm Ap" | grep -P "^([hHmszaApP\\s:\\.]|'[^']*')*$"
  $ echo "h:mm Ap" | grep -P "^([hHmszaApP\\h:\\.]|'[^']*')*$"
  h:mm Ap

Fixes #4572

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
