### PR TITLE
Show dive information in profile export

### DIFF
--- a/backend-shared/exportfuncs.h
+++ b/backend-shared/exportfuncs.h
@@ -13,7 +13,7 @@ struct ExportCallback {
 	virtual bool canceled() const;
 };
 
-void exportProfile(QString filename, bool selected_only, ExportCallback &cb);
+void exportProfile(QString filename, bool selected_only, ExportCallback &cb, bool diveinfo);
 void export_TeX(const char *filename, bool selected_only, bool plain, ExportCallback &cb);
 void export_depths(const char *filename, bool selected_only);
 std::vector<const dive_site *> getDiveSitesToExport(bool selectedOnly);

--- a/desktop-widgets/divelogexportdialog.cpp
+++ b/desktop-widgets/divelogexportdialog.cpp
@@ -224,7 +224,7 @@ void DiveLogExportDialog::on_buttonBox_accepted()
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile image"), lastDir);
 			if (!filename.isEmpty()) {
 				ProgressDialogCallback cb;
-				exportProfile(qPrintable(filename), ui->exportSelected->isChecked(), cb);
+                exportProfile(qPrintable(filename), ui->exportSelected->isChecked(), cb, ui->diveinfo->isChecked());
 			}
 		} else if (ui->exportProfileData->isChecked()) {
 			filename = QFileDialog::getSaveFileName(this, tr("Save profile data"), lastDir);

--- a/desktop-widgets/divelogexportdialog.ui
+++ b/desktop-widgets/divelogexportdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>507</width>
-    <height>423</height>
+    <height>556</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -173,6 +173,19 @@
              </property>
              <property name="text">
               <string>Anonymize</string>
+             </property>
+            </widget>
+            <widget class="QCheckBox" name="diveinfo">
+             <property name="geometry">
+              <rect>
+               <x>10</x>
+               <y>90</y>
+               <width>181</width>
+               <height>23</height>
+              </rect>
+             </property>
+             <property name="text">
+              <string>Dive info in profle</string>
              </property>
             </widget>
            </widget>
@@ -666,7 +679,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="exportGroup"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/profile-widget/profilescene.cpp
+++ b/profile-widget/profilescene.cpp
@@ -385,8 +385,8 @@ void ProfileScene::updateAxes(bool diveHasHeartBeat, bool simplified)
 		l.axis->setVisible(l.visible);
 		if (!l.visible)
 			continue;
-		bottomBorder -= l.height * dpr;
-		l.axis->setPosition(QRectF(leftBorder, bottomBorder, width, (l.height - l.bottom_border) * dpr));
+		bottomBorder -= l.height;
+		l.axis->setPosition(QRectF(leftBorder, bottomBorder, width, (l.height - l.bottom_border)));
 	}
 
 	height = bottomBorder - topBorder;


### PR DESCRIPTION
This was requested for social media posting.

This adds an option to overlay the profile picture with the most important dive information.

It addresses #4587 in a minimalistic way.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
