### PR TITLE
Fix bug in subsurface XML to DivelogsDE XML export parsing.

### DIFF
--- a/xslt/divelogs-export.xslt
+++ b/xslt/divelogs-export.xslt
@@ -135,7 +135,7 @@
               <xsl:value-of select="$double - 1" />
             </dbltank>
             <vol>
-              <xsl:value-of select="substring-before(@size, ' ') div $double" />
+              <xsl:value-of select="format-number(substring-before(@size, ' ') div $double, '#.##')" />
             </vol>
             <start_pressure>
               <xsl:choose>


### PR DESCRIPTION
When calculating the volume of tanks with fractional values, the division in the XSLT template causes a comma to be used as the decimal separator instead of a period.

This is fixed by explicitly converting the result with a known format string.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Explicitly cast tank volume using known decimal format.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
