### PR TITLE
build: remove cmake include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,6 @@ if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
 	SET(QML_IMPORT_PATH ${QML_IMPORT_PATH} ${CMAKE_SOURCE_DIR}/mobile-widgets/3rdparty/kirigami/src ${CMAKE_SOURCE_DIR}/mobile-widgets/qml)
 	add_subdirectory(mobile-widgets/3rdparty)
 	include_directories(${CMAKE_SOURCE_DIR}/mobile-widgets/3rdparty/kirigami/src)
-	include(${CMAKE_SOURCE_DIR}/mobile-widgets/3rdparty/kirigami/KF5Kirigami2Macros.cmake)
 
 	set(MOBILE_SRC
 		subsurface-mobile-main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,6 @@ if (SUBSURFACE_TARGET_EXECUTABLE MATCHES "MobileExecutable")
 
 	SET(QML_IMPORT_PATH ${QML_IMPORT_PATH} ${CMAKE_SOURCE_DIR}/mobile-widgets/3rdparty/kirigami/src ${CMAKE_SOURCE_DIR}/mobile-widgets/qml)
 	add_subdirectory(mobile-widgets/3rdparty)
-	include_directories(${CMAKE_SOURCE_DIR}/mobile-widgets/3rdparty/kirigami/src)
 
 	set(MOBILE_SRC
 		subsurface-mobile-main.cpp


### PR DESCRIPTION
In the top-level, we include a kirigami cmake-file, which defines a function kirigami_package_breeze_icons(). However, that seems not to be called anywhere. So remove the include.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Remove a seemingly unused cmake include.

Perhaps I'm mussing something and this is needed. No idea - cmake is a 100% mystery to me!

That said it seems to me that the breeze icons are fetched in ``scripts/mobilecomponents.sh`-