### PR TITLE
Qt 6: add generic yml to build Debian based Linux

### DIFF
--- a/.github/workflows/linux-debian-generic-qt6.yml
+++ b/.github/workflows/linux-debian-generic-qt6.yml
@@ -1,0 +1,87 @@
+name: Generic Qt 6 workflow for Debian and derivatives
+
+on:
+  workflow_call:
+    inputs:
+      container-image:
+        type: string
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-image }}
+
+    steps:
+    - name: get container ready for build
+      run: |
+        echo "--------------------------------------------------------------"
+        echo "update distro and install dependencies"
+
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
+        autoconf automake cmake g++ git libcrypto++-dev libcurl4-gnutls-dev \
+        libgit2-dev libsqlite3-dev libssh2-1-dev libssl-dev libssl-dev \
+        libtool libusb-1.0-0-dev libxml2-dev libxslt1-dev libzip-dev make \
+        pkg-config xvfb libbluetooth-dev libmtp-dev libraw-dev mdbtools-dev \
+        libqt6qml6 libqt6quick6 qt6-svg-dev libqt6svg6 qt6-5compat-dev \
+        qml6-module-qtpositioning qml6-module-qtlocation \
+        qmake6 qt6-location-dev qt6-connectivity-dev \
+        qml6-module-qtquick qt6-declarative-dev qt6-tools-dev qt6-tools-dev-tools \
+        qt6-positioning-dev qt6-declarative-private-dev
+
+        git config --global user.email "ci@subsurface-divelog.org"
+        git config --global user.name "Subsurface CI"
+        git config --global --add safe.directory $GITHUB_WORKSPACE
+        git config --global --add safe.directory $GITHUB_WORKSPACE/libdivecomputer
+    # needs git from the previous step
+    - name: checkout sources
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: set the version information
+      id: version_number
+      uses: ./.github/actions/manage-version
+      with:
+        no-increment: true
+
+    - name: build subsurface
+      run: |
+        echo "--------------------------------------------------------------"
+        echo "building desktop"
+
+        BUILD_EXTRA_ARGS=""
+        if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+          echo "Building a release version"
+          BUILD_EXTRA_ARGS="${BUILD_EXTRA_ARGS} -release"
+        fi
+
+        # now build for the desktop version
+        cd ..
+        bash -e -x subsurface/scripts/build.sh -desktop -build-with-qt6 -build-tests ${BUILD_EXTRA_ARGS}
+
+    - name: test desktop build
+      run: |
+        echo "--------------------------------------------------------------"
+        echo "running tests for desktop"
+        cd build/tests
+        # xvfb-run --auto-servernum ./TestGitStorage -v2
+        xvfb-run --auto-servernum make check
+        if [ $? -ne 0 ]; then
+          echo "Tests failed - adding the build output as artifacts"
+          exit 1
+        fi
+
+    - name: upload test artifacts
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: test-output-${{ steps.version_number.outputs.version }}
+        path: |
+          build/tests/
+          !build/tests/CMakeFiles/
+          !build/tests/Test*
+          build/tests/Testing/

