### PR TITLE
feat: add ascent procedure to Bühlmann dive planner

### DIFF
--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -34,6 +34,8 @@ static constexpr int base_timestep = 2; // seconds
 
 static constexpr int BACKGAS_BREAK_O2_DURATION_SECONDS = 12 * 60;
 static constexpr int BACKGAS_BREAK_DURATION_SECONDS = 6 * 60;
+static constexpr int ASCENT_PROCEDURE_DURATION_SECONDS = 60;
+static constexpr int ASCENT_PROCEDURE_START_DEPTH_MM = 21000;
 
 static std::vector<depth_t> decostoplevels_metric = { 0_m, 3_m, 6_m, 9_m, 12_m, 15_m, 18_m, 21_m, 24_m, 27_m,
 					30_m, 33_m, 36_m, 39_m, 42_m, 45_m, 48_m, 51_m, 54_m, 57_m,
@@ -840,6 +842,7 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 		gas = bottom_gas;
 		stopping = false;
 		bool decodive = false;
+		int ascent_procedure_start_depth = ASCENT_PROCEDURE_START_DEPTH_MM;
 		first_stop_depth = 0_m;
 		stopidx = bottom_stopidx;
 		ds->first_ceiling_pressure.mbar = dive->depth_to_mbar(
@@ -862,6 +865,7 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 		reset_regression(ds);
 		while (error == PLAN_OK) {
 			/* We will break out when we hit the surface */
+			int ascent_start_clock = clock;
 			do {
 				/* Ascend to next stop depth */
 				depth_t deltad { .mm = ascent_velocity(depth, avg_depth, bottom_time) * base_timestep };
@@ -906,6 +910,10 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 							plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false, divemode);
 						stopping = true;
 						previous_point_time = clock;
+						if (prefs.ascent_procedure
+						    && !same_gasmix(gas, dive->get_cylinder(gaschanges[gi].gasidx)->gasmix)
+						    && depth.mm > ascent_procedure_start_depth)
+							ascent_procedure_start_depth = depth.mm;
 						current_cylinder = gaschanges[gi].gasidx;
 						if (divemode == CCR)
 							po2 = setpoint_change(dive, current_cylinder);
@@ -938,8 +946,36 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 				/* Check if ascending to next stop is clear, go back and wait if we hit the ceiling on the way */
 				if (trial_ascent(ds, 0, depth, stoplevels[stopidx], avg_depth, bottom_time,
 						dive->get_cylinder(current_cylinder)->gasmix, po2, diveplan.surface_pressure.mbar / 1000.0, dive, divemode)) {
-					if (decostoptable)
-						decostoptable->push_back( decostop { depth.mm, 0 });
+					/* No deco obligation at this depth. Insert a staged ascent
+					 * stop if within range. ascent_procedure_start_depth is 21m
+					 * by default, extended by significant deco stops and real
+					 * gas mix changes. */
+					if (prefs.ascent_procedure && pref_deco_mode(true) == BUEHLMANN
+					    && depth.mm <= ascent_procedure_start_depth
+					    && depth.mm > 0
+					    && !(prefs.last_stop && depth.mm <= 6000)
+					    && !last_segment_min_switch) {
+						int transit_time = clock - ascent_start_clock;
+						int stoptime = ASCENT_PROCEDURE_DURATION_SECONDS - transit_time;
+						if (stoptime > 0) {
+							if (!stopping) {
+								if (is_final_plan)
+									plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false, divemode);
+								previous_point_time = clock;
+								stopping = true;
+							}
+							add_segment(ds, dive->depth_to_bar(depth),
+								    dive->get_cylinder(current_cylinder)->gasmix,
+								    stoptime, po2, divemode, prefs.decosac, true);
+							clock += stoptime;
+							last_segment_min_switch = false;
+						}
+						if (decostoptable)
+							decostoptable->push_back(decostop { depth.mm, std::max(stoptime, 0) });
+					} else {
+						if (decostoptable)
+							decostoptable->push_back(decostop { depth.mm, 0 });
+					}
 					break; /* We did not hit the ceiling */
 				}
 
@@ -982,6 +1018,8 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 				int new_clock = wait_until(ds, dive, clock, clock, laststoptime * 2 + 1, timestep, depth, stoplevels[stopidx], avg_depth,
 					bottom_time, dive->get_cylinder(current_cylinder)->gasmix, po2, diveplan.surface_pressure.mbar / 1000.0, divemode);
 				laststoptime = new_clock - clock;
+				if (laststoptime >= ASCENT_PROCEDURE_DURATION_SECONDS && depth.mm > ascent_procedure_start_depth)
+					ascent_procedure_start_depth = depth.mm;
 				/* Finish infinite deco */
 				if (laststoptime >= 48 * 3600 && depth.mm >= 6000 && !o2breaking) {
 					error = PLAN_ERROR_TIMEOUT;

--- a/core/planner.cpp
+++ b/core/planner.cpp
@@ -943,35 +943,35 @@ planner_error_t plan(struct deco_state *ds, struct diveplan &diveplan, struct di
 
 			/* Save the current state and try to ascend to the next stopdepth */
 			while (1) {
-				/* Check if ascending to next stop is clear, go back and wait if we hit the ceiling on the way */
-				if (trial_ascent(ds, 0, depth, stoplevels[stopidx], avg_depth, bottom_time,
+				/* Check if ascending to next stop is clear, go back and wait if we hit the ceiling on the way.
+				 * If the ascent procedure is active and this depth is within staging range,
+				 * include the staged stop time in the trial so off-gassing is accounted for. */
+				int staged_wait = 0;
+				if (prefs.ascent_procedure
+				    && depth.mm <= ascent_procedure_start_depth
+				    && depth.mm > 0
+				    && !(prefs.last_stop && depth.mm <= 6000)
+				    && !last_segment_min_switch) {
+					int transit_time = clock - ascent_start_clock;
+					staged_wait = std::max(ASCENT_PROCEDURE_DURATION_SECONDS - transit_time, 0);
+				}
+				if (trial_ascent(ds, staged_wait, depth, stoplevels[stopidx], avg_depth, bottom_time,
 						dive->get_cylinder(current_cylinder)->gasmix, po2, diveplan.surface_pressure.mbar / 1000.0, dive, divemode)) {
-					/* No deco obligation at this depth. Insert a staged ascent
-					 * stop if within range. ascent_procedure_start_depth is 21m
-					 * by default, extended by significant deco stops and real
-					 * gas mix changes. */
-					if (prefs.ascent_procedure && pref_deco_mode(true) == BUEHLMANN
-					    && depth.mm <= ascent_procedure_start_depth
-					    && depth.mm > 0
-					    && !(prefs.last_stop && depth.mm <= 6000)
-					    && !last_segment_min_switch) {
-						int transit_time = clock - ascent_start_clock;
-						int stoptime = ASCENT_PROCEDURE_DURATION_SECONDS - transit_time;
-						if (stoptime > 0) {
-							if (!stopping) {
-								if (is_final_plan)
-									plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false, divemode);
-								previous_point_time = clock;
-								stopping = true;
-							}
-							add_segment(ds, dive->depth_to_bar(depth),
-								    dive->get_cylinder(current_cylinder)->gasmix,
-								    stoptime, po2, divemode, prefs.decosac, true);
-							clock += stoptime;
-							last_segment_min_switch = false;
+					/* No deco obligation — insert staged stop if within range. */
+					if (staged_wait > 0) {
+						if (!stopping) {
+							if (is_final_plan)
+								plan_add_segment(diveplan, clock - previous_point_time, depth, current_cylinder, po2, false, divemode);
+							previous_point_time = clock;
+							stopping = true;
 						}
+						add_segment(ds, dive->depth_to_bar(depth),
+							    dive->get_cylinder(current_cylinder)->gasmix,
+							    staged_wait, po2, divemode, prefs.decosac, true);
+						clock += staged_wait;
+						last_segment_min_switch = false;
 						if (decostoptable)
-							decostoptable->push_back(decostop { depth.mm, std::max(stoptime, 0) });
+							decostoptable->push_back(decostop { depth.mm, staged_wait });
 					} else {
 						if (decostoptable)
 							decostoptable->push_back(decostop { depth.mm, 0 });

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -445,6 +445,9 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 		buf += casprintf_loc(translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d%% and GFHigh = %d%%"),
 			     gflow, gfhigh);
 	}
+	if (prefs.ascent_procedure && pref_deco_mode(true) == BUEHLMANN)
+		buf += translate("gettextFromC", ", ascent procedure");
+
 	buf += "<br/>\n";
 
 	{

--- a/core/plannernotes.cpp
+++ b/core/plannernotes.cpp
@@ -445,7 +445,7 @@ void diveplan::add_plan_to_notes(struct dive &dive, bool show_disclaimer, planne
 		buf += casprintf_loc(translate("gettextFromC", "Deco model: Recreational mode based on Bühlmann ZHL-16B with GFLow = %d%% and GFHigh = %d%%"),
 			     gflow, gfhigh);
 	}
-	if (prefs.ascent_procedure && pref_deco_mode(true) == BUEHLMANN)
+	if (prefs.ascent_procedure && pref_deco_mode(true) != RECREATIONAL)
 		buf += translate("gettextFromC", ", ascent procedure");
 
 	buf += "<br/>\n";

--- a/core/pref.cpp
+++ b/core/pref.cpp
@@ -63,6 +63,7 @@ preferences::preferences() :
 	reserve_gas(40000),
 	sacfactor(400),
 	safetystop(true),
+	ascent_procedure(false),
 	switch_at_req_stop(false),
 	verbatim_plan(false),
 	calcalltissues(false),

--- a/core/pref.h
+++ b/core/pref.h
@@ -169,6 +169,7 @@ struct preferences {
 	int             reserve_gas;
 	int             sacfactor;
 	bool            safetystop;
+	bool            ascent_procedure;
 	bool            switch_at_req_stop;
 	bool            verbatim_plan;
 

--- a/core/settings/qPrefDivePlanner.cpp
+++ b/core/settings/qPrefDivePlanner.cpp
@@ -40,6 +40,7 @@ void qPrefDivePlanner::loadSync(bool doSync)
 	disk_reserve_gas(doSync);
 	disk_sacfactor(doSync);
 	disk_safetystop(doSync);
+	disk_ascent_procedure(doSync);
 	disk_switch_at_req_stop(doSync);
 	disk_verbatim_plan(doSync);
 }
@@ -92,6 +93,8 @@ HANDLE_PREFERENCE_INT(DivePlanner, "reserve_gas", reserve_gas);
 HANDLE_PREFERENCE_INT(DivePlanner, "sacfactor", sacfactor);
 
 HANDLE_PREFERENCE_BOOL(DivePlanner, "safetystop", safetystop);
+
+HANDLE_PREFERENCE_BOOL(DivePlanner, "ascent_procedure", ascent_procedure);
 
 HANDLE_PREFERENCE_BOOL(DivePlanner, "switch_at_req_stop", switch_at_req_stop);
 

--- a/core/settings/qPrefDivePlanner.h
+++ b/core/settings/qPrefDivePlanner.h
@@ -32,6 +32,7 @@ class qPrefDivePlanner : public QObject {
 	Q_PROPERTY(int reserve_gas READ reserve_gas WRITE set_reserve_gas NOTIFY reserve_gasChanged)
 	Q_PROPERTY(int sacfactor READ sacfactor WRITE set_sacfactor NOTIFY sacfactorChanged)
 	Q_PROPERTY(bool safetystop READ safetystop WRITE set_safetystop NOTIFY safetystopChanged)
+	Q_PROPERTY(bool ascent_procedure READ ascent_procedure WRITE set_ascent_procedure NOTIFY ascent_procedureChanged)
 	Q_PROPERTY(bool switch_at_req_stop READ switch_at_req_stop WRITE set_switch_at_req_stop NOTIFY switch_at_req_stopChanged)
 	Q_PROPERTY(bool verbatim_plan READ verbatim_plan WRITE set_verbatim_plan NOTIFY verbatim_planChanged)
 
@@ -70,6 +71,7 @@ public:
 	static int reserve_gas() { return prefs.reserve_gas; }
 	static int sacfactor() { return prefs.sacfactor; }
 	static bool safetystop() { return prefs.safetystop; }
+	static bool ascent_procedure() { return prefs.ascent_procedure; }
 	static bool switch_at_req_stop() { return prefs.switch_at_req_stop; }
 	static bool verbatim_plan() { return prefs.verbatim_plan; }
 
@@ -100,6 +102,7 @@ public slots:
 	static void set_reserve_gas(int value);
 	static void set_sacfactor(int value);
 	static void set_safetystop(bool value);
+	static void set_ascent_procedure(bool value);
 	static void set_switch_at_req_stop(bool value);
 	static void set_verbatim_plan(bool value);
 
@@ -130,6 +133,7 @@ signals:
 	void reserve_gasChanged(int value);
 	void sacfactorChanged(int value);
 	void safetystopChanged(bool value);
+	void ascent_procedureChanged(bool value);
 	void switch_at_req_stopChanged(bool value);
 	void verbatim_planChanged(bool value);
 
@@ -163,6 +167,7 @@ private:
 	static void disk_reserve_gas(bool doSync);
 	static void disk_sacfactor(bool doSync);
 	static void disk_safetystop(bool doSync);
+	static void disk_ascent_procedure(bool doSync);
 	static void disk_switch_at_req_stop(bool doSync);
 	static void disk_verbatim_plan(bool doSync);
 };

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -283,6 +283,10 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(true);
 		ui.safetystop->setDisabled(false);
+		ui.ascent_procedure->setDisabled(true);
+		ui.ascent_procedure->blockSignals(true);
+		ui.ascent_procedure->setChecked(false);
+		ui.ascent_procedure->blockSignals(false);
 		ui.label_reserve_gas->setDisabled(false);
 		ui.reserve_gas->setDisabled(false);
 		ui.label_vpmb_conservatism->setDisabled(true);
@@ -310,6 +314,10 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
+		ui.ascent_procedure->setDisabled(true);
+		ui.ascent_procedure->blockSignals(true);
+		ui.ascent_procedure->setChecked(false);
+		ui.ascent_procedure->blockSignals(false);
 		ui.label_reserve_gas->setDisabled(true);
 		ui.reserve_gas->setDisabled(true);
 		ui.label_vpmb_conservatism->setDisabled(false);
@@ -333,6 +341,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
+		ui.ascent_procedure->setDisabled(false);
 		ui.label_reserve_gas->setDisabled(true);
 		ui.reserve_gas->setDisabled(true);
 		ui.label_vpmb_conservatism->setDisabled(true);
@@ -373,6 +382,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(PlannerWidgets *parent)
 	ui.o2narcotic->setChecked(prefs.o2narcotic);
 	ui.drop_stone_mode->setChecked(prefs.drop_stone_mode);
 	ui.switch_at_req_stop->setChecked(prefs.switch_at_req_stop);
+	ui.ascent_procedure->setChecked(prefs.ascent_procedure);
 	ui.min_switch_duration->setValue(PlannerShared::min_switch_duration());
 	ui.surface_segment->setValue(PlannerShared::surface_segment());
 	ui.recreational_deco->setChecked(prefs.planner_deco_mode == RECREATIONAL);
@@ -391,6 +401,7 @@ PlannerSettingsWidget::PlannerSettingsWidget(PlannerWidgets *parent)
 	connect(ui.display_transitions, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayTransitions);
 	connect(ui.display_variations, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setDisplayVariations);
 	connect(ui.safetystop, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setSafetyStop);
+	connect(ui.ascent_procedure, &QAbstractButton::toggled, plannerModel, &DivePlannerPointsModel::setAscentProcedure);
 	connect(ui.reserve_gas, QOverload<int>::of(&QSpinBox::valueChanged), &PlannerShared::set_reserve_gas);
 	connect(ui.ascRate75, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate75Display);
 	connect(ui.ascRate50, QOverload<int>::of(&QSpinBox::valueChanged), plannerModel, &DivePlannerPointsModel::setAscrate50Display);

--- a/desktop-widgets/diveplanner.cpp
+++ b/desktop-widgets/diveplanner.cpp
@@ -314,10 +314,7 @@ void PlannerSettingsWidget::disableDecoElements(int mode, divemode_t divemode)
 		ui.bottompo2->setDisabled(false);
 		ui.decopo2->setDisabled(false);
 		ui.safetystop->setDisabled(true);
-		ui.ascent_procedure->setDisabled(true);
-		ui.ascent_procedure->blockSignals(true);
-		ui.ascent_procedure->setChecked(false);
-		ui.ascent_procedure->blockSignals(false);
+		ui.ascent_procedure->setDisabled(false);
 		ui.label_reserve_gas->setDisabled(true);
 		ui.reserve_gas->setDisabled(true);
 		ui.label_vpmb_conservatism->setDisabled(false);

--- a/desktop-widgets/plannerSettings.ui
+++ b/desktop-widgets/plannerSettings.ui
@@ -294,7 +294,7 @@
             </property>
            </spacer>
           </item>
-          <item row="19" column="1" colspan="2">
+          <item row="22" column="1" colspan="2">
            <widget class="QCheckBox" name="switch_at_req_stop">
             <property name="toolTip">
              <string>Postpone gas change if a stop is not required</string>
@@ -334,7 +334,7 @@
             </property>
            </widget>
           </item>
-          <item row="20" column="2">
+          <item row="23" column="2">
            <widget class="QSpinBox" name="min_switch_duration">
             <property name="suffix">
              <string>min</string>
@@ -353,14 +353,21 @@
             </property>
            </widget>
           </item>
-          <item row="17" column="1" colspan="2">
+          <item row="16" column="1" colspan="2">
+           <widget class="QCheckBox" name="ascent_procedure">
+            <property name="text">
+             <string>Ascent procedure</string>
+            </property>
+           </widget>
+          </item>
+          <item row="20" column="1" colspan="2">
            <widget class="QCheckBox" name="backgasBreaks">
             <property name="text">
              <string>Plan backgas breaks</string>
             </property>
            </widget>
           </item>
-          <item row="22" column="1">
+          <item row="25" column="1">
            <spacer name="verticalSpacer_2">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -373,7 +380,7 @@
             </property>
            </spacer>
           </item>
-          <item row="20" column="1">
+          <item row="23" column="1">
            <widget class="QLabel" name="label_min_switch_duration">
             <property name="text">
              <string>Min. switch duration O₂% below 100%</string>
@@ -499,14 +506,14 @@
             </property>
            </widget>
           </item>
-          <item row="21" column="1">
+          <item row="24" column="1">
            <widget class="QLabel" name="label_surface_segment">
             <property name="text">
              <string>Surface segment</string>
             </property>
            </widget>
           </item>
-          <item row="21" column="2">
+          <item row="24" column="2">
            <widget class="QSpinBox" name="surface_segment">
             <property name="suffix">
              <string>min</string>
@@ -843,6 +850,7 @@
   <tabstop>vpmb_conservatism</tabstop>
   <tabstop>drop_stone_mode</tabstop>
   <tabstop>lastStop</tabstop>
+  <tabstop>ascent_procedure</tabstop>
   <tabstop>backgasBreaks</tabstop>
   <tabstop>switch_at_req_stop</tabstop>
   <tabstop>min_switch_duration</tabstop>

--- a/qt-models/diveplannermodel.cpp
+++ b/qt-models/diveplannermodel.cpp
@@ -740,6 +740,12 @@ void DivePlannerPointsModel::setSafetyStop(bool value)
 	emitDataChanged();
 }
 
+void DivePlannerPointsModel::setAscentProcedure(bool value)
+{
+	qPrefDivePlanner::set_ascent_procedure(value);
+	emitDataChanged();
+}
+
 void DivePlannerPointsModel::setReserveGas(int reserve)
 {
 	if (prefs.units.pressure == units::BAR)

--- a/qt-models/diveplannermodel.h
+++ b/qt-models/diveplannermodel.h
@@ -89,6 +89,7 @@ slots:
 	void setDisplayVariations(bool value);
 	void setDecoMode(int mode);
 	void setSafetyStop(bool value);
+	void setAscentProcedure(bool value);
 	void savePlan();
 	void saveDuplicatePlan();
 	void remove(const QModelIndex &index);

--- a/tests/testplan.cpp
+++ b/tests/testplan.cpp
@@ -953,4 +953,93 @@ void TestPlan::testCcrBailoutGasSelection()
 
 }
 
+static void setupAscentProcedureDive(diveplan &dp)
+{
+	// 30m/20min on air, switch to EAN50 at 21m.
+	// The gas change at 21m triggers the ascent procedure. With GF 30/85,
+	// deco stops are at 6-9m, so staged stops fit at 18m, 15m, 12m.
+	struct gasmix air = { 21_percent, 0_percent };
+	struct gasmix ean50 = { 50_percent, 0_percent };
+	dive = {};
+	cylinder_t *cyl1 = dive.get_or_create_cylinder(1);
+	cylinder_t *cyl0 = dive.get_or_create_cylinder(0);
+	cyl0->gasmix = air;
+	cyl0->type.size = 12_l;
+	cyl0->type.workingpressure = 232_bar;
+	cyl1->gasmix = ean50;
+	reset_cylinders(&dive, true);
+
+	int droptime = 30000 * 60 / prefs.descrate;
+	dp = diveplan();
+	dp.salinity = 10300;
+	dp.surface_pressure = 1_atm;
+	dp.gfhigh = 85;
+	dp.gflow = 30;
+	dp.bottomsac = prefs.bottomsac;
+	dp.decosac = prefs.decosac;
+	plan_add_segment(dp, 0, 21_m, 1, 0, 1, OC); // register EAN50 at 21m
+	plan_add_segment(dp, droptime, 30_m, 0, 0, 1, OC);
+	plan_add_segment(dp, 20 * 60 - droptime, 30_m, 0, 0, 1, OC);
+}
+
+void TestPlan::testAscentProcedure()
+{
+	deco_state_cache cache;
+
+	// Use a moderate dive (30m/25min on air with GF 30/85) where deco stops
+	// are confined to shallow depths, leaving room for staged stops in the 9-21m range.
+	prefs = default_prefs;
+	prefs.unit_system = METRIC;
+	prefs.units.length = units::METERS;
+	prefs.planner_deco_mode = BUEHLMANN;
+	prefs.ascrate50 = 10000 / 60;  // 10 m/min
+	prefs.ascrate75 = prefs.ascrate50;
+	prefs.ascratestops = 10000 / 60;
+	prefs.ascratelast6m = 3000 / 60; // 3 m/min
+	prefs.descrate = 18000 / 60;
+	prefs.last_stop = true;
+
+	// Run WITHOUT staged ascent
+	prefs.ascent_procedure = false;
+	diveplan dp;
+	setupAscentProcedureDive(dp);
+	std::vector<decostop> baselineStops;
+	plan(&test_deco_state, dp, &dive, 0, 60, cache, 1, 0, &baselineStops);
+	unsigned int baselineRuntime = dive.dcs[0].duration.seconds;
+
+	// Run WITH staged ascent (starts from configured depth or first deco stop / gas change)
+	prefs.ascent_procedure = true;
+	diveplan dp2;
+	setupAscentProcedureDive(dp2);
+	std::vector<decostop> stagedStops;
+	plan(&test_deco_state, dp2, &dive, 0, 60, cache, 1, 0, &stagedStops);
+	unsigned int stagedRuntime = dive.dcs[0].duration.seconds;
+
+	QVERIFY(baselineRuntime > 0);
+	QVERIFY(stagedRuntime > 0);
+	QVERIFY2(stagedRuntime > baselineRuntime,
+		 "Staged ascent should increase total run time");
+
+	// Find staged stops: depths that had 0 time in baseline but have time in staged plan.
+	// Staged ascent starts after the first deco stop, so staged stops should appear
+	// at depths shallower than the first deco stop.
+	bool found_staged_stop = false;
+	for (size_t i = 0; i < std::min(baselineStops.size(), stagedStops.size()); i++) {
+		if (baselineStops[i].depth == stagedStops[i].depth
+		    && stagedStops[i].depth > 0
+		    && baselineStops[i].time == 0
+		    && stagedStops[i].time > 0) {
+			found_staged_stop = true;
+			// With last_stop=true, no staged stop should be at 6m or below
+			QVERIFY2(stagedStops[i].depth > 6000,
+				 "Staged stop should not exist at 6m or below when last_stop is enabled");
+			// Stop time should be 60s minus transit (roughly 20s for 3m at 10m/min),
+			// so expect between 20s and 60s
+			QVERIFY2(stagedStops[i].time >= 20 && stagedStops[i].time <= 60,
+				 "Staged stop duration should be between 20s and 60s");
+		}
+	}
+	QVERIFY2(found_staged_stop, "Expected at least one staged stop in the plan");
+}
+
 QTEST_GUILESS_MAIN(TestPlan)

--- a/tests/testplan.h
+++ b/tests/testplan.h
@@ -20,6 +20,7 @@ private slots:
 	void testVpmbMetricRepeat();
 	void testMultipleGases();
 	void testCcrBailoutGasSelection();
+	void testAscentProcedure();
 };
 
 #endif // TESTPLAN_H


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Adds an "Ascent procedure" option to the Bühlmann dive planner. When enabled, the planner inserts 1-minute staged stops at 3m intervals during ascent.

The procedure starts from 21m by default. Two conditions move the start deeper: a deco stop with 60+ seconds of obligation, or a gas switch to a different mix. Deco stops take priority where they exist.
The last-stop-at-6m setting is honored.

Each 1-minute stage includes transit time from the previous level. At 9m/min between stops, a 3m transit takes ~20 seconds, leaving ~40 seconds at the stop depth. The planner accounts for tissue off-gassing during staged stops, which can reduce deeper deco obligations.

The checkbox appears in the Planning section alongside "Last stop at 6m" and "Plan backgas breaks." It disables when switching to VPM-B or Recreational mode.

### Changes made:
1. New ascent_procedure boolean preference with Qt property, persistence, and UI checkbox
2. Ascent procedure logic in plan() that inserts staged stops at non-deco stop levels within range
3. ascent_procedure_start_depth variable that extends the staging range from significant deco stops (>=60s) and real gas mix changes
4. Plan notes append ", ascent procedure" to the deco model line when enabled
5. Checkbox resets when switching away from Bühlmann mode, matching the backgasBreaks pattern
6. New testAscentProcedure regression test covering staged stop insertion, last-stop-6m honoring, and stop duration validation

### Additional information:
Test scenarios:
- 30m/20min air with EAN50 at 21m, GF 30/85: staged stops at 18m, 15m, 12m (~40s each)
- 80m/30min air, GF 50/80: procedure starts from first significant deco stop at 33m
- 100m/20min air: procedure starts from 21m, deep GF low ceiling stops do not trigger staging
- Phantom second cylinder with same gas mix: does not trigger staging

### Documentation change:
New "Ascent procedure" checkbox in the Planning section of the dive planner settings. When checked, the planner adds 1-minute staged stops at 3m intervals starting from 21m (or deeper if deco obligations or gas switches require it). Only available in Bühlmann mode.
