### PR TITLE
CCR dives should always have an O2 cylinder

### DIFF
--- a/core/dive.cpp
+++ b/core/dive.cpp
@@ -1081,6 +1081,24 @@ void dive::fixup_dive_dc(struct divecomputer &dc)
 		fake_dc(&dc);
 }
 
+/* CCR dives always have an O2 supply cylinder. If the dive computer
+ * didn't report one (e.g., Shearwater does not include the O2 supply
+ * in its gas list), add a default 100% O2 cylinder. */
+void dive::ensure_o2_cylinder()
+{
+	if (dcs.empty() || dcs[0].divemode != CCR)
+		return;
+	bool has_o2_cyl = std::any_of(cylinders.begin(), cylinders.end(),
+		[](const cylinder_t &cyl) { return cyl.cylinder_use == OXYGEN; });
+	if (!has_o2_cyl) {
+		cylinder_t o2_cyl;
+		o2_cyl.gasmix.o2 = 1000_permille;
+		o2_cyl.cylinder_use = OXYGEN;
+		o2_cyl.type.description = "oxygen";
+		cylinders.push_back(std::move(o2_cyl));
+	}
+}
+
 void dive::fixup_dive()
 {
 	sanitize_cylinder_info(*this);

--- a/core/dive.h
+++ b/core/dive.h
@@ -91,6 +91,7 @@ struct dive {
 	int number_of_computers() const;
 	void fixup_dive();
 	void fixup_dive_dc(struct divecomputer &dc);
+	void ensure_o2_cylinder();
 	timestamp_t endtime() const;		/* maximum over divecomputers (with samples) */
 	duration_t totaltime() const;		/* maximum over divecomputers (with samples) */
 	temperature_t dc_airtemp() const;	/* average over divecomputers */

--- a/core/libdivecomputer.cpp
+++ b/core/libdivecomputer.cpp
@@ -894,6 +894,8 @@ static int dive_cb(const unsigned char *data, unsigned int size,
 		return false;
 	}
 
+	dive->ensure_o2_cylinder();
+
 	/* Various libdivecomputer interface fixups */
 	if (dive->dcs[0].airtemp.mkelvin == 0 && first_temp_is_air && !dive->dcs[0].samples.empty()) {
 		dive->dcs[0].airtemp = dive->dcs[0].samples[0].temperature;

--- a/tests/testcylinderconfig.cpp
+++ b/tests/testcylinderconfig.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "testcylinderconfig.h"
+#include "core/dive.h"
+#include "core/divelog.h"
+#include "core/equipment.h"
+#include "core/file.h"
+#include "core/pref.h"
+
+void TestCylinderConfig::initTestCase()
+{
+	TestBase::initTestCase();
+	prefs = default_prefs;
+}
+
+void TestCylinderConfig::cleanup()
+{
+	clear_dive_file_data();
+}
+
+void TestCylinderConfig::testEnsureO2CylinderAddsForCcr()
+{
+	// A CCR dive with only a diluent cylinder should get an O2 cylinder added
+	struct dive d;
+	d.dcs[0].divemode = CCR;
+	cylinder_t dil;
+	dil.gasmix.o2 = 210_permille;
+	dil.cylinder_use = DILUENT;
+	d.cylinders.push_back(std::move(dil));
+
+	QCOMPARE((int)d.cylinders.size(), 1);
+	d.ensure_o2_cylinder();
+	QCOMPARE((int)d.cylinders.size(), 2);
+	QCOMPARE(d.cylinders[1].cylinder_use, OXYGEN);
+	QCOMPARE(d.cylinders[1].gasmix.o2.permille, 1000);
+}
+
+void TestCylinderConfig::testEnsureO2CylinderSkipsForOc()
+{
+	// An OC dive should not get an O2 cylinder added
+	struct dive d;
+	d.dcs[0].divemode = OC;
+	cylinder_t cyl;
+	cyl.gasmix.o2 = 320_permille;
+	cyl.cylinder_use = OC_GAS;
+	d.cylinders.push_back(std::move(cyl));
+
+	d.ensure_o2_cylinder();
+	QCOMPARE((int)d.cylinders.size(), 1);
+}
+
+void TestCylinderConfig::testEnsureO2CylinderIdempotent()
+{
+	// If an O2 cylinder already exists, don't add another
+	struct dive d;
+	d.dcs[0].divemode = CCR;
+	cylinder_t o2;
+	o2.gasmix.o2 = 1000_permille;
+	o2.cylinder_use = OXYGEN;
+	d.cylinders.push_back(std::move(o2));
+	cylinder_t dil;
+	dil.gasmix.o2 = 210_permille;
+	dil.cylinder_use = DILUENT;
+	d.cylinders.push_back(std::move(dil));
+
+	QCOMPARE((int)d.cylinders.size(), 2);
+	d.ensure_o2_cylinder();
+	QCOMPARE((int)d.cylinders.size(), 2);
+}
+
+void TestCylinderConfig::testParsedCcrDiveGetsO2Cylinder()
+{
+	// Load a file with CCR dives and verify every CCR dive has an O2 cylinder.
+	// The test file abitofeverything.ssrf has CCR dives — dive 35 has only
+	// a diluent cylinder. After fixup, ensure_o2_cylinder should have added one.
+	//
+	// Note: ensure_o2_cylinder is not currently called from the XML parse path,
+	// so we call it explicitly here to test the invariant.
+	QCOMPARE(parse_file(SUBSURFACE_TEST_DATA "/dives/abitofeverything.ssrf", &divelog), 0);
+	QVERIFY(!divelog.dives.empty());
+
+	int ccr_count = 0;
+	for (auto &dive : divelog.dives) {
+		if (dive->dcs.empty() || dive->dcs[0].divemode != CCR)
+			continue;
+		ccr_count++;
+
+		dive->ensure_o2_cylinder();
+
+		bool has_o2 = false;
+		for (auto &cyl : dive->cylinders) {
+			if (cyl.cylinder_use == OXYGEN) {
+				has_o2 = true;
+				QCOMPARE(cyl.gasmix.o2.permille, 1000);
+				break;
+			}
+		}
+		QVERIFY2(has_o2,
+			qPrintable(QString("CCR dive %1 has no OXYGEN cylinder").arg(dive->number)));
+	}
+	QVERIFY2(ccr_count >= 2, "Expected at least 2 CCR dives in test data");
+}
+
+QTEST_GUILESS_MAIN(TestCylinderConfig)

--- a/tests/testcylinderconfig.h
+++ b/tests/testcylinderconfig.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef TESTCYLINDERCONFIG_H
+#define TESTCYLINDERCONFIG_H
+
+#include "testbase.h"
+
+class TestCylinderConfig : public TestBase {
+	Q_OBJECT
+private slots:
+	void initTestCase();
+	void cleanup();
+
+	void testEnsureO2CylinderAddsForCcr();
+	void testEnsureO2CylinderSkipsForOc();
+	void testEnsureO2CylinderIdempotent();
+	void testParsedCcrDiveGetsO2Cylinder();
+};
+
+#endif


### PR DESCRIPTION
Signed-off-by: James Cialdea <j@jimbodude.net>

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Add a Oxygen cylinder to CCR dives being imported if no oxygen cylinder was provided by the dive computer

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
- Added void dive::ensure_o2_cylinder()
- Call ensure_o2_cylinder from dive_cb(), next to a bunch of other fix-ups
- Added TestCylinderConfig
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->
I don't think there is an open issue, but we started to discuss these features here https://groups.google.com/g/subsurface-divelog/c/K9u2SBEyUlw
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
I haven't tried this yet - looking for feedback on the approach while I get my computers ready.

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
