### PR TITLE
DC support: at BLE detection for Mares Quad Ci

### DIFF
--- a/core/btdiscovery.cpp
+++ b/core/btdiscovery.cpp
@@ -93,6 +93,8 @@ static struct namePattern name[] = {
 	// Mares dive computers
 	{ "Mares Genius", "Mares", "Genius" },
 	{ "Sirius", "Mares", "Sirius" },
+	{ "Quad Ci", "Mares", "Quad Ci" },
+	{ "Quad", "Mares", "Quad" },
 	{ "Mares", "Mares", "Quad" }, // we actually don't know and just pick a common one - user needs to fix in UI
 	// Cress dive computers
 	{ "CARESIO_", "Cressi", "Cartesio" },


### PR DESCRIPTION
And for any BLE computer in the Quad family that identifies with a name starting with Quad. It looks like they used to just call themselves 'Mares'...

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] HW support

### Pull request long description:
<!-- Describe your pull request in detail. -->
The Quad Ci is already supported by libdivecomputer, we just don't detect it by its name and hence it isn't offered as an option.
