### PR TITLE
Use updated LIBZIP API to squash some compiler warnings

### DIFF
--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -85,14 +85,14 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 	if (!zip) {
 		char buffer[1024];
 #if LIBZIP_VERSION_MAJOR >= 1
-                zip_error_t error;
-                zip_error_init_with_code(&error, error_code);   // from zip_* function return
-                snprintf(buffer, sizeof buffer, "%s", zip_error_strerror(&error));
-                zip_error_fini(&error);
+		zip_error_t error;
+		zip_error_init_with_code(&error, error_code);   // from zip_* function return
+		snprintf(buffer, sizeof buffer, "%s", zip_error_strerror(&error));
+		zip_error_fini(&error);
 #else
 		zip_error_to_str(buffer, sizeof buffer, error_code, errno);
-		report_error(qPrintable(tr("Failed to create zip file for upload: %s")), buffer);
 #endif
+		report_error(qPrintable(tr("Failed to create zip file for upload: %s")), buffer);
 		return false;
 	}
 

--- a/core/uploadDiveLogsDE.cpp
+++ b/core/uploadDiveLogsDE.cpp
@@ -178,7 +178,7 @@ bool uploadDiveLogsDE::prepareDives(const QString &tempfile, bool selected)
 		snprintf(filename, PATH_MAX, "%d.xml", i + 1);
 		s = zip_source_buffer(zip, membuf, streamsize, 1); // frees membuffer!
 		if (s) {
-                        int64_t ret = zip_file_add(zip, filename, s, ZIP_FL_OVERWRITE);
+			int64_t ret = zip_file_add(zip, filename, s, ZIP_FL_OVERWRITE);
 			if (ret == -1)
 				report_info("%s failed to include dive: %d", errPrefix, i);
 		}

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -392,15 +392,15 @@ void DivelogsDeWebServices::downloadFinished()
 	if (!zip) {
 		char buf[512];
 #if LIBZIP_VERSION_MAJOR >= 1
-                zip_error_t error;
-                zip_error_init_with_code(&error, errorcode);   // from zip_* function return
-                snprintf(buf, sizeof buf, "%s", zip_error_strerror(&error));
-                zip_error_fini(&error);
+		zip_error_t error;
+		zip_error_init_with_code(&error, errorcode);   // from zip_* function return
+		snprintf(buf, sizeof buf, "%s", zip_error_strerror(&error));
+		zip_error_fini(&error);
 #else
 		zip_error_to_str(buf, sizeof(buf), errorcode, errno);
+#endif
 		QMessageBox::critical(this, tr("Corrupted download"),
 				      tr("The archive could not be opened:\n%1").arg(QString::fromLocal8Bit(buf)));
-#endif
 		zipFile.close();
 		return;
 	}

--- a/desktop-widgets/subsurfacewebservices.cpp
+++ b/desktop-widgets/subsurfacewebservices.cpp
@@ -391,9 +391,16 @@ void DivelogsDeWebServices::downloadFinished()
 #endif
 	if (!zip) {
 		char buf[512];
+#if LIBZIP_VERSION_MAJOR >= 1
+                zip_error_t error;
+                zip_error_init_with_code(&error, errorcode);   // from zip_* function return
+                snprintf(buf, sizeof buf, "%s", zip_error_strerror(&error));
+                zip_error_fini(&error);
+#else
 		zip_error_to_str(buf, sizeof(buf), errorcode, errno);
 		QMessageBox::critical(this, tr("Corrupted download"),
 				      tr("The archive could not be opened:\n%1").arg(QString::fromLocal8Bit(buf)));
+#endif
 		zipFile.close();
 		return;
 	}


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [X] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
When compiling on Debian Trixie there were some compiler warnings. This squashes them. I did this with the help of an LLM. Changes seem to work. Not extensively tested.