### PR TITLE
Fix dive-site duplication by resetting pending-site state only on actual text edits

### DIFF
--- a/core/load-git.cpp
+++ b/core/load-git.cpp
@@ -226,7 +226,7 @@ static void parse_dive_location(char *, struct git_parser_state *state)
 			ds->name = name.c_str();
 		} else {
 			// and that dive site had a name. that's weird - if our name is different, add it to the notes
-			if (ds->name == name) {
+			if (ds->name != name) {
 				ds->notes += '\n';
 				ds->notes += format_string_std(translate("gettextFromC", "additional name for site: %s\n"), name.c_str());
 			}

--- a/desktop-widgets/locationinformation.cpp
+++ b/desktop-widgets/locationinformation.cpp
@@ -607,18 +607,16 @@ void DiveLocationLineEdit::setTemporaryDiveSiteName(const QString &name)
 
 void DiveLocationLineEdit::keyPressEvent(QKeyEvent *ev)
 {
+	const QString before = text();
+	const int key = ev->key();
 	QLineEdit::keyPressEvent(ev);
-	if (ev->key() != Qt::Key_Left &&
-	    ev->key() != Qt::Key_Right &&
-	    ev->key() != Qt::Key_Escape &&
-	    ev->key() != Qt::Key_Return) {
-
-		if (ev->key() != Qt::Key_Up && ev->key() != Qt::Key_Down)
-			currDs = RECENTLY_ADDED_DIVESITE;
-		else
-			showPopup();
-	} else if (ev->key() == Qt::Key_Escape) {
+	const bool textChanged = (text() != before);
+	if (key == Qt::Key_Escape) {
 		view->hide();
+	} else if (key == Qt::Key_Up || key == Qt::Key_Down) {
+		showPopup();
+	} else if (textChanged) {
+		currDs = RECENTLY_ADDED_DIVESITE;
 	}
 }
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
This PR fixes a dive-site duplication path caused by location input state handling.

When editing the dive-site field, the widget used to reset its internal pending-site pointer (`currDs`) for many non-text key presses. If the user had selected an existing dive site and then pressed such a key before saving, the save path could incorrectly treat the value as “create new dive site” and create a duplicate entry.

The fix changes key handling so the pending-site pointer is reset only when the text actually changes. This preserves selected existing dive sites across non-text key events.

Additionally, this PR fixes an unrelated but valid loader bug in `load-git`: the comparison for appending “additional name for site” notes was inverted and is corrected from `==` to `!=`.

### Changes made:
1) `desktop-widgets/locationinformation.cpp`:
- Refactored `DiveLocationLineEdit::keyPressEvent()` to use intent based key handling logic.
- Reset `currDs` to `RECENTLY_ADDED_DIVESITE` only when the line edit text actually changed.
- Preserve behavior for popup interaction (`Escape`, `Up/Down`).

2) `core/load-git.cpp`:
- Fixed condition in `parse_dive_location()`:
  - `if (ds->name == name)` -> `if (ds->name != name)`.

3) Tests:
- No permanent test changes included in this PR.
- Existing local test suite was run and passed after the fix.

### Additional information:
- Reproduced on unpatched build with a non-text key press (Ctrl  + S) between selecting an existing dive site and saving. (all platforms)
- Verified patched behavior no longer creates duplicate dive sites in that flow.
- Issue discussion board:  [https://groups.google.com/g/subsurface-divelog/c/IOJ6Ifu2Dqo](https://groups.google.com/g/subsurface-divelog/c/IOJ6Ifu2Dqo)

### Documentation change:
No user-facing workflow change intended; this is a correctness fix for existing behavior.
No documentation update required.

### Mentions:
@mikeller 