### PR TITLE
Support building on Debian Trixie

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,6 +184,19 @@ sudo apt install \
     qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev libraw-dev
 ```
 
+On Debian Trixie this seems to work
+```
+sudo apt install \
+    autoconf automake cmake g++ git libbluetooth-dev libcrypto++-dev \
+    libcurl4-openssl-dev libgit2-dev libqt5qml5 libqt5quick5 libqt5svg5-dev \
+    libsqlite3-dev libssh2-1-dev libssl-dev libtool \
+    libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make pkg-config \
+    qml-module-qtlocation qml-module-qtpositioning qml-module-qtquick2 \
+    qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
+    qtdeclarative5-private-dev qtlocation5-dev qtpositioning5-dev \
+    qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev libraw-dev
+```
+
 In order to build and run mobile-on-desktop, you also need
 
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -171,20 +171,10 @@ sudo zypper install git gcc-c++ make autoconf automake libtool cmake libzip-deve
     libqt5-qtconnectivity-devel libqt5-qtlocation-devel libcurl-devel \
     bluez-devel libgit2-devel libmtp-devel libraw-devel
 ```
-On Debian Bookworm this seems to work
-```
-sudo apt install \
-    autoconf automake cmake g++ git libbluetooth-dev libcrypto++-dev \
-    libcurl4-openssl-dev libgit2-dev libqt5qml5 libqt5quick5 libqt5svg5-dev \
-    libqt5webkit5-dev libsqlite3-dev libssh2-1-dev libssl-dev libtool \
-    libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make pkg-config \
-    qml-module-qtlocation qml-module-qtpositioning qml-module-qtquick2 \
-    qt5-qmake qtchooser qtconnectivity5-dev qtdeclarative5-dev \
-    qtdeclarative5-private-dev qtlocation5-dev qtpositioning5-dev \
-    qtscript5-dev qttools5-dev qttools5-dev-tools libmtp-dev libraw-dev
-```
 
-On Debian Trixie this seems to work
+On Debian this seems to work for Trixie. For Bookworm, install the same, plus
+one additional package `sudo apt install libqt5webkit5-dev`.
+
 ```
 sudo apt install \
     autoconf automake cmake g++ git libbluetooth-dev libcrypto++-dev \


### PR DESCRIPTION
Same as bookworm but libqt5webkit5-dev is not available

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [X] Documentation change
- [ ] Language translation

### Pull request long description:
Added instructions for required packages to build on Debian Trixie.
