### PR TITLE
Install qlitehtml in correct directory on non-mac

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -469,7 +469,7 @@ if [[ "$QUICK" != "1" && "$BUILD_DESKTOP" == "1" && "$BUILD_WITH_QT6" == "1" ]] 
 	git submodule update
 
 	# qlitehtml currently (2025-12-01) only allows in source tree builds
-	cmake $MAC_CMAKE .
+	cmake $MAC_CMAKE -DCMAKE_INSTALL_PREFIX=${INSTALL_ROOT} .
 	make
 	make install
 	if [ "$PLATFORM" = Darwin ] ; then


### PR DESCRIPTION
The CMAKE_INSTALL_PREFIX was only set for mac.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The qt6 version wouldn't compile for me, because it tried to install qlitehtml to "/usr/local".

I'm certain that this is the wrong fix, since it now passes the correct path twice on Mac, but for now this kludge does it for me.