--- a/.github/workflows/linux-debian-trixie-6.8.yml
+++ b/.github/workflows/linux-debian-trixie-6.8.yml
@@ -1,0 +1,20 @@
+name: Debian trixie / Qt 6
+
+on:
+  push:
+    paths-ignore:
+    - scripts/docker/**
+    branches:
+    - master
+  pull_request:
+    paths-ignore:
+    - scripts/docker/**
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  do-build-test:
+    uses: ./.github/workflows/linux-debian-generic-qt6.yml
+    with:
+      container-image: debian:trixie

--- a/.github/workflows/linux-ubuntu-25.10-qt6.yml
+++ b/.github/workflows/linux-ubuntu-25.10-qt6.yml
@@ -1,0 +1,20 @@
+name: Ubuntu 25.10 / Qt 6
+
+on:
+  push:
+    paths-ignore:
+    - scripts/docker/**
+    branches:
+    - master
+  pull_request:
+    paths-ignore:
+    - scripts/docker/**
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  do-build-test:
+    uses: ./.github/workflows/linux-debian-generic-qt6.yml
+    with:
+      container-image: ubuntu:25.10

--- a/packaging/macosx/build-deps.sh
+++ b/packaging/macosx/build-deps.sh
@@ -7,7 +7,7 @@
 # - ARCHS              architectures to build
 # - SRC                the 'parent src dir' - this is the directory under which everything is anchored
 # - SRC_DIR            usually 'subsurface'
-# - MAC_CMAKE          which cmake to use
+# - CMAKE_ARGS         which cmake options to use
 # - MAC_OPTS           macOS specific options
 # - MAC_OPTS_OPENSSL   ditto for openssl
 # - INSTALL_ROOT
@@ -42,8 +42,8 @@ if [ "$RUNNER_OS" = "macOS" ]; then
     export PKG_CONFIG_LIBDIR="${INSTALL_ROOT}/lib/pkgconfig"
     unset PKG_CONFIG_PATH
     export CMAKE_IGNORE_PATH="/opt/homebrew:/usr/local"
-    MAC_CMAKE="-DCMAKE_PREFIX_PATH=${INSTALL_ROOT} -DCMAKE_IGNORE_PATH=/opt/homebrew;/usr/local \
-        -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/usr/local -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON ${MAC_CMAKE}"
+    CMAKE_ARGS="-DCMAKE_PREFIX_PATH=${INSTALL_ROOT} -DCMAKE_IGNORE_PATH=/opt/homebrew;/usr/local \
+        -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/usr/local -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON ${CMAKE_ARGS}"
 
     pkg-config --variable pc_path pkg-config
 fi
@@ -57,7 +57,7 @@ pushd libz
 sed -i .bak 's/share\/pkgconfig/pkgconfig/' CMakeLists.txt
 mkdir -p build
 cd build
-cmake $MAC_CMAKE ..
+cmake $CMAKE_ARGS ..
 make
 make install
 popd
@@ -108,7 +108,7 @@ get_dep libssh2
 pushd libssh2
 mkdir -p build
 cd build
-cmake $MAC_CMAKE -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF \
+cmake $CMAKE_ARGS -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF \
         -DOPENSSL_ROOT_DIR="${INSTALL_ROOT}" \
         -DOPENSSL_INCLUDE_DIR="${INSTALL_ROOT}/include" \
         -DOPENSSL_CRYPTO_LIBRARY="${INSTALL_ROOT}/lib/libcrypto.dylib" \
@@ -135,7 +135,7 @@ get_dep libcurl
 pushd libcurl
 mkdir -p build
 cd build
-cmake  $MAC_CMAKE -DBUILD_CURL_EXE=OFF -DCURL_DISABLE_ALTSVC=ON -DCURL_DISABLE_COOKIES=ON \
+cmake  $CMAKE_ARGS -DBUILD_CURL_EXE=OFF -DCURL_DISABLE_ALTSVC=ON -DCURL_DISABLE_COOKIES=ON \
             -DCURL_DISABLE_CRYPTO_AUTH=ON -DCURL_DISABLE_DICT=ON -DCURL_DISABLE_DOH=ON \
             -DCURL_DISABLE_FILE=ON -DCURL_DISABLE_FTP=ON -DCURL_DISABLE_GETOPTIONS=ON \
             -DCURL_DISABLE_GOPHER=ON -DCURL_DISABLE_HSTS=ON -DCURL_DISABLE_IMAP=ON \
@@ -160,7 +160,7 @@ pushd libgit2
 mkdir -p build
 cd build
 LIBGIT_ARGS="-DLIBGIT2_INCLUDE_DIR=$INSTALL_ROOT/include -DLIBGIT2_LIBRARIES=$INSTALL_ROOT/lib/libgit2.dylib"
-cmake $MAC_CMAKE -DBUILD_CLAR=OFF ..
+cmake $CMAKE_ARGS -DBUILD_CLAR=OFF ..
 make
 make install
 popd
@@ -180,7 +180,7 @@ get_dep libzip
 pushd libzip
 mkdir -p build
 cd build
-cmake $MAC_CMAKE ..
+cmake $CMAKE_ARGS ..
 make
 make install
 popd
@@ -194,7 +194,7 @@ pushd hidapi
 bash ./bootstrap
 mkdir -p build
 cd build
-cmake $MAC_CMAKE -DCMAKE_INSTALL_LIBDIR="$INSTALL_ROOT/lib" ..
+cmake $CMAKE_ARGS -DCMAKE_INSTALL_LIBDIR="$INSTALL_ROOT/lib" ..
 make
 make install
 popd
@@ -219,7 +219,7 @@ get_dep libftdi1
 pushd libftdi1
 mkdir -p build
 cd build
-cmake $MAC_CMAKE -DFTDI_EEPROM=OFF -DCMAKE_INSTALL_LIBDIR="$INSTALL_ROOT/lib" ..
+cmake $CMAKE_ARGS -DFTDI_EEPROM=OFF -DCMAKE_INSTALL_LIBDIR="$INSTALL_ROOT/lib" ..
 make
 make install
 popd

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,6 +236,7 @@ export INSTALL_ROOT DEBUGRELEASE
 # make sure we find our own packages first (e.g., libgit2 only uses pkg_config to find libssh2)
 export PKG_CONFIG_PATH=$INSTALL_ROOT/lib/pkgconfig:$PKG_CONFIG_PATH
 
+CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=${INSTALL_ROOT} "
 # Verify that the Xcode Command Line Tools are installed
 if [ "$PLATFORM" = Darwin ] ; then
 	SDKROOT=$(xcrun --show-sdk-path)
@@ -252,11 +253,11 @@ if [ "$PLATFORM" = Darwin ] ; then
 	export BASESDK
 	if [ "$ARCHS" != "" ] ; then
 		# we do assume that the two architectures mentioned are x86_64 and arm64 .. that's kinda wrong
-		MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' -DCMAKE_BUILD_TYPE=${DEBUGRELEASE} -DCMAKE_INSTALL_PREFIX=${INSTALL_ROOT} -DCMAKE_POLICY_VERSION_MINIMUM=3.16"
+		CMAKE_ARGS+="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_ARCHITECTURES='x86_64;arm64' -DCMAKE_BUILD_TYPE=${DEBUGRELEASE} -DCMAKE_POLICY_VERSION_MINIMUM=3.16"
 		MAC_OPTS="-mmacosx-version-min=${BASESDK} -arch arm64 -arch x86_64"
 	else
 		ARCHS=$(uname -m) # crazy, I know, but $(arch) results in the incorrect 'i386' on an x86_64 Mac
-		MAC_CMAKE="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_ARCHITECTURES="$ARCHS" -DCMAKE_BUILD_TYPE={$DEBUGRELEASE} -DCMAKE_INSTALL_PREFIX=${INSTALL_ROOT} -DCMAKE_POLICY_VERSION_MINIMUM=3.16"
+		CMAKE_ARGS+="-DCMAKE_OSX_DEPLOYMENT_TARGET=${BASESDK} -DCMAKE_OSX_ARCHITECTURES="$ARCHS" -DCMAKE_BUILD_TYPE={$DEBUGRELEASE} -DCMAKE_INSTALL_PREFIX=${INSTALL_ROOT} -DCMAKE_POLICY_VERSION_MINIMUM=3.16"
 		MAC_OPTS="-mmacosx-version-min=${BASESDK}"
 	fi
 	# OpenSSL can't deal with multi arch build
@@ -265,7 +266,7 @@ if [ "$PLATFORM" = Darwin ] ; then
 
 	# if all we want is to build the dependencies, we are done with prep here
 	if [[ "$BUILD_DEPS_ONLY" == "1" ]] ; then
-		export ARCHS SRC SRC_DIR MAC_CMAKE MAC_OPTS MAC_OPTS_OPENSSL
+		export ARCHS SRC SRC_DIR CMAKE_ARGS MAC_OPTS MAC_OPTS_OPENSSL
 		bash "./${SRC_DIR}/packaging/macosx/build-deps.sh"
 		exit
 	fi
@@ -306,7 +307,7 @@ fi
 
 # on Debian and Ubuntu based systems, the private QtLocation and
 # QtPositioning headers aren't bundled. Download them if necessary.
-if [ "$PLATFORM" = Linux ] && [[ $QT_VERSION == 5* ]] ; then
+if [ "$PLATFORM" = Linux ] ; then
 	QT_HEADERS_PATH=$($QMAKE -query QT_INSTALL_HEADERS)
 
 	if [ ! -d "$QT_HEADERS_PATH/QtLocation/$QT_VERSION/QtLocation/private" ] &&
@@ -329,10 +330,13 @@ if [ "$PLATFORM" = Linux ] && [[ $QT_VERSION == 5* ]] ; then
 		find . -name '*_p.h' -print0 | xargs -0 cp -t "$QTLOC_PRIVATE"
 		cd "$SRC"
 
-		mkdir -p "$QTPOS_PRIVATE"
-		cd $QTLOC_GIT/src/positioning
-		find . -name '*_p.h' -print0 | xargs -0 cp -t "$QTPOS_PRIVATE"
-		cd "$SRC"
+		# for Qt 6 the positioning headers aren't included
+		if [ -d $QTLOC_GIT/src/positioning ]; then
+			mkdir -p "$QTPOS_PRIVATE"
+			cd $QTLOC_GIT/src/positioning
+			find . -name '*_p.h' -print0 | xargs -0 cp -t "$QTPOS_PRIVATE"
+			cd "$SRC"
+		fi
 
 		echo "* cleanup..."
 		rm -rf $QTLOC_GIT > /dev/null 2>&1
@@ -385,7 +389,7 @@ if [[ $PLATFORM != Darwin && "$LIBGITMAJ" -lt "1" && "$LIBGIT" -lt "26" ]] ; the
 	pushd libgit2
 	mkdir -p build
 	cd build
-	cmake $MAC_CMAKE -DBUILD_CLAR=OFF ..
+	cmake $CMAKE_ARGS -DBUILD_CLAR=OFF ..
 	make
 	make install
 	popd
@@ -469,7 +473,7 @@ if [[ "$QUICK" != "1" && "$BUILD_DESKTOP" == "1" && "$BUILD_WITH_QT6" == "1" ]] 
 	git submodule update
 
 	# qlitehtml currently (2025-12-01) only allows in source tree builds
-	cmake $MAC_CMAKE .
+	cmake $CMAKE_ARGS .
 	make
 	make install
 	if [ "$PLATFORM" = Darwin ] ; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -454,7 +454,11 @@ if [ "$QUICK" != "1" ] && [ "$BUILD_DESKTOP$BUILD_MOBILE" != "" ] ; then
 	if [[ $QT_VERSION == 6* ]]; then
 		# the latest version of googlemaps as of Nov 2025 builds out of the box with Qt 6.10
 		# but no longer builds against Qt 5... so we have two branches now
-		git checkout qt6-upstream
+
+		# We need to fetch first as this isn't the branch checked out by get-dep-lib.sh
+		git fetch
+
+		git switch qt6-upstream
 	fi
 	mkdir -p build
 	cd build


### PR DESCRIPTION
This isn't hooked up, yet, but with the couple of small changes to the build scripts I get a working local build here.

The most noisy part is a rename that maybe I should have broken out separately.  MAC_CMAKE was a misnomer - this was used on all builds. It just wasn't correctly populated on the non-macOS builds. That's why qlitehtml wanted to install in /usr/local on Linux.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup
- [x] Build system change

### Pull request long description:
<!-- Describe your pull request in detail. -->
This is the first step to build Qt 6 based versions on Ubuntu et al.
Mostly provided for review and feedback.

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger this should fix your build issues. At least for me on Ubuntu 25.10 a build of this branch works locally. Note that this will NOT work with 24.04 as that Qt version is too old.

@mikeller please take a look -- I want to hook this into similar Ubuntu and Debian builds as we do with the current Qt 5 script, but of course not for the older versions.