### PR TITLE
Modify the mobile planner to fix three bugs relating to cylinders

### DIFF
--- a/mobile-widgets/qml/DivePlannerEdit.qml
+++ b/mobile-widgets/qml/DivePlannerEdit.qml
@@ -22,6 +22,8 @@ TemplatePage {
 	ListModel { id: segmentListModel }
 	property var gasNumberModel: []
 
+	property var cylinderTypesModel: []
+
 	// --- Functions ---
 	function updateGasNumberList() {
 		var newList = [];
@@ -101,6 +103,7 @@ TemplatePage {
 	onVisibleChanged: {
 		// This code runs every time the page becomes visible
 		if (visible) {
+			cylinderTypesModel = manager.cylinderListInit;
 			updateLivePlanInfo()
 		}
 	}
@@ -262,10 +265,18 @@ TemplatePage {
 				}
 				TemplateComboBox {
 					id: typeBox
-					Layout.preferredWidth: Kirigami.Units.gridUnit * 6
-					model: manager.cylinderListInit
+					Layout.preferredWidth: Kirigami.Units.gridUnit * 10
+					model: divePlannerEditWindow.cylinderTypesModel
 					currentIndex: model.indexOf(type)
-
+					onActivated: {
+						if (currentIndex !== -1) {
+							// Update the 'type' property in the model with the selected cylinder text
+							cylinderListModel.setProperty(parent.index, "type", currentText);
+							
+							// This updates the dive plan summary in real-time
+							updateLivePlanInfo();
+						}
+					}
 				}
 				TemplateTextField {
 					id: mixField
@@ -405,9 +416,9 @@ TemplatePage {
 					model: gasNumberModel
 
 					currentIndex: gas
-					onCurrentIndexChanged: {
+					onActivated: {
 						if (currentIndex !== -1)
-						   segmentListModel.setProperty(index, "gas", currentValue)
+						   segmentListModel.setProperty(parent.index, "gas", currentIndex)
 						updateLivePlanInfo();
 					}
 				}

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -1429,18 +1429,17 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 		cylinder_t newCyl;
 		std::pair<volume_t, pressure_t> type_info = get_tank_info_data(tank_info_table, map["type"].toString().toStdString());
 		volume_t size = type_info.first;
-		pressure_t pressure = type_info.second;
 		newCyl.type.size = size;
-		newCyl.type.workingpressure = pressure;
+		if (prefs.units.pressure == units::BAR)
+			newCyl.type.workingpressure.mbar = map["pressure"].toInt() * 1000;
+		else
+			newCyl.type.workingpressure.mbar = psi_to_mbar(map["pressure"].toInt());
 		newCyl.type.description = map["type"].toString().toStdString();
 		QString mix = map["mix"].toString();
 		newCyl.gasmix.o2.permille = parseGasMixO2(mix);
 		newCyl.gasmix.he.permille = parseGasMixHE(mix);
 		sanitize_gasmix(newCyl.gasmix);
-		if (prefs.units.pressure == units::BAR)
-			newCyl.start.mbar = map["pressure"].toInt() * 1000;
-		else
-			newCyl.start.mbar = psi_to_mbar(map["pressure"].toInt());
+
 		int useIndex = map["use"].toInt();
 		newCyl.cylinder_use = (enum cylinderuse)useIndex;
 		d->cylinders.add(d->cylinders.size(), newCyl);
@@ -1488,8 +1487,7 @@ QVariantMap DivePlannerPointsModel::calculatePlan(const QVariantList &cylindersD
 	if (!diveplan.is_empty()) {
 		deco_state_cache cache;
 		struct deco_state plan_deco_state;
-		plan(&plan_deco_state, diveplan, d, dcNr, 60, cache, true, true, nullptr);
-
+		plan(&plan_deco_state, diveplan, d, dcNr, 60, cache, true, true, nullptr);			
 		if (shouldComputeVariations()) {
 			QString variations = computeVariations(plan_copy, plan_deco_state, nullptr);
 			if (!variations.isEmpty()) {


### PR DESCRIPTION
…ction

Fixes bugs related to selecting the gas in the segment, having custom gasses present in the dropdown, and using the start pressure in the calculations.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
The changes are related to the mobile planner. In the initial implementation there were three quickly identified minor bugs:
1. The cylinder list, for the first cylinder, would have been created before reading in all of the stored dives, thus causing the loss of all custom cylinders.
2. The gas dropdown in the segment list was implemented incorrectly, causing issues.
3. The cylinder type and pressure were incorrectly being passed on to the backend.

Please note, I do not like how I handle start pressures in calculatePlan in the c++ code. I am open to suggestions on how to handle this better.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
