### PR TITLE
cleanup: adding an aptly named helper

### DIFF
--- a/core/unix.cpp
+++ b/core/unix.cpp
@@ -18,9 +18,15 @@
 #include <zip.h>
 #include <string>
 
+static std::string fix_fucking_stupid(char * whatever)
+{
+	// std::string is FUCKING STUPID - initialization from NULL crashes at runtime
+	return std::string(whatever != NULL ? whatever : "");
+}
+
 static std::string system_default_path()
 {
-	std::string home(getenv("HOME"));
+	std::string home = fix_fucking_stupid(getenv("HOME"));
 	if (home.empty())
 		home = "~";
 	return home + "/.subsurface";
@@ -28,7 +34,7 @@ static std::string system_default_path()
 
 static std::string make_default_filename()
 {
-	std::string user = getenv("LOGNAME");
+	std::string user = fix_fucking_stupid(getenv("LOGNAME"));
 	if (user.empty())
 		user = "username";
 	return system_default_path() + "/" + user + ".xml";


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
I want to rip out every single use of std::string
I am really thinking if that should be my next pull request
I am so tired of wasting my time on this. This is at least the fourth time that I tried to track down a weird crash and it's this shit.

`std::string home(getenv("HOME"));` crashes if `HOME` isn't set.

### Changes made:
add an appropriately named helper to work around pointless crashes

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
@bstoeger -- no, I won't merge it with this function name. But I was tempted to push to master...